### PR TITLE
Add config for dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/"
+  schedule:
+    interval: daily
+    time: "04:00"
+  open-pull-requests-limit: 10


### PR DESCRIPTION
**What**:

Add config for dependabot


**Why**:
Activate dependabot for pontos to keep all dependencies up to date
automatically.

**How**:

Used the same dependabot config as gvm-tools

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests (n/a)
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry (n/a)
- [ ] Documentation (n/a)
