### PR TITLE
fix bug when creating a release HEAD was not identified

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - project_dev handling was not working when there was a command after the set[#33](https://github.com/greenbone/pontos/pull/33)
 - use git-signing-key instead of signing-key on commit [42](https://github.com/greenbone/pontos/pull/42)
+- HEAD was not identified in changelog [43](https://github.com/greenbone/pontos/pull/43)
 
 [Unreleased]: https://github.com/greenbone/pontos/compare/v0.3.0...HEAD
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - project_dev handling was not working when there was a command after the set[#33](https://github.com/greenbone/pontos/pull/33)
 - use git-signing-key instead of signing-key on commit [42](https://github.com/greenbone/pontos/pull/42)
-- HEAD was not identified in changelog [43](https://github.com/greenbone/pontos/pull/43)
+- HEAD was not identified in changelog [51](https://github.com/greenbone/pontos/pull/51)
 
 [Unreleased]: https://github.com/greenbone/pontos/compare/v0.3.0...HEAD
 

--- a/pontos/changelog/changelog.py
+++ b/pontos/changelog/changelog.py
@@ -28,7 +28,7 @@ class ChangelogError(Exception):
 
 
 __UNRELEASED_MATCHER = re.compile('unreleased', re.IGNORECASE)
-__MASTER_MATCHER = re.compile('master')
+__MASTER_MATCHER = re.compile('master|HEAD')
 
 __UNRELEASED_SKELETON = """## [Unreleased]
 ### Added

--- a/tests/changelog/test_changelog_update.py
+++ b/tests/changelog/test_changelog_update.py
@@ -134,7 +134,7 @@ so little
 ### changed
 I don't recognize it anymore
 ### security
-[Unreleased]: https://github.com/greenbone/pontos/compare/v1.0.0...master"""
+[Unreleased]: https://github.com/greenbone/pontos/compare/v1.0.0...HEAD"""
         test_md_template = """# Changelog
 something, somehing
 - unreleased


### PR DESCRIPTION
Due to the not found HEAD tag the release link was:

```
https://github.com/greenbone/python-gvm/compare/v20.11.3...HEAD
```

instead of

```
https://github.com/greenbone/python-gvm/compare/v20.11.3...v20.12.1
```

before it was just looking for master.

**What**:

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
