### PR TITLE
Add handling of PROJECT_DEV_VERSION in CMakelists.txt. 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 ### Added
+- add handling of PROJECT_DEV_VERSION in CMakeLists.txt if set [#32](https://github.com/greenbone/pontos/pull/32)
 ### Changed
 - set releasename to projectname version [#25](https://github.com/greenbone/pontos/pull/25)
 ### Deprecated

--- a/poetry.lock
+++ b/poetry.lock
@@ -144,11 +144,11 @@ description = "A Python utility / library to sort Python imports."
 name = "isort"
 optional = false
 python-versions = ">=3.6,<4.0"
-version = "5.4.2"
+version = "5.5.1"
 
 [package.extras]
 colors = ["colorama (>=0.4.3,<0.5.0)"]
-pipfile_deprecated_finder = ["pipreqs", "requirementslib", "tomlkit (>=0.5.3)"]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
 
 [[package]]
@@ -376,8 +376,8 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 isort = [
-    {file = "isort-5.4.2-py3-none-any.whl", hash = "sha256:60a1b97e33f61243d12647aaaa3e6cc6778f5eb9f42997650f1cc975b6008750"},
-    {file = "isort-5.4.2.tar.gz", hash = "sha256:d488ba1c5a2db721669cc180180d5acf84ebdc5af7827f7aaeaa75f73cf0e2b8"},
+    {file = "isort-5.5.1-py3-none-any.whl", hash = "sha256:a200d47b7ee8b7f7d0a9646650160c4a51b6a91a9413fd31b1da2c4de789f5d3"},
+    {file = "isort-5.5.1.tar.gz", hash = "sha256:92533892058de0306e51c88f22ece002a209dc8e80288aa3cec6d443060d584f"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.4.3.tar.gz", hash = "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"},

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -63,7 +63,8 @@ def build_release_dict(
 
 def initialize_default_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description='Release handling utility.', prog='pontos-release',
+        description='Release handling utility.',
+        prog='pontos-release',
     )
     parser.add_argument(
         '--release-version',
@@ -76,10 +77,14 @@ def initialize_default_parser() -> argparse.ArgumentParser:
         required=True,
     )
     parser.add_argument(
-        '--project', help='The github project', required=True,
+        '--project',
+        help='The github project',
+        required=True,
     )
     parser.add_argument(
-        '--space', default='greenbone', help='user/team name in github',
+        '--space',
+        default='greenbone',
+        help='user/team name in github',
     )
     parser.add_argument(
         '--signing-key',

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -63,8 +63,7 @@ def build_release_dict(
 
 def initialize_default_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(
-        description='Release handling utility.',
-        prog='pontos-release',
+        description='Release handling utility.', prog='pontos-release',
     )
     parser.add_argument(
         '--release-version',
@@ -77,14 +76,10 @@ def initialize_default_parser() -> argparse.ArgumentParser:
         required=True,
     )
     parser.add_argument(
-        '--project',
-        help='The github project',
-        required=True,
+        '--project', help='The github project', required=True,
     )
     parser.add_argument(
-        '--space',
-        default='greenbone',
-        help='user/team name in github',
+        '--space', default='greenbone', help='user/team name in github',
     )
     parser.add_argument(
         '--signing-key',
@@ -139,8 +134,13 @@ def parse(args=None):
     )
 
 
-def update_version(to: str, _version: version) -> Tuple[bool, str]:
-    executed, filename = _version.main(False, args=["--quiet", "update", to])
+def update_version(
+    to: str, _version: version, *, develop: bool
+) -> Tuple[bool, str]:
+    develop_arg = '--develop' if develop else ''
+    executed, filename = _version.main(
+        False, args=["--quiet", develop_arg, "update", to]
+    )
 
     if not executed:
         if filename == "":
@@ -186,7 +186,9 @@ def prepare(
     if git_version.encode() in git_tags.stdout.splitlines():
         raise ValueError('git tag {} is already taken.'.format(git_version))
 
-    executed, filename = update_version(release_version, _version)
+    executed, filename = update_version(
+        release_version, _version, develop=False
+    )
     if not executed:
         return False
 
@@ -226,7 +228,7 @@ def prepare(
     release_text.write_text(changelog_text)
 
     # set to new version add skeleton
-    executed, filename = update_version(nextversion, _version)
+    executed, filename = update_version(nextversion, _version, develop=True)
     if not executed:
         return False
 

--- a/pontos/version/cmake_version.py
+++ b/pontos/version/cmake_version.py
@@ -199,7 +199,9 @@ class CMakeVersionParser:
     def _tokenize(
         self, content: str
     ) -> Generator[
-        Tuple[int, str, str], Tuple[int, str, str], Tuple[int, str, str],
+        Tuple[int, str, str],
+        Tuple[int, str, str],
+        Tuple[int, str, str],
     ]:
         toks, remainder = self.__cmake_scanner.scan(content)
         if remainder != '':

--- a/pontos/version/cmake_version.py
+++ b/pontos/version/cmake_version.py
@@ -103,7 +103,7 @@ class CMakeVersionParser:
         self._cmake_content_lines = cmake_content_lines.split('\n')
         self._version_line_number = line_no
         self._current_version = current_version
-        self._project_dev_version_line_numeber = pd_line_no
+        self._project_dev_version_line_number = pd_line_no
         self._project_dev_version = pd
 
     __cmake_scanner = re.Scanner(

--- a/pontos/version/cmake_version.py
+++ b/pontos/version/cmake_version.py
@@ -110,7 +110,7 @@ class CMakeVersionParser:
         [
             (r'#.*', lambda _, token: ("comment", token)),
             (r'"[^"]*"', lambda _, token: ("string", token)),
-            (r'"[0-9]+"', lambda _, token: ("int", token)),
+            (r'"[0-9]+"', lambda _, token: ("number", token)),
             (r"\(", lambda _, token: ("open_bracket", token)),
             (r"\)", lambda _, token: ("close_bracket", token)),
             (r'[^ \t\r\n()#"]+', lambda _, token: ("word", token)),
@@ -134,11 +134,11 @@ class CMakeVersionParser:
 
         self._cmake_content_lines[self._version_line_number] = updated
         self._current_version = new_version
-        if self._project_dev_version_line_numeber:
+        if self._project_dev_version_line_number:
             self._cmake_content_lines[
-                self._project_dev_version_line_numeber
+                self._project_dev_version_line_number
             ] = self._cmake_content_lines[
-                self._project_dev_version_line_numeber
+                self._project_dev_version_line_number
             ].replace(
                 str(int(not develop)), str(int(develop))
             )
@@ -180,7 +180,7 @@ class CMakeVersionParser:
             ):
                 in_project_dev_version = True
             elif in_project_dev_version and (
-                token_type == 'word' or token_type == 'int'
+                token_type == 'word' or token_type == 'number'
             ):
                 project_dev_version_line_no = lineno
                 project_dev_version = value

--- a/pontos/version/cmake_version.py
+++ b/pontos/version/cmake_version.py
@@ -56,6 +56,7 @@ class CMakeVersionCommand:
             if commandline_arguments.command == 'update':
                 self.update_version(
                     commandline_arguments.version,
+                    develop=commandline_arguments.develop,
                 )
             elif commandline_arguments.command == 'show':
                 self.print_current_version()
@@ -70,11 +71,11 @@ class CMakeVersionCommand:
         if not self.__quiet:
             print(*args)
 
-    def update_version(self, version: str):
+    def update_version(self, version: str, *, develop: bool = False):
         content = self.__cmake_filepath.read_text()
         cmvp = CMakeVersionParser(content)
         previous_version = cmvp.get_current_version()
-        new_content = cmvp.update_version(version)
+        new_content = cmvp.update_version(version, develop=develop)
         self.__cmake_filepath.write_text(new_content)
         self.__print(
             'Updated version from {} to {}'.format(previous_version, version)
@@ -96,17 +97,20 @@ class CMakeVersionCommand:
 
 class CMakeVersionParser:
     def __init__(self, cmake_content_lines: str):
-        line_no, current_version = self._find_version_in_cmake(
+        line_no, current_version, pd_line_no, pd = self._find_version_in_cmake(
             cmake_content_lines
         )
         self._cmake_content_lines = cmake_content_lines.split('\n')
         self._version_line_number = line_no
         self._current_version = current_version
+        self._project_dev_version_line_numeber = pd_line_no
+        self._project_dev_version = pd
 
     __cmake_scanner = re.Scanner(
         [
             (r'#.*', lambda _, token: ("comment", token)),
             (r'"[^"]*"', lambda _, token: ("string", token)),
+            (r'"[0-9]+"', lambda _, token: ("int", token)),
             (r"\(", lambda _, token: ("open_bracket", token)),
             (r"\)", lambda _, token: ("close_bracket", token)),
             (r'[^ \t\r\n()#"]+', lambda _, token: ("word", token)),
@@ -119,7 +123,7 @@ class CMakeVersionParser:
     def get_current_version(self) -> str:
         return self._current_version
 
-    def update_version(self, new_version: str) -> str:
+    def update_version(self, new_version: str, *, develop: bool = False) -> str:
         if not is_version_pep440_compliant(new_version):
             raise VersionError(
                 "version {} is not pep 440 compliant.".format(new_version)
@@ -130,12 +134,30 @@ class CMakeVersionParser:
 
         self._cmake_content_lines[self._version_line_number] = updated
         self._current_version = new_version
+        if self._project_dev_version_line_numeber:
+            self._cmake_content_lines[
+                self._project_dev_version_line_numeber
+            ] = self._cmake_content_lines[
+                self._project_dev_version_line_numeber
+            ].replace(
+                str(int(not develop)), str(int(develop))
+            )
+            self._project_dev_version = str(int(develop))
 
         return '\n'.join(self._cmake_content_lines)
 
     def _find_version_in_cmake(self, content: str) -> Tuple[int, str]:
         in_project = False
         in_version = False
+
+        version_line_no: int = None
+        version: str = None
+
+        in_set = False
+        in_project_dev_version = False
+
+        project_dev_version_line_no: int = None
+        project_dev_version: int = None
 
         for lineno, token_type, value in self._tokenize(content):
             if token_type == 'word' and value == 'project':
@@ -145,18 +167,39 @@ class CMakeVersionParser:
             elif in_version and (
                 token_type == 'word' or token_type == 'string'
             ):
-                return lineno, value
+                version_line_no = lineno
+                version = value
+                in_project = False
+                in_version = False
+            elif token_type == 'word' and value == 'set':
+                in_set = True
+            elif (
+                in_set
+                and token_type == 'word'
+                and value == 'PROJECT_DEV_VERSION'
+            ):
+                in_project_dev_version = True
+            elif in_project_dev_version and (
+                token_type == 'word' or token_type == 'int'
+            ):
+                project_dev_version_line_no = lineno
+                project_dev_version = value
             elif in_project and token_type == 'close_bracket':
                 raise ValueError('unable to find cmake version in project.')
 
-        raise ValueError('unable to find cmake project.')
+        if not version or version_line_no is None:
+            raise ValueError('unable to find cmake version.')
+        return (
+            version_line_no,
+            version,
+            project_dev_version_line_no,
+            project_dev_version,
+        )
 
     def _tokenize(
         self, content: str
     ) -> Generator[
-        Tuple[int, str, str],
-        Tuple[int, str, str],
-        Tuple[int, str, str],
+        Tuple[int, str, str], Tuple[int, str, str], Tuple[int, str, str],
     ]:
         toks, remainder = self.__cmake_scanner.scan(content)
         if remainder != '':

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -111,8 +111,7 @@ def initialize_default_parser() -> argparse.ArgumentParser:
     - update
     """
     parser = argparse.ArgumentParser(
-        description='Version handling utilities.',
-        prog='version',
+        description='Version handling utilities.', prog='version',
     )
     parser.add_argument(
         '--quiet', help='don\'t print messages', action="store_true"
@@ -134,6 +133,11 @@ def initialize_default_parser() -> argparse.ArgumentParser:
     update_parser.add_argument(
         '--force',
         help="don't check if version is already set",
+        action="store_true",
+    )
+    update_parser.add_argument(
+        '--develop',
+        help="indicates if it is a develop version",
         action="store_true",
     )
     return parser
@@ -192,10 +196,7 @@ __version__ = "{}"\n"""
 
         self.version_file_path.write_text(self.TEMPLATE.format(version))
 
-    def update_pyproject_version(
-        self,
-        new_version: str,
-    ) -> None:
+    def update_pyproject_version(self, new_version: str,) -> None:
         """
         Update the version in the pyproject.toml file
         """
@@ -291,10 +292,7 @@ __version__ = "{}"\n"""
 
         try:
             if args.command == 'update':
-                self.update_version(
-                    args.version,
-                    force=args.force,
-                )
+                self.update_version(args.version, force=args.force)
             elif args.command == 'show':
                 self.print_current_version()
             elif args.command == 'verify':

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -111,7 +111,8 @@ def initialize_default_parser() -> argparse.ArgumentParser:
     - update
     """
     parser = argparse.ArgumentParser(
-        description='Version handling utilities.', prog='version',
+        description='Version handling utilities.',
+        prog='version',
     )
     parser.add_argument(
         '--quiet', help='don\'t print messages', action="store_true"
@@ -196,7 +197,10 @@ __version__ = "{}"\n"""
 
         self.version_file_path.write_text(self.TEMPLATE.format(version))
 
-    def update_pyproject_version(self, new_version: str,) -> None:
+    def update_pyproject_version(
+        self,
+        new_version: str,
+    ) -> None:
         """
         Update the version in the pyproject.toml file
         """

--- a/tests/version/test_cmake_version.py
+++ b/tests/version/test_cmake_version.py
@@ -155,7 +155,9 @@ class CMakeVersionParserTestCase(unittest.TestCase):
 
     def test_raise_exception_no_project(self):
         with self.assertRaises(ValueError) as context:
-            CMakeVersionParser("non_project(VERSION 2.3.5)",)
+            CMakeVersionParser(
+                "non_project(VERSION 2.3.5)",
+            )
 
         self.assertEqual(
             str(context.exception), 'unable to find cmake version.'

--- a/tests/version/test_cmake_version.py
+++ b/tests/version/test_cmake_version.py
@@ -113,7 +113,7 @@ class CMakeVersionParserTestCase(unittest.TestCase):
         )
         """
         under_test = CMakeVersionParser(test_cmake_lists)
-        self.assertEqual(under_test._project_dev_version_line_numeber, 7)
+        self.assertEqual(under_test._project_dev_version_line_number, 7)
         self.assertEqual(under_test._project_dev_version, '1')
 
     def test_update_project_dev_version(self):
@@ -129,7 +129,7 @@ class CMakeVersionParserTestCase(unittest.TestCase):
         """
         under_test = CMakeVersionParser(test_cmake_lists)
 
-        self.assertEqual(under_test._project_dev_version_line_numeber, 7)
+        self.assertEqual(under_test._project_dev_version_line_number, 7)
         self.assertEqual(under_test._project_dev_version, '1')
         result = under_test.update_version('41.41.41', develop=False)
         self.assertEqual(under_test._project_dev_version, '0')


### PR DESCRIPTION
**What**:

Add handling of PROJECT_DEV_VERSION in CMakelists.txt. 

**Why**:

PROJECT_DEV_VERSION is used within CMakeLists.txt to set the the version to a dev version, which needs to be set to `0` on actual release and `1` on dev versions.
```
if (PROJECT_DEV_VERSION)
  set (PROJECT_VERSION_SUFFIX "~dev${PROJECT_DEV_VERSION}")
endif (PROJECT_DEV_VERSION)
```
**How**:

Create a CMakeLists.txt and ru pontos release, afterwards verify the commit changes.

**Checklist**:

- [X] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
