### PR TITLE
add __version__.py if existing

### DIFF
--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -198,6 +198,7 @@ class GithubRelease:
         """
         print("Commiting changes")
         self.__run("git add {}".format(project_filename))
+        self.__run("git add *__version__.py || echo 'ignoring __version__'")
         self.__run("git add CHANGELOG.md")
         commit_msg = 'automatic release to {}'.format(release_version)
         self.__run("git commit -S -m '{}'".format(commit_msg),)


### PR DESCRIPTION
PoetryVersion sets a dynamic __version__.py which is not guessable by
the cmd runner upfront. Hence release adds a __version__.py if it is
existing. Otherwise it prints the message 'ignoring __version__'.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
