### PR TITLE
fix wrong signing key usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 ### Fixed
 - project_dev handling was not working when there was a command after the set[#33](https://github.com/greenbone/pontos/pull/33)
+- use git-signing-key instead of signing-key on commit [42](https://github.com/greenbone/pontos/pull/42)
 
 [Unreleased]: https://github.com/greenbone/pontos/compare/v0.3.0...HEAD
 

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -243,7 +243,7 @@ def prepare(
     commit_files(
         filename,
         commit_msg,
-        release_info.signing_key,
+        release_info.git_signing_key,
         release_info.shell_cmd_runner,
     )
 
@@ -283,7 +283,7 @@ def prepare(
     commit_files(
         filename,
         commit_msg,
-        release_info.signing_key,
+        release_info.git_signing_key,
         release_info.shell_cmd_runner,
     )
 


### PR DESCRIPTION
**What**:

pontos was using signing-key instead of git-signing-key within prepare.

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
