### PR TITLE
Don't mock shutils via sys.modules

### DIFF
--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -1,13 +1,14 @@
 # pylint: disable=C0413,W0108
 
+import shutil
 import unittest
-from unittest.mock import MagicMock
-from pathlib import Path
-import sys
+
 from dataclasses import dataclass
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
 import requests
 
-sys.modules['shutil'] = MagicMock()
 from pontos import version, release, changelog
 
 
@@ -16,6 +17,10 @@ class StdOutput:
     stdout: bytes
 
 
+_shutil_mock = MagicMock(spec=shutil)
+
+
+@patch("pontos.release.release.shutil", new=_shutil_mock)
 class ReleaseTestCase(unittest.TestCase):
 
     valid_gh_release_response = (


### PR DESCRIPTION
Manipulating sys.modules may have serious side effects. Use the patch
decorator instead.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
