### PR TITLE
seperate prepare and relase command

### DIFF
--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -272,6 +272,7 @@ class GithubRelease:
             print("Wrong reponse status code: {}".format(response.status_code))
             print(json.dumps(response.text, indent=4, sort_keys=True))
             return False
+        self.__path(".release.txt.md").unlink()
         github_json = json.loads(response.text)
         zip_path = download(github_json['zipball_url'], git_version + ".zip")
         tar_path = download(github_json['tarball_url'], git_version + ".tar.gz")

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -15,7 +15,7 @@ class ReleaseTestCase(unittest.TestCase):
         '{"zipball_url": "zip", "tarball_url": "tar", "upload_url":"upload"}'
     )
 
-    def test_release_successfully(self):
+    def test_prepare_successfully(self):
         fake_path_class = MagicMock(spec=Path)
         fake_requests = MagicMock(spec=requests)
         fake_post = MagicMock(spec=requests.Response).return_value
@@ -35,6 +35,39 @@ class ReleaseTestCase(unittest.TestCase):
             '--project',
             'testcases',
             'prepare',
+        ]
+        runner = lambda x: incoming.append(x)
+        released = release.main(
+            shell_cmd_runner=runner,
+            _path=fake_path_class,
+            _requests=fake_requests,
+            _version=fake_version,
+            _changelog=fake_changelog,
+            leave=False,
+            args=args,
+        )
+        self.assertTrue(released)
+
+    def test_release_successfully(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_requests = MagicMock(spec=requests)
+        fake_post = MagicMock(spec=requests.Response).return_value
+        fake_post.status_code = 201
+        fake_post.text = self.valid_gh_release_response
+        fake_requests.post.return_value = fake_post
+        fake_version = MagicMock(spec=version)
+        fake_version.main.return_value = (True, 'MyProject.conf')
+        fake_changelog = MagicMock(spec=changelog)
+        fake_changelog.update.return_value = ('updated', 'changelog')
+        incoming = []
+        args = [
+            '--release-version',
+            '0.0.1',
+            '--next-release-version',
+            '0.0.2dev',
+            '--project',
+            'testcases',
+            'release',
         ]
         runner = lambda x: incoming.append(x)
         released = release.main(

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -34,7 +34,7 @@ class ReleaseTestCase(unittest.TestCase):
             '0.0.2dev',
             '--project',
             'testcases',
-            'release',
+            'prepare',
         ]
         runner = lambda x: incoming.append(x)
         released = release.main(
@@ -96,7 +96,7 @@ class ReleaseTestCase(unittest.TestCase):
             '0.0.2dev',
             '--project',
             'testcases',
-            'release',
+            'prepare',
         ]
         runner = lambda x: incoming.append(x)
         released = release.main(
@@ -125,7 +125,7 @@ class ReleaseTestCase(unittest.TestCase):
             '0.0.2dev',
             '--project',
             'testcases',
-            'release',
+            'prepare',
         ]
         runner = lambda x: incoming.append(x)
         released = release.main(


### PR DESCRIPTION
to be capable of reviewing the changes upfront the release and prepare
command are seperated in
- prepare (does create tag, commit and markdown changes)
- release (does push and create the actual release)

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
