### PR TITLE
Release command

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -89,22 +89,6 @@ commands:
             poetry run twine upload dist/*
 
 jobs:
-  build-35:
-    executor: python-35
-    steps:
-      - build
-  test-35:
-    executor: python-35
-    steps:
-      - test
-  build-36:
-    executor: python-36
-    steps:
-      - build
-  test-36:
-    executor: python-36
-    steps:
-      - test
   build-37:
     executor: python-37
     steps:
@@ -135,10 +119,6 @@ workflows:
   version: 2
   build_and_test:
     jobs:
-      - build-35
-      - test-35
-      - build-36
-      - test-36
       - build-37
       - test-37
       - build-38

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,14 +1,6 @@
 version: 2.1
 
 executors:
-  python-35:
-    docker:
-      - image: circleci/python:3.5
-    working_directory: ~/repo
-  python-36:
-    docker:
-      - image: circleci/python:3.6
-    working_directory: ~/repo
   python-37:
     docker:
       - image: circleci/python:3.7

--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ venv.bak/
 
 # vscode settings
 .vscode
+# vim settings in virtualenv
+.vim

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
  
 * add possibility to update the version within a cmake project.
-* add possibility to execute main script via poetry run version
+* add possibility to execute version script via poetry run version
+* add CHANGELOD.md handling (upating unreleased, get unreleased information)
+* add release command to to a release 
 
 ### Changed
 * `__main__` checks if there is CMakeLists.txt or pyproject.toml in path.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+ 
+* add possibility to update the version within a cmake project.
+* add possibility to execute main script via poetry run version
 
 ### Changed
+* `__main__` checks if there is CMakeLists.txt or pyproject.toml in path.
+   Based on that it decide which version command it will execute.
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ the titan of the sea.
 
 ### Requirements
 
-Python 3.5 and later is supported.
+Python 3.7 and later is supported.
 
 ### Install using pip
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -145,28 +145,6 @@ colorama = "*"
 
 [[package]]
 category = "main"
-description = "Git Object Database"
-name = "gitdb"
-optional = false
-python-versions = ">=3.4"
-version = "4.0.5"
-
-[package.dependencies]
-smmap = ">=3.0.1,<4"
-
-[[package]]
-category = "main"
-description = "Python Git Library"
-name = "gitpython"
-optional = false
-python-versions = ">=3.4"
-version = "3.1.7"
-
-[package.dependencies]
-gitdb = ">=4.0.1,<5"
-
-[[package]]
-category = "main"
 description = "Internationalized Domain Names in Applications (IDNA)"
 name = "idna"
 optional = false
@@ -293,14 +271,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "1.14.0"
 
 [[package]]
-category = "main"
-description = "A pure Python implementation of a sliding window memory map manager"
-name = "smmap"
-optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "3.0.4"
-
-[[package]]
 category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
 marker = "python_version >= \"3.6\" and python_version < \"4.0\""
@@ -348,7 +318,7 @@ python-versions = "*"
 version = "1.11.2"
 
 [metadata]
-content-hash = "adf3f640fbbb81cb14fa3c3f5e8de06ae91f6a9dedd189731f87261bd613c433"
+content-hash = "630170cc733bfa6eaa0272f7a28cdb409255949d6de4ff8c463841ec8533afdb"
 lock-version = "1.0"
 python-versions = "^3.5"
 
@@ -400,14 +370,6 @@ colorama = [
 colorful = [
     {file = "colorful-0.5.4-py2.py3-none-any.whl", hash = "sha256:8d264b52a39aae4c0ba3e2a46afbaec81b0559a99be0d2cfe2aba4cf94531348"},
     {file = "colorful-0.5.4.tar.gz", hash = "sha256:86848ad4e2eda60cd2519d8698945d22f6f6551e23e95f3f14dfbb60997807ea"},
-]
-gitdb = [
-    {file = "gitdb-4.0.5-py3-none-any.whl", hash = "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac"},
-    {file = "gitdb-4.0.5.tar.gz", hash = "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"},
-]
-gitpython = [
-    {file = "GitPython-3.1.7-py3-none-any.whl", hash = "sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5"},
-    {file = "GitPython-3.1.7.tar.gz", hash = "sha256:2db287d71a284e22e5c2846042d0602465c7434d910406990d5b74df4afb0858"},
 ]
 idna = [
     {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
@@ -495,10 +457,6 @@ rope = [
 six = [
     {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
     {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
-]
-smmap = [
-    {file = "smmap-3.0.4-py2.py3-none-any.whl", hash = "sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4"},
-    {file = "smmap-3.0.4.tar.gz", hash = "sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24"},
 ]
 toml = [
     {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},

--- a/poetry.lock
+++ b/poetry.lock
@@ -5,20 +5,20 @@ marker = "python_version >= \"3.6\" and python_version < \"4.0\""
 name = "appdirs"
 optional = false
 python-versions = "*"
-version = "1.4.3"
+version = "1.4.4"
 
 [[package]]
 category = "dev"
 description = "An abstract syntax tree for Python with inference support."
 name = "astroid"
 optional = false
-python-versions = ">=3.5.*"
-version = "2.3.3"
+python-versions = ">=3.5"
+version = "2.4.2"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0,<1.5.0"
 six = ">=1.12,<2.0"
-wrapt = ">=1.11.0,<1.12.0"
+wrapt = ">=1.11,<2.0"
 
 [package.dependencies.typed-ast]
 python = "<3.8"
@@ -121,7 +121,7 @@ marker = "python_version >= \"3.6\" and python_version < \"4.0\""
 name = "click"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
-version = "7.1.1"
+version = "7.1.2"
 
 [[package]]
 category = "dev"
@@ -187,7 +187,7 @@ description = "Core utilities for Python packages"
 name = "packaging"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
-version = "20.3"
+version = "20.4"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
@@ -208,13 +208,14 @@ description = "python code static checker"
 name = "pylint"
 optional = false
 python-versions = ">=3.5.*"
-version = "2.4.4"
+version = "2.5.3"
 
 [package.dependencies]
-astroid = ">=2.3.0,<2.4"
+astroid = ">=2.4.0,<=2.5"
 colorama = "*"
 isort = ">=4.2.5,<5"
 mccabe = ">=0.6,<0.7"
+toml = ">=0.7.1"
 
 [[package]]
 category = "main"
@@ -231,7 +232,7 @@ marker = "python_version >= \"3.6\" and python_version < \"4.0\""
 name = "regex"
 optional = false
 python-versions = "*"
-version = "2020.4.4"
+version = "2020.7.14"
 
 [[package]]
 category = "main"
@@ -268,16 +269,15 @@ description = "Python 2 and 3 compatibility utilities"
 name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
-version = "1.14.0"
+version = "1.15.0"
 
 [[package]]
 category = "dev"
 description = "Python Library for Tom's Obvious, Minimal Language"
-marker = "python_version >= \"3.6\" and python_version < \"4.0\""
 name = "toml"
 optional = false
 python-versions = "*"
-version = "0.10.0"
+version = "0.10.1"
 
 [[package]]
 category = "main"
@@ -315,21 +315,21 @@ description = "Module for decorators, wrappers and monkey patching."
 name = "wrapt"
 optional = false
 python-versions = "*"
-version = "1.11.2"
+version = "1.12.1"
 
 [metadata]
-content-hash = "630170cc733bfa6eaa0272f7a28cdb409255949d6de4ff8c463841ec8533afdb"
+content-hash = "ad9ac77e3ddb25bb28fd17356dcbc9cfc18fa7cc36e4dca0bc5b626d6c223077"
 lock-version = "1.0"
-python-versions = "^3.5"
+python-versions = "^3.7"
 
 [metadata.files]
 appdirs = [
-    {file = "appdirs-1.4.3-py2.py3-none-any.whl", hash = "sha256:d8b24664561d0d34ddfaec54636d502d7cea6e29c3eaf68f3df6180863e2166e"},
-    {file = "appdirs-1.4.3.tar.gz", hash = "sha256:9e5896d1372858f8dd3344faf4e5014d21849c756c8d5701f78f8a103b372d92"},
+    {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
+    {file = "appdirs-1.4.4.tar.gz", hash = "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"},
 ]
 astroid = [
-    {file = "astroid-2.3.3-py3-none-any.whl", hash = "sha256:840947ebfa8b58f318d42301cf8c0a20fd794a33b61cc4638e28e9e61ba32f42"},
-    {file = "astroid-2.3.3.tar.gz", hash = "sha256:71ea07f44df9568a75d0f354c49143a4575d90645e9fead6dfb52c26a85ed13a"},
+    {file = "astroid-2.4.2-py3-none-any.whl", hash = "sha256:bc58d83eb610252fd8de6363e39d4f1d0619c894b0ed24603b881c02e64c7386"},
+    {file = "astroid-2.4.2.tar.gz", hash = "sha256:2f4078c2a41bf377eea06d71c9d2ba4eb8f6b1af2135bec27bbbb7d8f12bb703"},
 ]
 attrs = [
     {file = "attrs-19.3.0-py2.py3-none-any.whl", hash = "sha256:08a96c641c3a74e44eb59afb61a24f2cb9f4d7188748e76ba4bb5edfa3cb7d1c"},
@@ -360,8 +360,8 @@ chardet = [
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 click = [
-    {file = "click-7.1.1-py2.py3-none-any.whl", hash = "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"},
-    {file = "click-7.1.1.tar.gz", hash = "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"},
+    {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
+    {file = "click-7.1.2.tar.gz", hash = "sha256:d2b5255c7c6349bc1bd1e59e08cd12acbbd63ce649f2588755783aa94dfb6b1a"},
 ]
 colorama = [
     {file = "colorama-0.4.3-py2.py3-none-any.whl", hash = "sha256:7d73d2a99753107a36ac6b455ee49046802e59d9d076ef8e47b61499fa29afff"},
@@ -407,43 +407,43 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 packaging = [
-    {file = "packaging-20.3-py2.py3-none-any.whl", hash = "sha256:82f77b9bee21c1bafbf35a84905d604d5d1223801d639cf3ed140bd651c08752"},
-    {file = "packaging-20.3.tar.gz", hash = "sha256:3c292b474fda1671ec57d46d739d072bfd495a4f51ad01a055121d81e952b7a3"},
+    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
+    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
 ]
 pathspec = [
     {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
     {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
 ]
 pylint = [
-    {file = "pylint-2.4.4-py3-none-any.whl", hash = "sha256:886e6afc935ea2590b462664b161ca9a5e40168ea99e5300935f6591ad467df4"},
-    {file = "pylint-2.4.4.tar.gz", hash = "sha256:3db5468ad013380e987410a8d6956226963aed94ecb5f9d3a28acca6d9ac36cd"},
+    {file = "pylint-2.5.3-py3-none-any.whl", hash = "sha256:d0ece7d223fe422088b0e8f13fa0a1e8eb745ebffcb8ed53d3e95394b6101a1c"},
+    {file = "pylint-2.5.3.tar.gz", hash = "sha256:7dd78437f2d8d019717dbf287772d0b2dbdfd13fc016aa7faa08d67bccc46adc"},
 ]
 pyparsing = [
     {file = "pyparsing-2.4.7-py2.py3-none-any.whl", hash = "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"},
     {file = "pyparsing-2.4.7.tar.gz", hash = "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1"},
 ]
 regex = [
-    {file = "regex-2020.4.4-cp27-cp27m-win32.whl", hash = "sha256:90742c6ff121a9c5b261b9b215cb476eea97df98ea82037ec8ac95d1be7a034f"},
-    {file = "regex-2020.4.4-cp27-cp27m-win_amd64.whl", hash = "sha256:24f4f4062eb16c5bbfff6a22312e8eab92c2c99c51a02e39b4eae54ce8255cd1"},
-    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:08119f707f0ebf2da60d2f24c2f39ca616277bb67ef6c92b72cbf90cbe3a556b"},
-    {file = "regex-2020.4.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:c9423a150d3a4fc0f3f2aae897a59919acd293f4cb397429b120a5fcd96ea3db"},
-    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:c087bff162158536387c53647411db09b6ee3f9603c334c90943e97b1052a156"},
-    {file = "regex-2020.4.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:1cbe0fa0b7f673400eb29e9ef41d4f53638f65f9a2143854de6b1ce2899185c3"},
-    {file = "regex-2020.4.4-cp36-cp36m-win32.whl", hash = "sha256:0ce9537396d8f556bcfc317c65b6a0705320701e5ce511f05fc04421ba05b8a8"},
-    {file = "regex-2020.4.4-cp36-cp36m-win_amd64.whl", hash = "sha256:7e1037073b1b7053ee74c3c6c0ada80f3501ec29d5f46e42669378eae6d4405a"},
-    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4385f12aa289d79419fede43f979e372f527892ac44a541b5446617e4406c468"},
-    {file = "regex-2020.4.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a58dd45cb865be0ce1d5ecc4cfc85cd8c6867bea66733623e54bd95131f473b6"},
-    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:ccccdd84912875e34c5ad2d06e1989d890d43af6c2242c6fcfa51556997af6cd"},
-    {file = "regex-2020.4.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:ea4adf02d23b437684cd388d557bf76e3afa72f7fed5bbc013482cc00c816948"},
-    {file = "regex-2020.4.4-cp37-cp37m-win32.whl", hash = "sha256:2294f8b70e058a2553cd009df003a20802ef75b3c629506be20687df0908177e"},
-    {file = "regex-2020.4.4-cp37-cp37m-win_amd64.whl", hash = "sha256:e91ba11da11cf770f389e47c3f5c30473e6d85e06d7fd9dcba0017d2867aab4a"},
-    {file = "regex-2020.4.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5635cd1ed0a12b4c42cce18a8d2fb53ff13ff537f09de5fd791e97de27b6400e"},
-    {file = "regex-2020.4.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:23069d9c07e115537f37270d1d5faea3e0bdded8279081c4d4d607a2ad393683"},
-    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c162a21e0da33eb3d31a3ac17a51db5e634fc347f650d271f0305d96601dc15b"},
-    {file = "regex-2020.4.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:fb95debbd1a824b2c4376932f2216cc186912e389bdb0e27147778cf6acb3f89"},
-    {file = "regex-2020.4.4-cp38-cp38-win32.whl", hash = "sha256:2a3bf8b48f8e37c3a40bb3f854bf0121c194e69a650b209628d951190b862de3"},
-    {file = "regex-2020.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3"},
-    {file = "regex-2020.4.4.tar.gz", hash = "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142"},
+    {file = "regex-2020.7.14-cp27-cp27m-win32.whl", hash = "sha256:e46d13f38cfcbb79bfdb2964b0fe12561fe633caf964a77a5f8d4e45fe5d2ef7"},
+    {file = "regex-2020.7.14-cp27-cp27m-win_amd64.whl", hash = "sha256:6961548bba529cac7c07af2fd4d527c5b91bb8fe18995fed6044ac22b3d14644"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c50a724d136ec10d920661f1442e4a8b010a4fe5aebd65e0c2241ea41dbe93dc"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8a51f2c6d1f884e98846a0a9021ff6861bdb98457879f412fdc2b42d14494067"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:9c568495e35599625f7b999774e29e8d6b01a6fb684d77dee1f56d41b11b40cd"},
+    {file = "regex-2020.7.14-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:51178c738d559a2d1071ce0b0f56e57eb315bcf8f7d4cf127674b533e3101f88"},
+    {file = "regex-2020.7.14-cp36-cp36m-win32.whl", hash = "sha256:9eddaafb3c48e0900690c1727fba226c4804b8e6127ea409689c3bb492d06de4"},
+    {file = "regex-2020.7.14-cp36-cp36m-win_amd64.whl", hash = "sha256:14a53646369157baa0499513f96091eb70382eb50b2c82393d17d7ec81b7b85f"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:1269fef3167bb52631ad4fa7dd27bf635d5a0790b8e6222065d42e91bede4162"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d0a5095d52b90ff38592bbdc2644f17c6d495762edf47d876049cfd2968fbccf"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:4c037fd14c5f4e308b8370b447b469ca10e69427966527edcab07f52d88388f7"},
+    {file = "regex-2020.7.14-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bc3d98f621898b4a9bc7fecc00513eec8f40b5b83913d74ccb445f037d58cd89"},
+    {file = "regex-2020.7.14-cp37-cp37m-win32.whl", hash = "sha256:46bac5ca10fb748d6c55843a931855e2727a7a22584f302dd9bb1506e69f83f6"},
+    {file = "regex-2020.7.14-cp37-cp37m-win_amd64.whl", hash = "sha256:0dc64ee3f33cd7899f79a8d788abfbec168410be356ed9bd30bbd3f0a23a7204"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5ea81ea3dbd6767873c611687141ec7b06ed8bab43f68fad5b7be184a920dc99"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:bbb332d45b32df41200380fff14712cb6093b61bd142272a10b16778c418e98e"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c11d6033115dc4887c456565303f540c44197f4fc1a2bfb192224a301534888e"},
+    {file = "regex-2020.7.14-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:75aaa27aa521a182824d89e5ab0a1d16ca207318a6b65042b046053cfc8ed07a"},
+    {file = "regex-2020.7.14-cp38-cp38-win32.whl", hash = "sha256:d6cff2276e502b86a25fd10c2a96973fdb45c7a977dca2138d661417f3728341"},
+    {file = "regex-2020.7.14-cp38-cp38-win_amd64.whl", hash = "sha256:7a2dd66d2d4df34fa82c9dc85657c5e019b87932019947faece7983f2089a840"},
+    {file = "regex-2020.7.14.tar.gz", hash = "sha256:3a3af27a8d23143c49a3420efe5b3f8cf1a48c6fc8bc6856b03f638abc1833bb"},
 ]
 requests = [
     {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
@@ -455,13 +455,12 @@ rope = [
     {file = "rope-0.16.0.tar.gz", hash = "sha256:d2830142c2e046f5fc26a022fe680675b6f48f81c7fc1f03a950706e746e9dfe"},
 ]
 six = [
-    {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
-    {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
+    {file = "six-1.15.0-py2.py3-none-any.whl", hash = "sha256:8b74bedcbbbaca38ff6d7491d76f2b06b3592611af620f8426e82dddb04a5ced"},
+    {file = "six-1.15.0.tar.gz", hash = "sha256:30639c035cdb23534cd4aa2dd52c3bf48f06e5f4a941509c8bafd8ce11080259"},
 ]
 toml = [
-    {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
-    {file = "toml-0.10.0-py2.py3-none-any.whl", hash = "sha256:235682dd292d5899d361a811df37e04a8828a5b1da3115886b73cf81ebc9100e"},
-    {file = "toml-0.10.0.tar.gz", hash = "sha256:229f81c57791a41d65e399fc06bf0848bab550a9dfd5ed66df18ce5f05e73d5c"},
+    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
+    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
 ]
 tomlkit = [
     {file = "tomlkit-0.5.11-py2.py3-none-any.whl", hash = "sha256:4e1bd6c9197d984528f9ff0cc9db667c317d8881288db50db20eeeb0f6b0380b"},
@@ -495,5 +494,5 @@ urllib3 = [
     {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 wrapt = [
-    {file = "wrapt-1.11.2.tar.gz", hash = "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"},
+    {file = "wrapt-1.12.1.tar.gz", hash = "sha256:b62ffa81fb85f4332a4f609cab4ac40709470da05643a082ec1eb88e6d9b97d7"},
 ]

--- a/poetry.lock
+++ b/poetry.lock
@@ -99,6 +99,22 @@ typed-ast = ">=1.4.0"
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
+category = "main"
+description = "Python package for providing Mozilla's CA Bundle."
+name = "certifi"
+optional = false
+python-versions = "*"
+version = "2020.6.20"
+
+[[package]]
+category = "main"
+description = "Universal encoding detector for Python 2 and 3"
+name = "chardet"
+optional = false
+python-versions = "*"
+version = "3.0.4"
+
+[[package]]
 category = "dev"
 description = "Composable command line interface toolkit"
 marker = "python_version >= \"3.6\" and python_version < \"4.0\""
@@ -126,6 +142,36 @@ version = "0.5.4"
 
 [package.dependencies]
 colorama = "*"
+
+[[package]]
+category = "main"
+description = "Git Object Database"
+name = "gitdb"
+optional = false
+python-versions = ">=3.4"
+version = "4.0.5"
+
+[package.dependencies]
+smmap = ">=3.0.1,<4"
+
+[[package]]
+category = "main"
+description = "Python Git Library"
+name = "gitpython"
+optional = false
+python-versions = ">=3.4"
+version = "3.1.7"
+
+[package.dependencies]
+gitdb = ">=4.0.1,<5"
+
+[[package]]
+category = "main"
+description = "Internationalized Domain Names in Applications (IDNA)"
+name = "idna"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.10"
 
 [[package]]
 category = "dev"
@@ -210,6 +256,24 @@ python-versions = "*"
 version = "2020.4.4"
 
 [[package]]
+category = "main"
+description = "Python HTTP for Humans."
+name = "requests"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+version = "2.24.0"
+
+[package.dependencies]
+certifi = ">=2017.4.17"
+chardet = ">=3.0.2,<4"
+idna = ">=2.5,<3"
+urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+
+[package.extras]
+security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7)", "win-inet-pton"]
+
+[[package]]
 category = "dev"
 description = "a python refactoring library..."
 name = "rope"
@@ -227,6 +291,14 @@ name = "six"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*"
 version = "1.14.0"
+
+[[package]]
+category = "main"
+description = "A pure Python implementation of a sliding window memory map manager"
+name = "smmap"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "3.0.4"
 
 [[package]]
 category = "dev"
@@ -255,6 +327,19 @@ python-versions = "*"
 version = "1.4.1"
 
 [[package]]
+category = "main"
+description = "HTTP library with thread-safe connection pooling, file post, and more."
+name = "urllib3"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, <4"
+version = "1.25.10"
+
+[package.extras]
+brotli = ["brotlipy (>=0.6.0)"]
+secure = ["certifi", "cryptography (>=1.3.4)", "idna (>=2.0.0)", "pyOpenSSL (>=0.14)", "ipaddress"]
+socks = ["PySocks (>=1.5.6,<1.5.7 || >1.5.7,<2.0)"]
+
+[[package]]
 category = "dev"
 description = "Module for decorators, wrappers and monkey patching."
 name = "wrapt"
@@ -263,7 +348,8 @@ python-versions = "*"
 version = "1.11.2"
 
 [metadata]
-content-hash = "d27137607a2ebde5a9cc02b2795cffb1c5421f3036183f6b17f8f4d47b6d9c9d"
+content-hash = "adf3f640fbbb81cb14fa3c3f5e8de06ae91f6a9dedd189731f87261bd613c433"
+lock-version = "1.0"
 python-versions = "^3.5"
 
 [metadata.files]
@@ -295,6 +381,14 @@ black = [
     {file = "black-19.10b0-py36-none-any.whl", hash = "sha256:1b30e59be925fafc1ee4565e5e08abef6b03fe455102883820fe5ee2e4734e0b"},
     {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
 ]
+certifi = [
+    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
+    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+]
+chardet = [
+    {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
+    {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
+]
 click = [
     {file = "click-7.1.1-py2.py3-none-any.whl", hash = "sha256:e345d143d80bf5ee7534056164e5e112ea5e22716bbb1ce727941f4c8b471b9a"},
     {file = "click-7.1.1.tar.gz", hash = "sha256:8a18b4ea89d8820c5d0c7da8a64b2c324b4dabb695804dbfea19b9be9d88c0cc"},
@@ -306,6 +400,18 @@ colorama = [
 colorful = [
     {file = "colorful-0.5.4-py2.py3-none-any.whl", hash = "sha256:8d264b52a39aae4c0ba3e2a46afbaec81b0559a99be0d2cfe2aba4cf94531348"},
     {file = "colorful-0.5.4.tar.gz", hash = "sha256:86848ad4e2eda60cd2519d8698945d22f6f6551e23e95f3f14dfbb60997807ea"},
+]
+gitdb = [
+    {file = "gitdb-4.0.5-py3-none-any.whl", hash = "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac"},
+    {file = "gitdb-4.0.5.tar.gz", hash = "sha256:c9e1f2d0db7ddb9a704c2a0217be31214e91a4fe1dea1efad19ae42ba0c285c9"},
+]
+gitpython = [
+    {file = "GitPython-3.1.7-py3-none-any.whl", hash = "sha256:fa3b92da728a457dd75d62bb5f3eb2816d99a7fe6c67398e260637a40e3fafb5"},
+    {file = "GitPython-3.1.7.tar.gz", hash = "sha256:2db287d71a284e22e5c2846042d0602465c7434d910406990d5b74df4afb0858"},
+]
+idna = [
+    {file = "idna-2.10-py2.py3-none-any.whl", hash = "sha256:b97d804b1e9b523befed77c48dacec60e6dcb0b5391d57af6a65a312a90648c0"},
+    {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 isort = [
     {file = "isort-4.3.21-py2.py3-none-any.whl", hash = "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"},
@@ -377,6 +483,10 @@ regex = [
     {file = "regex-2020.4.4-cp38-cp38-win_amd64.whl", hash = "sha256:5bfed051dbff32fd8945eccca70f5e22b55e4148d2a8a45141a3b053d6455ae3"},
     {file = "regex-2020.4.4.tar.gz", hash = "sha256:295badf61a51add2d428a46b8580309c520d8b26e769868b922750cf3ce67142"},
 ]
+requests = [
+    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
+    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+]
 rope = [
     {file = "rope-0.16.0-py2-none-any.whl", hash = "sha256:ae1fa2fd56f64f4cc9be46493ce54bed0dd12dee03980c61a4393d89d84029ad"},
     {file = "rope-0.16.0-py3-none-any.whl", hash = "sha256:52423a7eebb5306a6d63bdc91a7c657db51ac9babfb8341c9a1440831ecf3203"},
@@ -385,6 +495,10 @@ rope = [
 six = [
     {file = "six-1.14.0-py2.py3-none-any.whl", hash = "sha256:8f3cd2e254d8f793e7f3d6d9df77b92252b52637291d0f0da013c76ea2724b6c"},
     {file = "six-1.14.0.tar.gz", hash = "sha256:236bdbdce46e6e6a3d61a337c0f8b763ca1e8717c03b369e87a7ec7ce1319c0a"},
+]
+smmap = [
+    {file = "smmap-3.0.4-py2.py3-none-any.whl", hash = "sha256:54c44c197c819d5ef1991799a7e30b662d1e520f2ac75c9efbeb54a742214cf4"},
+    {file = "smmap-3.0.4.tar.gz", hash = "sha256:9c98bbd1f9786d22f14b3d4126894d56befb835ec90cef151af566c7e19b5d24"},
 ]
 toml = [
     {file = "toml-0.10.0-py2.7.egg", hash = "sha256:f1db651f9657708513243e61e6cc67d101a39bad662eaa9b5546f789338e07a3"},
@@ -417,6 +531,10 @@ typed-ast = [
     {file = "typed_ast-1.4.1-cp38-cp38-win_amd64.whl", hash = "sha256:fc0fea399acb12edbf8a628ba8d2312f583bdbdb3335635db062fa98cf71fca4"},
     {file = "typed_ast-1.4.1-cp39-cp39-macosx_10_15_x86_64.whl", hash = "sha256:d43943ef777f9a1c42bf4e552ba23ac77a6351de620aa9acf64ad54933ad4d34"},
     {file = "typed_ast-1.4.1.tar.gz", hash = "sha256:8c8aaad94455178e3187ab22c8b01a3837f8ee50e09cf31f1ba129eb293ec30b"},
+]
+urllib3 = [
+    {file = "urllib3-1.25.10-py2.py3-none-any.whl", hash = "sha256:e7983572181f5e1522d9c98453462384ee92a0be7fac5f1413a1e35c56cc0461"},
+    {file = "urllib3-1.25.10.tar.gz", hash = "sha256:91056c15fa70756691db97756772bb1eb9678fa585d9184f24534b100dc60f4a"},
 ]
 wrapt = [
     {file = "wrapt-1.11.2.tar.gz", hash = "sha256:565a021fd19419476b9362b05eeaa094178de64f8361e44468f9e9d7843901e1"},

--- a/pontos/changelog/__init__.py
+++ b/pontos/changelog/__init__.py
@@ -1,0 +1,1 @@
+from .changelog import update, ChangelogError

--- a/pontos/changelog/changelog.py
+++ b/pontos/changelog/changelog.py
@@ -44,7 +44,7 @@ __UNRELEASED_SKELETON = """## [Unreleased]
 
 
 def update(
-    markdown,
+    markdown: str,
     new_version: str,
     project_name: str,
     git_tag_prefix: str = 'v',
@@ -59,7 +59,7 @@ def update(
     """
 
     def may_add_skeleton(
-        heading_count, first_headline_state, markdown
+        heading_count: int, first_headline_state: int, markdown: str
     ) -> (int, str):
         if first_headline_state == -1 and heading_count == 1:
             return 0, markdown
@@ -140,7 +140,7 @@ __CHANGELOG_SCANNER = __build_scanner()
 
 
 def _tokenize(
-    markdown,
+    markdown: str,
 ) -> List[
     Tuple[int, str, int, str],
 ]:

--- a/pontos/changelog/changelog.py
+++ b/pontos/changelog/changelog.py
@@ -1,0 +1,152 @@
+# Copyright (C) 2020 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import re
+from typing import Tuple, List
+from datetime import date
+
+
+class ChangelogError(Exception):
+    """
+    Some error has occurred during changelog handling
+    """
+
+
+__UNRELEASED_MATCHER = re.compile("unreleased", re.IGNORECASE)
+__MASTER_MATCHER = re.compile("master")
+
+__UNRELEASED_SKELETON = """## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+[Unreleased]: https://github.com/{}/{}/compare/{}...HEAD
+
+
+"""
+
+
+def update(
+    markdown,
+    new_version: str,
+    project_name: str,
+    git_tag_prefix: str = 'v',
+    git_space: str = 'greenbone',
+    containing_version: str = None,
+) -> Tuple[str, str]:
+    """
+    update tokenizes CHANGELOG.md and if a version is given it changes
+    unreleased headline and link to given version.
+
+    returns updated markdown and change log for further processing.
+    """
+
+    def may_add_skeleton(
+        heading_count, first_headline_state, markdown
+    ) -> (int, str):
+        if first_headline_state == -1 and heading_count == 1:
+            return 0, markdown
+        if first_headline_state == 0 and heading_count > 1:
+            prepared_skeleton = __UNRELEASED_SKELETON.format(
+                git_space, project_name, git_tag
+            )
+            return 1, markdown + prepared_skeleton
+        return first_headline_state, markdown
+
+    git_tag = "{}{}".format(git_tag_prefix, new_version)
+    tokens = _tokenize(markdown)
+    hc = 0
+    changelog = ""
+    updated_markdown = ""
+    may_changelog_relevant = True
+    first_headline_state = -1  # -1 initial, 0 found, 1 handled
+
+    for tt, heading_count, tc in tokens:
+        first_headline_state, updated_markdown = may_add_skeleton(
+            heading_count, first_headline_state, updated_markdown
+        )
+        if tt == 'unreleased':
+            if (
+                containing_version and containing_version in tc
+            ) or not containing_version:
+                hc = heading_count
+                if new_version:
+                    tc = __UNRELEASED_MATCHER.sub(new_version, tc)
+                    tc += " - {}".format(date.today().isoformat())
+        elif heading_count > 0 and hc > 0 and heading_count <= hc:
+            may_changelog_relevant = False
+        if tt == 'unreleased_link' and new_version:
+            tc = __UNRELEASED_MATCHER.sub(new_version, tc)
+            tc = __MASTER_MATCHER.sub(git_tag, tc)
+
+        updated_markdown += tc
+        if may_changelog_relevant:
+            append_word = hc > 0
+            if append_word:
+                changelog += tc
+    return (
+        updated_markdown if changelog else "",
+        changelog,
+    )
+
+
+def __build_scanner():
+    def token_handler(key: str):
+        """
+        generates a lambda for the regex scanner with a given key.
+
+        This lambda will return a tuple: key, count # of token and token.
+
+        The count is used to identify the level of heading on a special
+        ended which can be used to identify when this section ended.
+        """
+        return lambda _, token: (key, token.count('#'), token)
+
+    return re.Scanner(
+        [
+            (r'#{1,} Added', token_handler('added')),
+            (r'#{1,} Changed', token_handler("changed")),
+            (r'#{1,} Deprecated', token_handler("deprecated")),
+            (r'#{1,} Removed', token_handler("removed")),
+            (r'#{1,} Fixed', token_handler("fixed")),
+            (r'#{1,} Security', token_handler("security")),
+            (r'#{1,}.*(?=[Uu]nreleased).*', token_handler("unreleased")),
+            (r'\[[Uu]nreleased\].*', token_handler("unreleased_link"),),
+            (r'#{1,} .*', token_handler("heading")),
+            (r'\n', token_handler("newline")),
+            (r'..*', token_handler("any")),
+        ]
+    )
+
+
+__CHANGELOG_SCANNER = __build_scanner()
+
+
+def _tokenize(
+    markdown,
+) -> List[
+    Tuple[int, str, int, str],
+]:
+    toks, remainder = __CHANGELOG_SCANNER.scan(markdown)
+    if remainder != '':
+        raise ChangelogError(
+            "unrecognized tokens in markdown: {}".format(remainder)
+        )
+    return toks

--- a/pontos/changelog/changelog.py
+++ b/pontos/changelog/changelog.py
@@ -60,7 +60,7 @@ def update(
 
     def may_add_skeleton(
         heading_count: int, first_headline_state: int, markdown: str
-    ) -> (int, str):
+    ) -> Tuple[int, str]:
         if first_headline_state == -1 and heading_count == 1:
             return 0, markdown
         if first_headline_state == 0 and heading_count > 1:

--- a/pontos/release/__init__.py
+++ b/pontos/release/__init__.py
@@ -1,0 +1,4 @@
+from .release import GithubRelease, main
+
+
+__all__ = ['GithubRelease', 'main']

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -5,7 +5,7 @@ import os
 import json
 import shutil
 from pathlib import Path
-from typing import Callable, List
+from typing import Callable, Dict, List, Union
 
 import requests
 from pontos import version
@@ -19,7 +19,7 @@ def build_release_dict(
     target_commitish: str = '',  # needed when tag is not there yet
     draft: bool = False,
     prerelease: bool = False,
-):
+) -> Dict[str, Union[str, bool]]:
     """
     builds the dict for release post on github, see:
     https://docs.github.com/en/rest/reference/repos#create-a-release
@@ -47,13 +47,15 @@ def initialize_default_parser() -> argparse.ArgumentParser:
     parser.add_argument(
         '--release-version',
         help='Will release changelog as version. Must be PEP 440 compliant',
+        required=True,
     )
     parser.add_argument(
         '--next-release-version',
         help='Sets the next PEP 440 compliant version in project definition.',
+        required=True,
     )
     parser.add_argument(
-        '--project', help='The github project',
+        '--project', help='The github project', required=True,
     )
     parser.add_argument(
         '--space', default='greenbone', help='user/team name in github',
@@ -78,17 +80,6 @@ def initialize_default_parser() -> argparse.ArgumentParser:
 def parse(args=None):
     parser = initialize_default_parser()
     commandline_arguments = parser.parse_args(args)
-    needed_attr = [
-        'command',
-        'release_version',
-        'next_release_version',
-        'project',
-    ]
-    for attr in needed_attr:
-        if not getattr(commandline_arguments, attr, None):
-            parser.print_usage()
-            return None
-
     token = (
         os.environ['GITHUB_TOKEN']
         if not args or not 'testcases' in args

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -1,0 +1,325 @@
+import argparse
+import sys
+import subprocess
+import os
+import json
+import shutil
+from pathlib import Path
+from typing import Callable, List
+
+import requests
+from pontos import version
+from pontos import changelog
+
+
+def build_release_dict(
+    release_version: str,
+    release_changelog: str,
+    name: str = '',
+    target_commitish: str = '',  # needed when tag is not there yet
+    draft: bool = False,
+    prerelease: bool = False,
+):
+    """
+    builds the dict for release post on github, see:
+    https://docs.github.com/en/rest/reference/repos#create-a-release
+    for more details.
+    """
+    tag_name = (
+        release_version
+        if release_version.startswith('v')
+        else "v" + release_version
+    )
+    return {
+        'tag_name': tag_name,
+        'target_commitish': target_commitish,
+        'name': name,
+        'body': release_changelog,
+        'draft': draft,
+        'prerelease': prerelease,
+    }
+
+
+def initialize_default_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description='Release handling utility.', prog='pontos-release',
+    )
+    parser.add_argument(
+        '--release-version',
+        help='Will release changelog as version. Must be PEP 440 compliant',
+    )
+    parser.add_argument(
+        '--next-release-version',
+        help='Sets the next PEP 440 compliant version in project definition.',
+    )
+    parser.add_argument(
+        '--project', help='The github project',
+    )
+    parser.add_argument(
+        '--space', default='greenbone', help='user/team name in github',
+    )
+    parser.add_argument(
+        '--signing-key',
+        default='0ED1E580',
+        help='The key to sign zip, tarballs of a release',
+    )
+
+    subparsers = parser.add_subparsers(
+        title='subcommands',
+        description='valid subcommands',
+        help='additional help',
+        dest='command',
+    )
+
+    subparsers.add_parser('release')
+    return parser
+
+
+def parse(args=None):
+    parser = initialize_default_parser()
+    commandline_arguments = parser.parse_args(args)
+    needed_attr = [
+        'command',
+        'release_version',
+        'next_release_version',
+        'project',
+    ]
+    for attr in needed_attr:
+        if not getattr(commandline_arguments, attr, None):
+            parser.print_usage()
+            return None
+
+    token = (
+        os.environ['GITHUB_TOKEN']
+        if not args or not 'testcases' in args
+        else 'TOKEN'
+    )
+    user = (
+        os.environ['GITHUB_USER']
+        if not args or not 'testcases' in args
+        else 'USER'
+    )
+    return (
+        commandline_arguments.command,
+        commandline_arguments.release_version,
+        commandline_arguments.next_release_version,
+        commandline_arguments.project,
+        commandline_arguments.space,
+        commandline_arguments.signing_key,
+        user,
+        token,
+    )
+
+
+def run(
+    release_version: str,
+    nextversion: str,
+    project: str,
+    space: str,
+    signing_key: str,
+    username: str,
+    token: str,
+    git_tag_prefix: str,
+    shell_cmd_runner: Callable,
+    _path: Path,
+    _requests: requests,
+    _version: version,
+    _changelog: changelog,
+):
+    print("in release")
+    executed, filename = _version.main(
+        False, args=["--quiet", "update", nextversion]
+    )
+    if not executed:
+        if filename == "":
+            print("No project definition found.")
+        else:
+            print("Unable to update version {} in {}", nextversion, filename)
+        return False
+    print("updated version {} to {}".format(filename, nextversion))
+    change_log_path = _path.cwd() / 'CHANGELOG.md'
+    updated, changelog_text = _changelog.update(
+        change_log_path.read_text(),
+        release_version,
+        project,
+        git_tag_prefix=git_tag_prefix,
+        git_space=space,
+    )
+    change_log_path.write_text(updated)
+    print("updated CHANGELOG.md")
+    git = GithubRelease(
+        token,
+        username,
+        project,
+        signing_key,
+        space=space,
+        tag_prefix=git_tag_prefix,
+        run_cmd=shell_cmd_runner,
+        path=_path,
+        gh_requests=_requests,
+    )
+    return git.commit(filename, release_version, changelog_text)
+
+
+class GithubRelease:
+    space = None
+    project = None
+    token = None
+    user = None
+    tag_prefix = None
+    signing_key = None
+    __run = None
+    __path = None
+    __requests = None
+
+    def __init__(
+        self,
+        token: str,
+        user: str,
+        project: str,
+        signing_key: str,
+        space: str = 'greenbone',
+        tag_prefix: str = 'v',
+        run_cmd=lambda x: subprocess.run(x, shell=True, check=True),
+        path: Path = Path,
+        gh_requests: requests = requests,
+    ):
+        self.auth = (user, token)
+        self.project = project
+        self.space = space
+        self.tag_prefix = tag_prefix
+        self.signing_key = signing_key
+        self.__run = run_cmd
+        self.__path = path
+        self.__requests = gh_requests
+
+    def commit(
+        self, project_filename: str, release_version: str, changelog_text: str,
+    ) -> bool:
+        """
+        commit adds:
+        - filename
+        - CHANGELOG.md
+        commits those changes, creates a tag based on:
+        - release_version
+        - tag_prefix
+        pushes those changes into remote repository and creates a release.
+        """
+        print("Commiting changes")
+        self.__run("git add {}".format(project_filename))
+        self.__run("git add CHANGELOG.md")
+        commit_msg = 'automatic release to {}'.format(release_version)
+        self.__run("git commit -S -m '{}'".format(commit_msg),)
+        git_version = "{}{}".format(self.tag_prefix, release_version)
+        self.__run("git tag -s {} -m '{}'".format(git_version, commit_msg),)
+        print("Pushing changes")
+        self.__run("git push --follow-tags")
+        return self.create_release(git_version, changelog_text)
+
+    def create_release(self, git_version: str, changelog_text: str) -> bool:
+        def download(url, filename):
+            file_path = self.__path("/tmp/{}".format(filename))
+            with self.__requests.get(url, stream=True) as resp:
+                with file_path.open(mode='wb') as download_file:
+                    shutil.copyfileobj(resp.raw, download_file)
+            return file_path
+
+        print("Creating release")
+        release_info = build_release_dict(git_version, changelog_text)
+        headers = {'Accept': 'application/vnd.github.v3+json'}
+        base_url = "https://api.github.com/repos/{}/{}/releases".format(
+            self.space, self.project
+        )
+        response = self.__requests.post(
+            base_url, headers=headers, auth=self.auth, json=release_info
+        )
+        if response.status_code != 201:
+            print("Wrong reponse status code: {}".format(response.status_code))
+            print(json.dumps(response.text, indent=4, sort_keys=True))
+            return False
+        github_json = json.loads(response.text)
+        zip_path = download(github_json['zipball_url'], git_version + ".zip")
+        tar_path = download(github_json['tarball_url'], git_version + ".tar.gz")
+        print("Signing {}".format([zip_path, tar_path]))
+        gpg_cmd = "gpg --default-key {} --detach-sign --armor {}"
+        self.__run(gpg_cmd.format(self.signing_key, zip_path))
+        self.__run(gpg_cmd.format(self.signing_key, tar_path))
+        return self.upload_assets([zip_path, tar_path], github_json)
+
+    def upload_assets(self, pathnames: List[str], github_json: str) -> bool:
+        print("Uploading assets: {}".format(pathnames))
+        asset_url = github_json['upload_url'].replace('{?name,label}', '')
+        paths = [self.__path('{}.asc'.format(p)) for p in pathnames]
+        upload_headers = {
+            'Accept': 'application/vnd.github.v3+json',
+            'content-type': 'application/octet-stream',
+        }
+        for path in paths:
+            to_upload = path.read_bytes()
+            resp = self.__requests.post(
+                "{}?name={}".format(asset_url, path.name),
+                headers=upload_headers,
+                auth=self.auth,
+                data=to_upload,
+            )
+            if resp.status_code != 201:
+                print(
+                    "Wrong reponse status {} while uploading {}".format(
+                        resp.status_code, path.name
+                    )
+                )
+                print(json.dumps(resp.text, indent=4, sort_keys=True))
+                return False
+            else:
+                print("uploaded: {}".format(path.name))
+        return True
+
+
+def main(
+    git_tag_prefix: str = "v",
+    shell_cmd_runner=lambda x: subprocess.run(x, shell=True, check=True),
+    _path: Path = Path,
+    _requests: requests = requests,
+    _version: version = version,
+    _changelog: changelog = changelog,
+    leave: bool = True,
+    args=None,
+):
+    def execute(
+        command: str,
+        release_version: str,
+        next_release_version: str,
+        project: str,
+        space: str,
+        signing_key: str,
+        user: str,
+        token: str,
+    ):
+        if command == 'release':
+            return run(
+                release_version,
+                next_release_version,
+                project,
+                space,
+                signing_key,
+                user,
+                token,
+                git_tag_prefix,
+                shell_cmd_runner,
+                _path,
+                _requests,
+                _version,
+                _changelog,
+            )
+        raise ValueError("Unknown command: {}".format(command))
+
+    values = parse(args)
+    if not values:
+        return sys.exit(1) if leave else False
+    if not execute(*values):
+        return sys.exit(1) if leave else False
+    return execute(*values)
+
+
+if __name__ == '__main__':
+    main()

--- a/pontos/version/__init__.py
+++ b/pontos/version/__init__.py
@@ -26,6 +26,8 @@ from .version import (
     get_version_from_pyproject_toml,
 )
 
+from .cmake_version import CMakeVersionParser, CMakeVersionCommand
+
 __all__ = [
     '__version__',
     'VersionCommand',
@@ -34,4 +36,5 @@ __all__ = [
     'strip_version',
     'is_version_pep440_compliant',
     'get_version_from_pyproject_toml',
+    'CMakeVersionCommand',
 ]

--- a/pontos/version/__init__.py
+++ b/pontos/version/__init__.py
@@ -57,4 +57,5 @@ __all__ = [
     'is_version_pep440_compliant',
     'get_version_from_pyproject_toml',
     'CMakeVersionCommand',
+    'PontosVersionCommand',
 ]

--- a/pontos/version/__init__.py
+++ b/pontos/version/__init__.py
@@ -14,10 +14,12 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
+import sys
+from pathlib import Path
 from .__version__ import __version__
 
 from .version import (
+    PontosVersionCommand,
     VersionCommand,
     VersionError,
     safe_version,
@@ -27,6 +29,24 @@ from .version import (
 )
 
 from .cmake_version import CMakeVersionParser, CMakeVersionCommand
+
+
+def main(leave=True, args=None):
+    available_cmds = [
+        ('CMakeLists.txt', CMakeVersionCommand),
+        ('pyproject.toml', PontosVersionCommand),
+    ]
+    for file_name, cmd in available_cmds:
+        project_definition_path = Path.cwd() / file_name
+        if project_definition_path.exists():
+            result = cmd().run(args)
+            if leave:
+                sys.exit(result)
+            return result == 0, file_name
+    if leave:
+        sys.exit("No command found")
+    return False, ""
+
 
 __all__ = [
     '__version__',

--- a/pontos/version/__main__.py
+++ b/pontos/version/__main__.py
@@ -19,12 +19,21 @@
 
 import sys
 
+from pathlib import Path
 from .version import PontosVersionCommand
+from .cmake_version import CMakeVersionCommand
 
 
 def main():
-    cmd = PontosVersionCommand()
-    sys.exit(cmd.run())
+    available_cmds = [
+        ('CMakeLists.txt', CMakeVersionCommand),
+        ('pyproject.toml', PontosVersionCommand),
+    ]
+    for fileName, cmd in available_cmds:
+        project_definition_path = Path.cwd() / fileName
+        if project_definition_path.exists():
+            sys.exit(cmd().run())
+    sys.exit("No command found")
 
 
 if __name__ == '__main__':

--- a/pontos/version/cmake_version.py
+++ b/pontos/version/cmake_version.py
@@ -1,0 +1,145 @@
+# Copyright (C) 2020 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import re
+from typing import Tuple, Generator, Union
+from pathlib import Path
+from .version import (
+    is_version_pep440_compliant,
+    VersionError,
+    initialize_default_parser,
+)
+
+
+class CMakeVersionCommand:
+    __cmake_filepath = None
+
+    def __init__(self, *, cmake_lists_path: Path = None):
+        if not cmake_lists_path:
+            cmake_lists_path = Path.cwd() / 'CMakeLists.txt'
+        if not cmake_lists_path.exists():
+            raise VersionError(
+                '{} file not found.'.format(str(cmake_lists_path))
+            )
+
+        self.__cmake_filepath = cmake_lists_path
+        self.parser = initialize_default_parser()
+
+    def run(self, args=None) -> Union[int, str]:
+        args = self.parser.parse_args(args)
+
+        if not getattr(args, 'command', None):
+            self.parser.print_usage()
+            return 0
+
+        try:
+            if args.command == 'update':
+                self.update_version(args.version,)
+            elif args.command == 'show':
+                self.print_current_version()
+            elif args.command == 'verify':
+                self.verify_version(args.version)
+        except VersionError as e:
+            return str(e)
+        return 0
+
+    def update_version(self, version: str):
+        content = self.__cmake_filepath.read_text()
+        cmvp = CMakeVersionParser(content)
+        previous_version = cmvp.get_current_version()
+        new_content = cmvp.update_version(version)
+        self.__cmake_filepath.write_text(new_content)
+        print('Updated version from {} to {}'.format(previous_version, version))
+
+    def print_current_version(self):
+        content = self.__cmake_filepath.read_text()
+        cmvp = CMakeVersionParser(content)
+        print(cmvp.get_current_version())
+
+    def verify_version(self, version: str):
+        if not is_version_pep440_compliant(version):
+            raise VersionError(
+                "Version {} is not PEP 440 compliant.".format(version)
+            )
+        print('OK')
+
+
+class CMakeVersionParser:
+    def __init__(self, cmake_content_lines: str):
+        line_no, current_version = self._find_version_in_cmake(
+            cmake_content_lines
+        )
+        self._cmake_content_lines = cmake_content_lines.split('\n')
+        self._version_line_number = line_no
+        self._current_version = current_version
+
+    __cmake_scanner = re.Scanner(
+        [
+            (r'#.*', lambda _, token: ("comment", token)),
+            (r'"[^"]*"', lambda _, token: ("string", token)),
+            (r"\(", lambda _, token: ("open_bracket", token)),
+            (r"\)", lambda _, token: ("close_bracket", token)),
+            (r'[^ \t\r\n()#"]+', lambda _, token: ("word", token)),
+            (r'\n', lambda _, token: ("newline", token)),
+            # to have spaces etc correctly
+            (r"\s+", lambda _, token: ("special_printable", token)),
+        ]
+    )
+
+    def get_current_version(self) -> str:
+        return self._current_version
+
+    def update_version(self, new_version: str) -> str:
+        if not is_version_pep440_compliant(new_version):
+            raise VersionError(
+                "version {} is not pep 440 compliant.".format(new_version)
+            )
+        to_update = self._cmake_content_lines[self._version_line_number]
+        updated = to_update.replace(self._current_version, new_version)
+        self._cmake_content_lines[self._version_line_number] = updated
+        self._current_version = new_version
+        return '\n'.join(self._cmake_content_lines)
+
+    def _find_version_in_cmake(self, content: str) -> Tuple[int, str]:
+        in_project = False
+        in_version = False
+        for lineno, token_type, value in self._tokenize(content):
+            if token_type == 'word' and value == 'project':
+                in_project = True
+            elif in_project and token_type == 'word' and value == 'VERSION':
+                in_version = True
+            elif in_version and (
+                token_type == 'word' or token_type == 'string'
+            ):
+                return lineno, value
+            elif in_project and token_type == 'close_bracket':
+                raise ValueError('unable to find cmake version in project.')
+        raise ValueError('unable to find cmake project.')
+
+    def _tokenize(
+        self, content: str
+    ) -> Generator[
+        Tuple[int, str, str], Tuple[int, str, str], Tuple[int, str, str],
+    ]:
+        toks, remainder = self.__cmake_scanner.scan(content)
+        if remainder != '':
+            print('WARNING: unrecognized cmake tokens: {}'.format(remainder))
+        line_num = 0
+        for tok_type, tok_contents in toks:
+            line_num += tok_contents.count('\n')
+            yield line_num, tok_type, tok_contents.strip()

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -113,6 +113,9 @@ def initialize_default_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
         description='Version handling utilities.', prog='version',
     )
+    parser.add_argument(
+        '--quiet', help='don\'t print messages', action="store_true"
+    )
 
     subparsers = parser.add_subparsers(
         title='subcommands',
@@ -123,7 +126,6 @@ def initialize_default_parser() -> argparse.ArgumentParser:
 
     verify_parser = subparsers.add_parser('verify')
     verify_parser.add_argument('version', help='version string to compare')
-
     subparsers.add_parser('show')
 
     update_parser = subparsers.add_parser('update')
@@ -143,6 +145,8 @@ class VersionCommand:
 
 __version__ = "{}"\n"""
 
+    __quiet = False
+
     def __init__(
         self,
         *,
@@ -159,7 +163,8 @@ __version__ = "{}"\n"""
         self.parser = initialize_default_parser()
 
     def _print(self, *args) -> None:
-        print(*args)
+        if not self.__quiet:
+            print(*args)
 
     def get_current_version(self) -> str:
         version_module_name = self.version_file_path.stem
@@ -270,12 +275,14 @@ __version__ = "{}"\n"""
     def print_current_version(self) -> None:
         self._print(self.get_current_version())
 
-    def run(self) -> Union[int, str]:
-        args = self.parser.parse_args()
+    def run(self, args=None) -> Union[int, str]:
+        args = self.parser.parse_args(args)
 
         if not getattr(args, 'command', None):
             self.parser.print_usage()
             return 0
+
+        self.__quiet = args.quiet
 
         try:
             if args.command == 'update':

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -103,6 +103,39 @@ def is_version_pep440_compliant(version: str) -> bool:
     return version == safe_version(version)
 
 
+def initialize_default_parser() -> argparse.ArgumentParser:
+    """
+    Returns a default argument parser containing:
+    - verify
+    - show
+    - update
+    """
+    parser = argparse.ArgumentParser(
+        description='Version handling utilities.', prog='version',
+    )
+
+    subparsers = parser.add_subparsers(
+        title='subcommands',
+        description='valid subcommands',
+        help='additional help',
+        dest='command',
+    )
+
+    verify_parser = subparsers.add_parser('verify')
+    verify_parser.add_argument('version', help='version string to compare')
+
+    subparsers.add_parser('show')
+
+    update_parser = subparsers.add_parser('update')
+    update_parser.add_argument('version', help='version string to use')
+    update_parser.add_argument(
+        '--force',
+        help="don't check if version is already set",
+        action="store_true",
+    )
+    return parser
+
+
 class VersionCommand:
     TEMPLATE = """# pylint: disable=invalid-name
 
@@ -123,29 +156,7 @@ __version__ = "{}"\n"""
         self._configure_parser()
 
     def _configure_parser(self):
-        self.parser = argparse.ArgumentParser(
-            description='Version handling utilities.', prog='version',
-        )
-
-        subparsers = self.parser.add_subparsers(
-            title='subcommands',
-            description='valid subcommands',
-            help='additional help',
-            dest='command',
-        )
-
-        verify_parser = subparsers.add_parser('verify')
-        verify_parser.add_argument('version', help='version string to compare')
-
-        subparsers.add_parser('show')
-
-        update_parser = subparsers.add_parser('update')
-        update_parser.add_argument('version', help='version string to use')
-        update_parser.add_argument(
-            '--force',
-            help="don't check if version is already set",
-            action="store_true",
-        )
+        self.parser = initialize_default_parser()
 
     def _print(self, *args) -> None:
         print(*args)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ packages = [
 python = "^3.5"
 tomlkit = "^0.5.11"
 packaging = "^20.3"
+GitPython = "^3.1.7"
+requests = "^2.24.0"
 
 [tool.poetry.dev-dependencies]
 pylint = "^2.4.4"
@@ -67,7 +69,8 @@ mode = "poetry"
 version-module-file = "pontos/version/__version__.py"
 
 [tool.poetry.scripts]
-version = 'pontos.version.__main__:main'
+pontos-version = 'pontos.version:main'
+pontos-release = 'pontos.release.release:main'
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,8 @@ mode = "poetry"
 [tool.pontos.version]
 version-module-file = "pontos/version/__version__.py"
 
+[tool.poetry.scripts]
+version = 'pontos.version.__main__:main'
 [build-system]
 requires = ["poetry>=0.12"]
 build-backend = "poetry.masonry.api"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,7 +31,6 @@ packages = [
 python = "^3.5"
 tomlkit = "^0.5.11"
 packaging = "^20.3"
-GitPython = "^3.1.7"
 requests = "^2.24.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.5"
+python = "^3.7"
 tomlkit = "^0.5.11"
 packaging = "^20.3"
 requests = "^2.24.0"

--- a/tests/changelog/__init__.py
+++ b/tests/changelog/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Greenbone Networks GmbH
+# Copyright (C) 2020 Pontos Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -15,9 +15,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=invalid-name
+import os
 
-from pontos import version
+from contextlib import contextmanager
+from pathlib import Path
 
-if __name__ == '__main__':
-    version.main()
+
+@contextmanager
+def use_cwd(path: Path) -> None:
+    """
+    Context Manager to change the current working directory temporaryly
+    """
+    current_cwd = Path.cwd()
+
+    os.chdir(str(path))
+
+    yield
+
+    os.chdir(str(current_cwd))

--- a/tests/changelog/test_changelog_changelog.py
+++ b/tests/changelog/test_changelog_changelog.py
@@ -1,0 +1,96 @@
+import unittest
+from pontos import changelog
+
+
+class ChangelogTestCase(unittest.TestCase):
+    def test_return_none_when_no_unreleased_information_found(self):
+        test_md = """
+# Changelog
+something, somehing
+- unreleased
+- not unreleased
+## 1.0.0
+### added
+- cool stuff 1
+- cool stuff 2
+"""
+        _, cl = changelog.update(test_md, '', '')
+        self.assertEqual(cl, '')
+
+    def test_find_unreleased_information_before_another_version(self):
+        unreleased = """
+## Unreleased
+### fixed
+so much
+### added
+so little
+### changed
+I don't recognize it anymore
+### security
+[Unreleased]: https://github.com/greenbone/pontos/compare/v1.0.0...master 
+"""
+        test_md = """
+# Changelog
+something, somehing
+- unreleased
+- not unreleased
+{}
+## 1.0.0
+### added
+- cool stuff 1
+- cool stuff 2
+        """.format(
+            unreleased
+        )
+        _, result = changelog.update(test_md, '', '')
+        self.assertEqual(result.strip(), unreleased.strip())
+
+
+def test_find_unreleased_information_no_other_version(self):
+    unreleased = """
+## Unreleased
+### fixed
+so much
+### added
+so little
+### changed
+I don't recognize it anymore
+### security
+[Unreleased]: https://github.com/greenbone/pontos/compare/v1.0.0...master 
+"""
+    test_md = """
+{}
+        """.format(
+        unreleased
+    )
+    _, result = changelog.update(test_md, '', '')
+    self.assertEqual(result.strip(), unreleased.strip())
+
+
+def test_find_unreleased_information_before_after_another_version(self):
+    unreleased = """
+## Unreleased
+### fixed
+so much
+### added
+so little
+### changed
+I don't recognize it anymore
+### security
+[Unreleased]: https://github.com/greenbone/pontos/compare/v1.0.0...master 
+"""
+    test_md = """
+# Changelog
+something, somehing
+- unreleased
+- not unreleased
+## 1.0.0
+### added
+- cool stuff 1
+- cool stuff 2
+{}
+        """.format(
+        unreleased
+    )
+    _, result = changelog.update(test_md, '', '')
+    self.assertEqual(result.strip(), unreleased.strip())

--- a/tests/changelog/test_changelog_update.py
+++ b/tests/changelog/test_changelog_update.py
@@ -1,0 +1,72 @@
+import unittest
+from datetime import date
+from pontos import changelog
+
+
+class ChangelogUpdateTestCase(unittest.TestCase):
+    def test_markdown_empty_updated_and_changelog_on_no_unreleased(self):
+        test_md = """
+# Changelog
+something, somehing
+- unreleased
+- not unreleased
+## 1.0.0
+### added
+- cool stuff 1
+- cool stuff 2
+"""
+        updated, release_notes = changelog.update(test_md, '1.2.3', 'hidden')
+        self.assertIs('', updated)
+        self.assertIs('', release_notes)
+
+    def test_update_markdown_return_changelog(self):
+        keep_a_changelog_skeleton = """
+## [Unreleased]
+### Added
+### Changed
+### Deprecated
+### Removed
+### Fixed
+
+[Unreleased]: https://github.com/greenbone/hidden/compare/v1.2.3...HEAD
+
+"""
+        released = """
+## [1.2.3] - {}
+### fixed
+so much
+### added
+so little
+### changed
+I don't recognize it anymore
+### security
+[1.2.3]: https://github.com/greenbone/pontos/compare/v1.0.0...v1.2.3""".format(
+            date.today().isoformat()
+        )
+
+        unreleased = """
+## [Unreleased]
+### fixed
+so much
+### added
+so little
+### changed
+I don't recognize it anymore
+### security
+[Unreleased]: https://github.com/greenbone/pontos/compare/v1.0.0...master"""
+        test_md_template = """# Changelog
+something, somehing
+- unreleased
+- not unreleased
+{}
+## 1.0.0
+### added
+- cool stuff 1
+- cool stuff 2"""
+        test_md = test_md_template.format(unreleased)
+        released_md = test_md_template.format(
+            keep_a_changelog_skeleton + released
+        )
+        updated, release_notes = changelog.update(test_md, '1.2.3', 'hidden')
+        self.assertEqual(released_md.strip(), updated.strip())
+        self.assertEqual(released.strip(), release_notes.strip())

--- a/tests/release/__init__.py
+++ b/tests/release/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Greenbone Networks GmbH
+# Copyright (C) 2020 Pontos Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -15,9 +15,21 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=invalid-name
+import os
 
-from pontos import version
+from contextlib import contextmanager
+from pathlib import Path
 
-if __name__ == '__main__':
-    version.main()
+
+@contextmanager
+def use_cwd(path: Path) -> None:
+    """
+    Context Manager to change the current working directory temporaryly
+    """
+    current_cwd = Path.cwd()
+
+    os.chdir(str(path))
+
+    yield
+
+    os.chdir(str(current_cwd))

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -81,31 +81,6 @@ class ReleaseTestCase(unittest.TestCase):
         )
         self.assertFalse(released)
 
-    def test_not_release_on_missing_version(self):
-        fake_path_class = MagicMock(spec=Path)
-        fake_requests = MagicMock(spec=requests)
-        fake_version = MagicMock(spec=version)
-        fake_changelog = MagicMock(spec=changelog)
-        incoming = []
-        args = [
-            '--next-release-version',
-            '0.0.2dev',
-            '--project',
-            'testcases',
-            'release',
-        ]
-        runner = lambda x: incoming.append(x)
-        released = release.main(
-            shell_cmd_runner=runner,
-            _path=fake_path_class,
-            _requests=fake_requests,
-            _version=fake_version,
-            _changelog=fake_changelog,
-            leave=False,
-            args=args,
-        )
-        self.assertFalse(released)
-
     def test_not_release_when_no_project_found(self):
         fake_path_class = MagicMock(spec=Path)
         fake_requests = MagicMock(spec=requests)

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -1,0 +1,165 @@
+# pylint: disable=C0413,W0108
+
+import unittest
+from unittest.mock import MagicMock
+from pathlib import Path
+import sys
+import requests
+
+sys.modules['shutil'] = MagicMock()
+from pontos import version, release, changelog
+
+
+class ReleaseTestCase(unittest.TestCase):
+    valid_gh_release_response = (
+        '{"zipball_url": "zip", "tarball_url": "tar", "upload_url":"upload"}'
+    )
+
+    def test_release_successfully(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_requests = MagicMock(spec=requests)
+        fake_post = MagicMock(spec=requests.Response).return_value
+        fake_post.status_code = 201
+        fake_post.text = self.valid_gh_release_response
+        fake_requests.post.return_value = fake_post
+        fake_version = MagicMock(spec=version)
+        fake_version.main.return_value = (True, 'MyProject.conf')
+        fake_changelog = MagicMock(spec=changelog)
+        fake_changelog.update.return_value = ('updated', 'changelog')
+        incoming = []
+        args = [
+            '--release-version',
+            '0.0.1',
+            '--next-release-version',
+            '0.0.2dev',
+            '--project',
+            'testcases',
+            'release',
+        ]
+        runner = lambda x: incoming.append(x)
+        released = release.main(
+            shell_cmd_runner=runner,
+            _path=fake_path_class,
+            _requests=fake_requests,
+            _version=fake_version,
+            _changelog=fake_changelog,
+            leave=False,
+            args=args,
+        )
+        self.assertTrue(released)
+
+    def test_not_release_successfully_when_github_create_release_fails(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_requests = MagicMock(spec=requests)
+        fake_post = MagicMock(spec=requests.Response).return_value
+        fake_post.status_code = 401
+        fake_post.text = self.valid_gh_release_response
+        fake_requests.post.return_value = fake_post
+        fake_version = MagicMock(spec=version)
+        fake_version.main.return_value = (True, 'MyProject.conf')
+        fake_changelog = MagicMock(spec=changelog)
+        fake_changelog.update.return_value = ('updated', 'changelog')
+        incoming = []
+        args = [
+            '--release-version',
+            '0.0.1',
+            '--next-release-version',
+            '0.0.2dev',
+            '--project',
+            'testcases',
+            'release',
+        ]
+        runner = lambda x: incoming.append(x)
+        released = release.main(
+            shell_cmd_runner=runner,
+            _path=fake_path_class,
+            _requests=fake_requests,
+            _version=fake_version,
+            _changelog=fake_changelog,
+            leave=False,
+            args=args,
+        )
+        self.assertFalse(released)
+
+    def test_not_release_on_missing_version(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_requests = MagicMock(spec=requests)
+        fake_version = MagicMock(spec=version)
+        fake_changelog = MagicMock(spec=changelog)
+        incoming = []
+        args = [
+            '--next-release-version',
+            '0.0.2dev',
+            '--project',
+            'testcases',
+            'release',
+        ]
+        runner = lambda x: incoming.append(x)
+        released = release.main(
+            shell_cmd_runner=runner,
+            _path=fake_path_class,
+            _requests=fake_requests,
+            _version=fake_version,
+            _changelog=fake_changelog,
+            leave=False,
+            args=args,
+        )
+        self.assertFalse(released)
+
+    def test_not_release_when_no_project_found(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_requests = MagicMock(spec=requests)
+        fake_version = MagicMock(spec=version)
+        fake_version.main.return_value = (False, '')
+        fake_changelog = MagicMock(spec=changelog)
+        fake_changelog.update.return_value = ('updated', 'changelog')
+        incoming = []
+        args = [
+            '--release-version',
+            '0.0.1',
+            '--next-release-version',
+            '0.0.2dev',
+            '--project',
+            'testcases',
+            'release',
+        ]
+        runner = lambda x: incoming.append(x)
+        released = release.main(
+            shell_cmd_runner=runner,
+            _path=fake_path_class,
+            _requests=fake_requests,
+            _version=fake_version,
+            _changelog=fake_changelog,
+            leave=False,
+            args=args,
+        )
+        self.assertFalse(released)
+
+    def test_not_release_when_updating_version_fails(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_requests = MagicMock(spec=requests)
+        fake_version = MagicMock(spec=version)
+        fake_version.main.return_value = (False, 'MyProject.conf')
+        fake_changelog = MagicMock(spec=changelog)
+        fake_changelog.update.return_value = ('updated', 'changelog')
+        incoming = []
+        args = [
+            '--release-version',
+            '0.0.1',
+            '--next-release-version',
+            '0.0.2dev',
+            '--project',
+            'testcases',
+            'release',
+        ]
+        runner = lambda x: incoming.append(x)
+        released = release.main(
+            shell_cmd_runner=runner,
+            _path=fake_path_class,
+            _requests=fake_requests,
+            _version=fake_version,
+            _changelog=fake_changelog,
+            leave=False,
+            args=args,
+        )
+        self.assertFalse(released)

--- a/tests/version/test_cmake_version.py
+++ b/tests/version/test_cmake_version.py
@@ -1,0 +1,117 @@
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock
+from pontos.version import CMakeVersionParser, VersionError, CMakeVersionCommand
+
+
+class CMakeVersionCommandTestCase(unittest.TestCase):
+    def test_raise_exception_file_not_exists(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = False
+        with self.assertRaises(VersionError):
+            CMakeVersionCommand(cmake_lists_path=fake_path)
+
+    def test_raise_exception_no_project(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = True
+        fake_path.read_text.return_value = ""
+        with self.assertRaises(ValueError):
+            CMakeVersionCommand(cmake_lists_path=fake_path).run(args=['show'])
+        fake_path.read_text.assert_called_with()
+
+    def test_return_error_string_incorrect_version_on_verify(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = True
+        fake_path.read_text.return_value = ""
+        result = CMakeVersionCommand(cmake_lists_path=fake_path).run(
+            args=['verify', 'su_much_version_so_much_wow']
+        )
+        self.assertTrue(
+            isinstance(result, str), "expected result to be an error string"
+        )
+
+    def test_return_0_correct_version_on_verify(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = True
+        fake_path.read_text.return_value = ""
+        result = CMakeVersionCommand(cmake_lists_path=fake_path).run(
+            args=['verify', '21.4']
+        )
+        self.assertEqual(0, result)
+
+    def test_should_call_print_current_version_without_raising_exception(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = True
+        fake_path.read_text.return_value = "project(VERSION 21)"
+        CMakeVersionCommand(cmake_lists_path=fake_path).run(args=['show'])
+        fake_path.read_text.assert_called_with()
+
+    def test_raise_update_version(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_path = fake_path_class.return_value
+        fake_path.__str__.return_value = 'CMakeLists.txt'
+        fake_path.exists.return_value = True
+        fake_path.read_text.return_value = "project(VERSION 21)"
+        CMakeVersionCommand(cmake_lists_path=fake_path).run(
+            args=['update', '22']
+        )
+        fake_path.read_text.assert_called_with()
+        fake_path.write_text.assert_called_with('project(VERSION 22)')
+
+
+class CMakeVersionParserTestCase(unittest.TestCase):
+    def test_get_current_version_single_line_project(self):
+        under_test = CMakeVersionParser("project(VERSION 2.3.4)")
+        self.assertEqual(under_test.get_current_version(), '2.3.4')
+
+    def test_update_version_project(self):
+        under_test = CMakeVersionParser("project(VERSION 2.3.4)")
+        self.assertEqual(
+            under_test.update_version('2.3.5'), "project(VERSION 2.3.5)"
+        )
+
+    def test_update_raise_exception_when_version_is_incorrect(self):
+        under_test = CMakeVersionParser("project(VERSION 2.3.4)")
+        with self.assertRaises(VersionError):
+            under_test.update_version('su_much_version_so_much_wow')
+
+    def test_not_confuse_version_outside_project(self):
+        under_test = CMakeVersionParser(
+            "non_project(VERSION 2.3.5)\nproject(VERSION 2.3.4)"
+        )
+        self.assertEqual(under_test.get_current_version(), '2.3.4')
+
+    def test_get_current_version_multiline_project(self):
+        under_test = CMakeVersionParser("project\n(\nVERSION\n\t    2.3.4)")
+        self.assertEqual(under_test.get_current_version(), '2.3.4')
+
+    def test_get_current_version_multiline_project_combined_token(self):
+        under_test = CMakeVersionParser(
+            "project\n(\nDESCRIPTION something VERSION 2.3.4 LANGUAGES c\n)"
+        )
+        self.assertEqual(under_test.get_current_version(), '2.3.4')
+
+    def test_raise_exception_project_no_version(self):
+        with self.assertRaises(ValueError) as context:
+            CMakeVersionParser("project(DESCRIPTION something LANGUAGES c)")
+        self.assertEqual(
+            str(context.exception), 'unable to find cmake version in project.'
+        )
+
+    def test_raise_exception_no_project(self):
+        with self.assertRaises(ValueError) as context:
+            CMakeVersionParser("non_project(VERSION 2.3.5)",)
+
+        self.assertEqual(
+            str(context.exception), 'unable to find cmake project.'
+        )


### PR DESCRIPTION
Add cmake version to be capable of using pontos in cmake projects this creates a simple
cmake parser to get and update the version within CMakeLists.txt.

This parser is then used within a cmake version command.

This main script verifies if there is a CMakeLists.txt or a
pyproject.toml and decides based on that if it runs PoetryCommand or
CMakeCommand.

Add Changelog module to retrieve the changelog for the release and
update unreleased to version.

Add release command, this command will use:
- pontos.version
- pontos.changelog

to:
1. update the version in the project definition to next-version
2. change Unreleased of CHANGELOG.md to given version
3. commit those files
4. push the changes
5. create a tag
6. create a release
7. sign source code tar- and zipball
8. upload signatures as assets

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
