### PR TITLE
add cmake versioning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ venv.bak/
 
 # vscode settings
 .vscode
+# vim settings in virtualenv
+.vim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+ 
+* add possibility to update the version within a cmake project.
+* add possibility to execute main script via poetry run version
 
 ### Changed
+* `__main__` checks if there is CMakeLists.txt or pyproject.toml in path.
+   Based on that it decide which version command it will execute.
 
 ### Fixed
 

--- a/pontos/version/__init__.py
+++ b/pontos/version/__init__.py
@@ -26,6 +26,8 @@ from .version import (
     get_version_from_pyproject_toml,
 )
 
+from .cmake_version import CMakeVersionParser, CMakeVersionCommand
+
 __all__ = [
     '__version__',
     'VersionCommand',
@@ -34,4 +36,5 @@ __all__ = [
     'strip_version',
     'is_version_pep440_compliant',
     'get_version_from_pyproject_toml',
+    'CMakeVersionCommand',
 ]

--- a/pontos/version/__main__.py
+++ b/pontos/version/__main__.py
@@ -19,12 +19,21 @@
 
 import sys
 
+from pathlib import Path
 from .version import PontosVersionCommand
+from .cmake_version import CMakeVersionCommand
 
 
 def main():
-    cmd = PontosVersionCommand()
-    sys.exit(cmd.run())
+    available_cmds = [
+        ('CMakeLists.txt', CMakeVersionCommand),
+        ('pyproject.toml', PontosVersionCommand),
+    ]
+    for fileName, cmd in available_cmds:
+        project_definition_path = Path.cwd() / fileName
+        if project_definition_path.exists():
+            sys.exit(cmd().run())
+    sys.exit("No command found")
 
 
 if __name__ == '__main__':

--- a/pontos/version/cmake_version.py
+++ b/pontos/version/cmake_version.py
@@ -1,0 +1,145 @@
+# Copyright (C) 2020 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import re
+from typing import Tuple, Generator, Union
+from pathlib import Path
+from .version import (
+    is_version_pep440_compliant,
+    VersionError,
+    initialize_default_parser,
+)
+
+
+class CMakeVersionCommand:
+    __cmake_filepath = None
+
+    def __init__(self, *, cmake_lists_path: Path = None):
+        if not cmake_lists_path:
+            cmake_lists_path = Path.cwd() / 'CMakeLists.txt'
+        if not cmake_lists_path.exists():
+            raise VersionError(
+                '{} file not found.'.format(str(cmake_lists_path))
+            )
+
+        self.__cmake_filepath = cmake_lists_path
+        self.parser = initialize_default_parser()
+
+    def run(self, args=None) -> Union[int, str]:
+        args = self.parser.parse_args(args)
+
+        if not getattr(args, 'command', None):
+            self.parser.print_usage()
+            return 0
+
+        try:
+            if args.command == 'update':
+                self.update_version(args.version,)
+            elif args.command == 'show':
+                self.print_current_version()
+            elif args.command == 'verify':
+                self.verify_version(args.version)
+        except VersionError as e:
+            return str(e)
+        return 0
+
+    def update_version(self, version: str):
+        content = self.__cmake_filepath.read_text()
+        cmvp = CMakeVersionParser(content)
+        previous_version = cmvp.get_current_version()
+        new_content = cmvp.update_version(version)
+        self.__cmake_filepath.write_text(new_content)
+        print('Updated version from {} to {}'.format(previous_version, version))
+
+    def print_current_version(self):
+        content = self.__cmake_filepath.read_text()
+        cmvp = CMakeVersionParser(content)
+        print(cmvp.get_current_version())
+
+    def verify_version(self, version: str):
+        if not is_version_pep440_compliant(version):
+            raise VersionError(
+                "Version {} is not PEP 440 compliant.".format(version)
+            )
+        print('OK')
+
+
+class CMakeVersionParser:
+    def __init__(self, cmake_content_lines: str):
+        line_no, current_version = self._find_version_in_cmake(
+            cmake_content_lines
+        )
+        self._cmake_content_lines = cmake_content_lines.split('\n')
+        self._version_line_number = line_no
+        self._current_version = current_version
+
+    __cmake_scanner = re.Scanner(
+        [
+            (r'#.*', lambda _, token: ("comment", token)),
+            (r'"[^"]*"', lambda _, token: ("string", token)),
+            (r"\(", lambda _, token: ("open_bracket", token)),
+            (r"\)", lambda _, token: ("close_bracket", token)),
+            (r'[^ \t\r\n()#"]+', lambda _, token: ("word", token)),
+            (r'\n', lambda _, token: ("newline", token)),
+            # to have spaces etc correctly
+            (r"\s+", lambda _, token: ("special_printable", token)),
+        ]
+    )
+
+    def get_current_version(self) -> str:
+        return self._current_version
+
+    def update_version(self, new_version: str) -> str:
+        if not is_version_pep440_compliant(new_version):
+            raise VersionError(
+                "version {} is not pep 440 compliant.".format(new_version)
+            )
+        to_update = self._cmake_content_lines[self._version_line_number]
+        updated = to_update.replace(self._current_version, new_version)
+        self._cmake_content_lines[self._version_line_number] = updated
+        self._current_version = new_version
+        return '\n'.join(self._cmake_content_lines)
+
+    def _find_version_in_cmake(self, content: str) -> Tuple[int, str]:
+        in_project = False
+        in_version = False
+        for lineno, token_type, value in self._tokenize(content):
+            if token_type == 'word' and value == 'project':
+                in_project = True
+            elif in_project and token_type == 'word' and value == 'VERSION':
+                in_version = True
+            elif in_version and (
+                token_type == 'word' or token_type == 'string'
+            ):
+                return lineno, value
+            elif in_project and token_type == 'close_bracket':
+                raise ValueError('unable to find cmake version in project.')
+        raise ValueError('unable to find cmake project.')
+
+    def _tokenize(
+        self, content: str
+    ) -> Generator[
+        Tuple[int, str, str], Tuple[int, str, str], Tuple[int, str, str],
+    ]:
+        toks, remainder = self.__cmake_scanner.scan(content)
+        if remainder != '':
+            print('WARNING: unrecognized cmake tokens: {}'.format(remainder))
+        line_num = 0
+        for tok_type, tok_contents in toks:
+            line_num += tok_contents.count('\n')
+            yield line_num, tok_type, tok_contents.strip()

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -103,6 +103,39 @@ def is_version_pep440_compliant(version: str) -> bool:
     return version == safe_version(version)
 
 
+def initialize_default_parser() -> argparse.ArgumentParser:
+    """
+    Returns a default argument parser containing:
+    - verify
+    - show
+    - update
+    """
+    parser = argparse.ArgumentParser(
+        description='Version handling utilities.', prog='version',
+    )
+
+    subparsers = parser.add_subparsers(
+        title='subcommands',
+        description='valid subcommands',
+        help='additional help',
+        dest='command',
+    )
+
+    verify_parser = subparsers.add_parser('verify')
+    verify_parser.add_argument('version', help='version string to compare')
+
+    subparsers.add_parser('show')
+
+    update_parser = subparsers.add_parser('update')
+    update_parser.add_argument('version', help='version string to use')
+    update_parser.add_argument(
+        '--force',
+        help="don't check if version is already set",
+        action="store_true",
+    )
+    return parser
+
+
 class VersionCommand:
     TEMPLATE = """# pylint: disable=invalid-name
 
@@ -123,29 +156,7 @@ __version__ = "{}"\n"""
         self._configure_parser()
 
     def _configure_parser(self):
-        self.parser = argparse.ArgumentParser(
-            description='Version handling utilities.', prog='version',
-        )
-
-        subparsers = self.parser.add_subparsers(
-            title='subcommands',
-            description='valid subcommands',
-            help='additional help',
-            dest='command',
-        )
-
-        verify_parser = subparsers.add_parser('verify')
-        verify_parser.add_argument('version', help='version string to compare')
-
-        subparsers.add_parser('show')
-
-        update_parser = subparsers.add_parser('update')
-        update_parser.add_argument('version', help='version string to use')
-        update_parser.add_argument(
-            '--force',
-            help="don't check if version is already set",
-            action="store_true",
-        )
+        self.parser = initialize_default_parser()
 
     def _print(self, *args) -> None:
         print(*args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ mode = "poetry"
 [tool.pontos.version]
 version-module-file = "pontos/version/__version__.py"
 
+[tool.poetry.scripts]
+version = 'pontos.version.__main__:main'
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/tests/version/test_cmake_version.py
+++ b/tests/version/test_cmake_version.py
@@ -1,0 +1,117 @@
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+from pontos.version import CMakeVersionParser, VersionError, CMakeVersionCommand
+
+
+class CMakeVersionCommandTestCase(unittest.TestCase):
+    def test_raise_exception_file_not_exists(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = False
+        with self.assertRaises(VersionError):
+            CMakeVersionCommand(cmake_lists_path=fake_path)
+
+    def test_raise_exception_no_project(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = True
+        fake_path.read_text.return_value = ""
+        with self.assertRaises(ValueError):
+            CMakeVersionCommand(cmake_lists_path=fake_path).run(args=['show'])
+        fake_path.read_text.assert_called_with()
+
+    def test_return_error_string_incorrect_version_on_verify(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = True
+        fake_path.read_text.return_value = ""
+        result = CMakeVersionCommand(cmake_lists_path=fake_path).run(
+            args=['verify', 'su_much_version_so_much_wow']
+        )
+        self.assertTrue(
+            isinstance(result, str), "expected result to be an error string"
+        )
+
+    def test_return_0_correct_version_on_verify(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = True
+        fake_path.read_text.return_value = ""
+        result = CMakeVersionCommand(cmake_lists_path=fake_path).run(
+            args=['verify', '21.4']
+        )
+        self.assertEqual(0, result)
+
+    def test_should_call_print_current_version_without_raising_exception(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = True
+        fake_path.read_text.return_value = "project(VERSION 21)"
+        CMakeVersionCommand(cmake_lists_path=fake_path).run(args=['show'])
+        fake_path.read_text.assert_called_with()
+
+    def test_raise_update_version(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = True
+        fake_path.read_text.return_value = "project(VERSION 21)"
+        CMakeVersionCommand(cmake_lists_path=fake_path).run(
+            args=['update', '22']
+        )
+        fake_path.read_text.assert_called_with()
+        fake_path.write_text.assert_called_with('project(VERSION 22)')
+
+
+class CMakeVersionParserTestCase(unittest.TestCase):
+    def test_get_current_version_single_line_project(self):
+        under_test = CMakeVersionParser("project(VERSION 2.3.4)")
+        self.assertEqual(under_test.get_current_version(), '2.3.4')
+
+    def test_update_version_project(self):
+        under_test = CMakeVersionParser("project(VERSION 2.3.4)")
+        self.assertEqual(
+            under_test.update_version('2.3.5'), "project(VERSION 2.3.5)"
+        )
+
+    def test_update_raise_exception_when_version_is_incorrect(self):
+        under_test = CMakeVersionParser("project(VERSION 2.3.4)")
+        with self.assertRaises(VersionError):
+            under_test.update_version('su_much_version_so_much_wow')
+
+    def test_not_confuse_version_outside_project(self):
+        under_test = CMakeVersionParser(
+            "non_project(VERSION 2.3.5)\nproject(VERSION 2.3.4)"
+        )
+        self.assertEqual(under_test.get_current_version(), '2.3.4')
+
+    def test_get_current_version_multiline_project(self):
+        under_test = CMakeVersionParser("project\n(\nVERSION\n\t    2.3.4)")
+        self.assertEqual(under_test.get_current_version(), '2.3.4')
+
+    def test_get_current_version_multiline_project_combined_token(self):
+        under_test = CMakeVersionParser(
+            "project\n(\nDESCRIPTION something VERSION 2.3.4 LANGUAGES c\n)"
+        )
+        self.assertEqual(under_test.get_current_version(), '2.3.4')
+
+    def test_raise_exception_project_no_version(self):
+        with self.assertRaises(ValueError) as context:
+            CMakeVersionParser("project(DESCRIPTION something LANGUAGES c)")
+        self.assertEqual(
+            str(context.exception), 'unable to find cmake version in project.'
+        )
+
+    def test_raise_exception_no_project(self):
+        with self.assertRaises(ValueError) as context:
+            CMakeVersionParser("non_project(VERSION 2.3.5)",)
+
+        self.assertEqual(
+            str(context.exception), 'unable to find cmake project.'
+        )


### PR DESCRIPTION
to be capable of using pontos in cmake projects this creates a simple
cmake parser to get and update the version within CMakeLists.txt.

This parser is then used within a cmake version command.

This main script verifies if there is a CMakeLists.txt or a
pyproject.toml and decides based on that if it runs PoetryCommand or
CMakeCommand.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
