### PR TITLE
Refactor PontosVersionCommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+* Specify the path to the version file in the `pyproject.toml` and not in a
+  derived `VersionCommand` anymore. This will allow to use pontos version as
+  a development dependency only [#2](https://github.com/greenbone/pontos/pull/2)
+
 ### Fixed
 
 ### Removed

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import argparse
+import importlib
 import re
 
 from pathlib import Path
@@ -150,7 +151,20 @@ __version__ = "{}"\n"""
         print(*args)
 
     def get_current_version(self) -> str:
-        raise NotImplementedError()
+        version_module_name = self.version_file_path.stem
+        module_parts = list(self.version_file_path.parts[:-1]) + [
+            version_module_name
+        ]
+        module_name = '.'.join(module_parts)
+        try:
+            version_module = importlib.import_module(module_name)
+        except ModuleNotFoundError:
+            raise VersionError(
+                'Could not load version from {}. Import failed.'.format(
+                    module_name
+                )
+            )
+        return version_module.__version__
 
     def update_version_file(self, new_version: str) -> None:
         """

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -109,30 +109,21 @@ class VersionCommand:
 
 __version__ = "{}"\n"""
 
-    pyproject_toml_path = Path.cwd() / 'pyproject.toml'
-
     def __init__(
         self,
         *,
         version_file_path: Path = None,
-        pyproject_toml_path: Path = None,
-        name: str = None
+        pyproject_toml_path: Path = None
     ):
-        if version_file_path:
-            self.version_file_path = version_file_path
+        self.version_file_path = version_file_path
 
-        if pyproject_toml_path:
-            self.pyproject_toml_path = pyproject_toml_path
-
-        if name:
-            self.name = name
+        self.pyproject_toml_path = pyproject_toml_path
 
         self._configure_parser()
 
     def _configure_parser(self):
         self.parser = argparse.ArgumentParser(
-            description='Version handling utilities for {}.'.format(self.name),
-            prog='version',
+            description='Version handling utilities.', prog='version',
         )
 
         subparsers = self.parser.add_subparsers(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,9 @@ exclude = '''
 pre-commit = ['autohooks.plugins.black', 'autohooks.plugins.pylint']
 mode = "poetry"
 
+[tool.pontos.version]
+version-module-file = "pontos/version/__version__.py"
+
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/tests/version/__init__.py
+++ b/tests/version/__init__.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2020 Pontos Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+
+from contextlib import contextmanager
+from pathlib import Path
+
+
+@contextmanager
+def use_cwd(path: Path) -> None:
+    """
+    Context Manager to change the current working directory temporaryly
+    """
+    current_cwd = Path.cwd()
+
+    os.chdir(str(path))
+
+    yield
+
+    os.chdir(str(current_cwd))

--- a/tests/version/test_print_current_version.py
+++ b/tests/version/test_print_current_version.py
@@ -28,7 +28,7 @@ class PrintCurrentVersionTestCase(unittest.TestCase):
         VersionCommand.get_current_version = MagicMock(return_value='1.2.3')
         VersionCommand._print = print_mock  # pylint: disable=protected-access
 
-        cmd = VersionCommand(name='foo')
+        cmd = VersionCommand()
         cmd.print_current_version()
 
         print_mock.assert_called_with('1.2.3')

--- a/tests/version/test_update_pyroject_version.py
+++ b/tests/version/test_update_pyroject_version.py
@@ -31,7 +31,7 @@ class UpdatePyprojectVersionTestCase(unittest.TestCase):
         fake_path = fake_path_class.return_value
         fake_path.read_text.return_value = ""
 
-        cmd = VersionCommand(name='foo', pyproject_toml_path=fake_path)
+        cmd = VersionCommand(pyproject_toml_path=fake_path)
 
         cmd.update_pyproject_version('20.04dev1')
 
@@ -46,7 +46,7 @@ class UpdatePyprojectVersionTestCase(unittest.TestCase):
         fake_path = fake_path_class.return_value
         fake_path.read_text.return_value = "[tool]"
 
-        cmd = VersionCommand(name='foo', pyproject_toml_path=fake_path)
+        cmd = VersionCommand(pyproject_toml_path=fake_path)
         cmd.update_pyproject_version('20.04dev1')
 
         text = fake_path.write_text.call_args[0][0]
@@ -60,7 +60,7 @@ class UpdatePyprojectVersionTestCase(unittest.TestCase):
         fake_path = fake_path_class.return_value
         fake_path.read_text.return_value = "[tool.poetry]"
 
-        cmd = VersionCommand(name='foo', pyproject_toml_path=fake_path)
+        cmd = VersionCommand(pyproject_toml_path=fake_path)
         cmd.update_pyproject_version('20.04dev1')
 
         text = fake_path.write_text.call_args[0][0]
@@ -74,7 +74,7 @@ class UpdatePyprojectVersionTestCase(unittest.TestCase):
         fake_path = fake_path_class.return_value
         fake_path.read_text.return_value = '[tool.poetry]\nversion = "1.2.3"'
 
-        cmd = VersionCommand(name='foo', pyproject_toml_path=fake_path)
+        cmd = VersionCommand(pyproject_toml_path=fake_path)
         cmd.update_pyproject_version('20.04dev1')
 
         text = fake_path.write_text.call_args[0][0]

--- a/tests/version/test_update_version_file.py
+++ b/tests/version/test_update_version_file.py
@@ -28,7 +28,7 @@ class UpdateVersionFileTestCase(unittest.TestCase):
         fake_path_class = MagicMock(spec=Path)
         fake_path = fake_path_class.return_value
 
-        cmd = VersionCommand(name='foo', version_file_path=fake_path)
+        cmd = VersionCommand(version_file_path=fake_path)
         cmd.update_version_file('22.04dev1')
 
         text = fake_path.write_text.call_args[0][0]

--- a/tests/version/test_verify_version.py
+++ b/tests/version/test_verify_version.py
@@ -27,7 +27,7 @@ class VerifyVersionTestCase(unittest.TestCase):
     def test_current_version_not_pep440_compliant(self):
         fake_version_py = Path('foo.py')
         VersionCommand.get_current_version = MagicMock(return_value='1.02.03')
-        cmd = VersionCommand(name='foo', version_file_path=fake_version_py)
+        cmd = VersionCommand(version_file_path=fake_version_py)
 
         with self.assertRaisesRegex(
             VersionError, 'The version .* in foo.py is not PEP 440 compliant.',
@@ -42,9 +42,7 @@ class VerifyVersionTestCase(unittest.TestCase):
 
         VersionCommand.get_current_version = MagicMock(return_value='1.2.3')
         cmd = VersionCommand(
-            name='foo',
-            version_file_path=fake_version_py,
-            pyproject_toml_path=fake_path,
+            version_file_path=fake_version_py, pyproject_toml_path=fake_path,
         )
 
         with self.assertRaisesRegex(
@@ -64,9 +62,7 @@ class VerifyVersionTestCase(unittest.TestCase):
         VersionCommand._print = print_mock  # pylint: disable=protected-access
 
         cmd = VersionCommand(
-            name='foo',
-            version_file_path=fake_version_py,
-            pyproject_toml_path=fake_path,
+            version_file_path=fake_version_py, pyproject_toml_path=fake_path,
         )
         cmd.verify_version('current')
 
@@ -81,9 +77,7 @@ class VerifyVersionTestCase(unittest.TestCase):
         VersionCommand.get_current_version = MagicMock(return_value='1.2.3')
 
         cmd = VersionCommand(
-            name='foo',
-            version_file_path=fake_version_py,
-            pyproject_toml_path=fake_path,
+            version_file_path=fake_version_py, pyproject_toml_path=fake_path,
         )
 
         with self.assertRaisesRegex(
@@ -103,9 +97,7 @@ class VerifyVersionTestCase(unittest.TestCase):
         VersionCommand._print = print_mock  # pylint: disable=protected-access
 
         cmd = VersionCommand(
-            name='foo',
-            version_file_path=fake_version_py,
-            pyproject_toml_path=fake_path,
+            version_file_path=fake_version_py, pyproject_toml_path=fake_path,
         )
         cmd.verify_version('1.2.3')
 


### PR DESCRIPTION
Don't require to implement an own VersionCommand for the library/tool using pontos for handling version information. Instead allow to specify the version file in the `pyproject.toml`.
```toml
[tool.pontos.version]
version-module-file = "foo/__version__.py"
```
**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
