### PR TITLE
Allow to defined a git remote to push commits and tags

### DIFF
--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -69,6 +69,10 @@ def initialize_default_parser() -> argparse.ArgumentParser:
         '--git-signing-key',
         help='The key to sign the commits and tag for a release',
     )
+    parser.add_argument(
+        '--git-remote-name',
+        help='The git remote name to push the commits and tag to',
+    )
 
     subparsers = parser.add_subparsers(
         title='subcommands',
@@ -103,6 +107,7 @@ def parse(args=None):
         commandline_arguments.space,
         commandline_arguments.signing_key,
         commandline_arguments.git_signing_key,
+        commandline_arguments.git_remote_name,
         user,
         token,
     )
@@ -215,6 +220,7 @@ def release(
     username: str,
     token: str,
     git_tag_prefix: str,
+    git_remote_name: str,
     shell_cmd_runner: Callable,
     _path: Path,
     _requests: requests,
@@ -264,7 +270,12 @@ def release(
     changelog_text = _path(".release.txt.md").read_text()
 
     print("Pushing changes")
-    shell_cmd_runner("git push --follow-tags")
+
+    if git_remote_name:
+        shell_cmd_runner("git push --follow-tags {}".format(git_remote_name))
+    else:
+        shell_cmd_runner("git push --follow-tags")
+
     print("Creating release")
     release_info = build_release_dict(git_version, changelog_text)
     headers = {'Accept': 'application/vnd.github.v3+json'}
@@ -309,6 +320,7 @@ def main(
         space: str,
         signing_key: str,
         git_signing_key: str,
+        git_remote_name: str,
         user: str,
         token: str,
     ):
@@ -337,6 +349,7 @@ def main(
                 user,
                 token,
                 git_tag_prefix,
+                git_remote_name,
                 shell_cmd_runner,
                 _path,
                 _requests,

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -204,3 +204,37 @@ class ReleaseTestCase(unittest.TestCase):
             args=args,
         )
         self.assertFalse(released)
+
+    def test_release_to_specific_git_remote(self):
+        fake_path_class = MagicMock(spec=Path)
+        fake_requests = MagicMock(spec=requests)
+        fake_post = MagicMock(spec=requests.Response).return_value
+        fake_post.status_code = 201
+        fake_post.text = self.valid_gh_release_response
+        fake_requests.post.return_value = fake_post
+        fake_version = MagicMock(spec=version)
+        fake_version.main.return_value = (True, 'MyProject.conf')
+        fake_changelog = MagicMock(spec=changelog)
+        fake_changelog.update.return_value = ('updated', 'changelog')
+        args = [
+            '--release-version',
+            '0.0.1',
+            '--next-release-version',
+            '0.0.2dev',
+            '--project',
+            'testcases',
+            '--git-remote-name',
+            'testremote',
+            'release',
+        ]
+        runner = lambda x: StdOutput('')
+        released = release.main(
+            shell_cmd_runner=runner,
+            _path=fake_path_class,
+            _requests=fake_requests,
+            _version=fake_version,
+            _changelog=fake_changelog,
+            leave=False,
+            args=args,
+        )
+        self.assertTrue(released)


### PR DESCRIPTION
When doing the release it should be possible to push the commits and tag
to another git remote then the current default remote for pushes.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
