### PR TITLE
[pontos-release]: Automatically calculate calendar version. Add workflow for automatic releases.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,13 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 ## [Unreleased]
 ### Added
 - Template for header [85](https://github.com/greenbone/pontos/pull/85)
+
 ### Changed
+- For `pontos-release` the `--release-version` argument is not required anymore. You can choose between `--release-version` and `--calendar` now.
+  - `--calendar` will automatically look up the next calendar release version number
+  - `--release-version` can still be used for setting the release version number manually
+  - `--next-version` is not required anymore, it will be set by calculating the next `dev` version, if not manually set. [104](https://github.com/greenbone/pontos/pull/104)
+
 ### Deprecated
 ### Removed
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,10 +10,11 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 - Template for header [85](https://github.com/greenbone/pontos/pull/85)
 
 ### Changed
-- For `pontos-release` the `--release-version` argument is not required anymore. You can choose between `--release-version` and `--calendar` now.
+- For `pontos-release` the `--release-version` argument is not required anymore. You can choose between `--release-version` and `--calendar` now. [104](https://github.com/greenbone/pontos/pull/104)
   - `--calendar` will automatically look up the next calendar release version number
   - `--release-version` can still be used for setting the release version number manually
-  - `--next-version` is not required anymore, it will be set by calculating the next `dev` version, if not manually set. [104](https://github.com/greenbone/pontos/pull/104)
+  - `--next-version` is not required anymore, it will be set by calculating the next `dev` version, if not manually set.
+- The new Changelog and setting the next version is now done after the release within `pontos-release release` [104](https://github.com/greenbone/pontos/pull/104)
 
 ### Deprecated
 ### Removed

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -128,7 +128,7 @@ if it has been lost.
 * Run pontos-release prepare
 
   ```sh
-  poetry run pontos-release --project pontos --space greenbone prepare --release-version <version> --next-version <dev-version> --git-signing-key <your-public-gpg-key>
+  poetry run pontos-release prepare --release-version <version> --git-signing-key <your-public-gpg-key>
   ```
 
 * Check git log and tag
@@ -155,7 +155,22 @@ if it has been lost.
 * Run pontos-release release
 
   ```sh
-  poetry run pontos-release --project pontos --space greenbone release --release-version <version> --git-remote-name upstream
+  poetry run pontos-release --project pontos --space greenbone release --release-version <version> --next-version <dev-version> --git-remote-name upstream
+  ```
+
+## Create Release without giving a version
+
+* You can also let pontos calculate the next **calendar** version for you. Therefore you can use the `--calendar` argument in prepare:
+
+  ```sh
+  poetry run pontos-release prepare --calendar --git-signing-key <your-public-gpg-key>
+  ```
+
+* Pontos can also automatically set the next dev version for you. If you do not explicitly set a `--next-version` it will set to the next dev version:
+  * e.g. release-version is 0.0.1, pontos will set next-version to 0.0.2.dev1
+
+  ```sh
+  poetry run pontos-release --project pontos --space greenbone release --git-remote-name upstream
   ```
 
 ## Uploading to the 'real' PyPI

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -112,14 +112,18 @@ def initialize_default_parser() -> argparse.ArgumentParser:
     release_parser.set_defaults(func=release)
     release_parser.add_argument(
         '--release-version',
-        help='Will release changelog as version. Must be PEP 440 compliant',
-        required=True,
+        help=(
+            'Will release changelog as version. Must be PEP 440 compliant. '
+            'default: lookup version in project definition.'
+        ),
     )
 
     release_parser.add_argument(
         '--next-version',
-        help='Sets the next PEP 440 compliant version in project definition '
-        'after the release',
+        help=(
+            'Sets the next PEP 440 compliant version in project definition '
+            'after the release. default: set to next dev version',
+        ),
     )
 
     release_parser.add_argument(
@@ -156,10 +160,7 @@ def initialize_default_parser() -> argparse.ArgumentParser:
     )
     sign_parser.add_argument(
         '--release-version',
-        help=(
-            'Will release changelog as version. Must be PEP 440 compliant. '
-            'If not given, it will be read from the changelog.'
-        ),
+        help='Will release changelog as version. Must be PEP 440 compliant.',
     )
     sign_parser.add_argument(
         '--git-tag-prefix',

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 # pontos/release/release.py
-# Copyright (C) 2020 Greenbone Networks GmbH
+# Copyright (C) 2020 - 2021 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
@@ -17,16 +17,13 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
+
 import argparse
 import sys
 import subprocess
 import os
-import re
 import json
 import shutil
-from contextlib import redirect_stdout
-from io import StringIO
-import datetime
 
 from pathlib import Path
 from typing import Callable, Dict, List, Union, Tuple
@@ -34,6 +31,11 @@ from typing import Callable, Dict, List, Union, Tuple
 import requests
 
 from pontos import version
+from pontos.version import (
+    calculate_calendar_version,
+    get_current_version,
+    get_next_dev_version,
+)
 from pontos import changelog
 
 RELEASE_TEXT_FILE = ".release.txt.md"
@@ -72,16 +74,6 @@ def initialize_default_parser() -> argparse.ArgumentParser:
         description='Release handling utility.',
         prog='pontos-release',
     )
-    parser.add_argument(
-        '--project',
-        help='The github project',
-        required=True,
-    )
-    parser.add_argument(
-        '--space',
-        default='greenbone',
-        help='user/team name in github',
-    )
 
     subparsers = parser.add_subparsers(
         title='subcommands',
@@ -107,11 +99,6 @@ def initialize_default_parser() -> argparse.ArgumentParser:
     )
 
     prepare_parser.add_argument(
-        '--next-version',
-        help='Sets the next PEP 440 compliant version in project definition '
-        'after the release',
-    )
-    prepare_parser.add_argument(
         '--git-signing-key',
         help='The key to sign the commits and tag for a release',
     )
@@ -128,6 +115,13 @@ def initialize_default_parser() -> argparse.ArgumentParser:
         help='Will release changelog as version. Must be PEP 440 compliant',
         required=True,
     )
+
+    release_parser.add_argument(
+        '--next-version',
+        help='Sets the next PEP 440 compliant version in project definition '
+        'after the release',
+    )
+
     release_parser.add_argument(
         '--git-remote-name',
         help='The git remote name to push the commits and tag to',
@@ -136,6 +130,21 @@ def initialize_default_parser() -> argparse.ArgumentParser:
         '--git-tag-prefix',
         default='v',
         help='Prefix for git tag versions. Default: %(default)s',
+    )
+    release_parser.add_argument(
+        '--git-signing-key',
+        help='The key to sign the commits and tag for a release',
+    )
+
+    release_parser.add_argument(
+        '--project',
+        help='The github project',
+        required=True,
+    )
+    release_parser.add_argument(
+        '--space',
+        default='greenbone',
+        help='user/team name in github',
     )
 
     sign_parser = subparsers.add_parser('sign')
@@ -156,6 +165,16 @@ def initialize_default_parser() -> argparse.ArgumentParser:
         '--git-tag-prefix',
         default='v',
         help='Prefix for git tag versions. Default: %(default)s',
+    )
+    sign_parser.add_argument(
+        '--project',
+        help='The github project',
+        required=True,
+    )
+    sign_parser.add_argument(
+        '--space',
+        default='greenbone',
+        help='user/team name in github',
     )
     return parser
 
@@ -251,56 +270,6 @@ def upload_assets(
     return True
 
 
-def calculate_calendar_version(_version: version) -> Tuple[bool, str]:
-    """find the release version by checking latest version and
-    the today's date"""
-    args = ['show']
-
-    with redirect_stdout(StringIO()) as version_str:
-        executed, _ = _version.main(False, args=args)
-
-    current_version = None
-    if executed:
-        current_version = version_str.getvalue()
-        print(f"Found version {current_version}")
-    else:
-        print("No version found, creating initial version")
-
-    today = datetime.date.today()
-    dev = None
-    if current_version:
-        if 'dev' in current_version:
-            year, month, minor, dev = current_version.split('.')
-        else:
-            year, month, minor = current_version.split('.')
-        if not dev:
-            # in case current version is not a dev version
-            # increment it
-            minor = str(int(minor) + 1)
-        if not int(year) == today.year % 100:
-            year = str(today.year % 100)
-            # since current year is higher than version year
-            # set minor to 0
-            minor = str(0)
-        if not int(month) == today.month:
-            month = str(today.month)
-            # since current month is higher than version month
-            # set minor to 0
-            minor = str(0)
-    else:
-        year = str(today.year % 100)
-        month = str(today.month)
-        minor = str(0)
-
-    release_version = ".".join([year, month, minor])
-
-    minor = str(int(minor) + 1)
-
-    next_version = ".".join([year, month, minor, 'dev1'])
-
-    return release_version, next_version
-
-
 def prepare(
     shell_cmd_runner: Callable,
     args: argparse.Namespace,
@@ -310,38 +279,36 @@ def prepare(
     changelog_module: changelog,
     **_kwargs,
 ) -> bool:
-    project: str = args.project
-    space: str = args.space
     git_tag_prefix: str = args.git_tag_prefix
     git_signing_key: str = args.git_signing_key
     calendar: bool = args.calendar
-    release_version: str = args.release_version
-    next_version: str = args.next_version
 
-    print("in prepare")
+    if calendar:
+        release_version: str = calculate_calendar_version()
+    else:
+        release_version: str = args.release_version
+
+    # else:
+    #     if not next_version:
+    #         year, month, minor = release_version.split('.')
+    #         minor = str(int(minor) + 1)
+    #         next_version = '.'.join([year, month, minor, 'dev1'])
+
+    print(f"Preparing the release {release_version}")
 
     # guardian
     git_tags = shell_cmd_runner('git tag -l')
     git_version = "{}{}".format(git_tag_prefix, release_version)
     if git_version.encode() in git_tags.stdout.splitlines():
-        raise ValueError('git tag {} is already taken.'.format(git_version))
+        raise ValueError(f'git tag {git_version} is already taken.')
 
-    if calendar:
-        release_version, next_version = calculate_calendar_version(
-            version_module
-        )
-    else:
-        if not next_version:
-            year, month, minor = release_version.split('.')
-            minor = str(int(minor) + 1)
-            next_version = '.'.join([year, month, minor, 'dev1'])
     executed, filename = update_version(
         release_version, version_module, develop=False
     )
     if not executed:
         return False
 
-    print("updated version {} to {}".format(filename, release_version))
+    print(f"updated version  in {filename} to {release_version}")
 
     change_log_path = path.cwd() / 'CHANGELOG.md'
     updated, changelog_text = changelog_module.update(
@@ -381,7 +348,76 @@ def prepare(
     release_text = path(RELEASE_TEXT_FILE)
     release_text.write_text(changelog_text)
 
+    print(
+        f"Please verify git tag {git_version}, "
+        f"commit and release text in {str(release_text)}"
+    )
+    print("Afterwards please execute release")
+
+    return True
+
+
+def release(
+    shell_cmd_runner: Callable,
+    args: argparse.Namespace,
+    *,
+    path: Path,
+    version_module: version,
+    username: str,
+    token: str,
+    requests_module: requests,
+    changelog_module: changelog,
+    **_kwargs,
+) -> bool:
+    project: str = args.project
+    space: str = args.space
+    git_signing_key: str = args.git_signing_key
+    git_remote_name: str = (
+        args.git_remote_name if args.git_remote_name is not None else ''
+    )
+    git_tag_prefix: str = args.git_tag_prefix
+    release_version: str = args.release_version
+    next_version: str = args.next_version
+
+    if not release_version:
+        release_version = get_current_version()
+
+    if not next_version:
+        next_version = get_next_dev_version(release_version)
+
+    print("Pushing changes")
+
+    shell_cmd_runner(f"git push --follow-tags {git_remote_name}")
+
+    print("Creating release")
+    changelog_text: str = path(RELEASE_TEXT_FILE).read_text()
+
+    headers = {'Accept': 'application/vnd.github.v3+json'}
+
+    base_url = "https://api.github.com/repos/{}/{}/releases".format(
+        space, project
+    )
+    git_version = f'{git_tag_prefix}{release_version}'
+    response = requests_module.post(
+        base_url,
+        headers=headers,
+        auth=(username, token),
+        json=build_release_dict(
+            git_version,
+            changelog_text,
+            name="{} {}".format(project, release_version),
+        ),
+    )
+    if response.status_code != 201:
+        print("Wrong response status code: {}".format(response.status_code))
+        print(json.dumps(response.text, indent=4, sort_keys=True))
+        return False
+
+    path(RELEASE_TEXT_FILE).unlink()
+
     # set to new version add skeleton
+    change_log_path = path.cwd() / 'CHANGELOG.md'
+
     executed, filename = update_version(
         next_version, version_module, develop=True
     )
@@ -408,83 +444,6 @@ def prepare(
         shell_cmd_runner,
     )
 
-    print(
-        f"Please verify git tag {git_version}, "
-        f"commit and release text in {str(release_text)}"
-    )
-    print("Afterwards please execute release")
-
-    return True
-
-
-def find_release_version_in_changelog(changelog_text: str) -> str:
-    """Find the version string in the changelog text"""
-    try:
-        if changelog_text:
-            today = datetime.date.today()
-            regex = f'({str(today.year % 100)}\\.{str(today.month)}\\.\\d+)'
-            return re.compile(regex).search(changelog_text).group()
-    except AttributeError:
-        try:
-            today = datetime.date.today()
-            regex = r'(\d+\.\d+\.\d+)'
-            return re.compile(regex).search(changelog_text).group()
-        except AttributeError as e:
-            print(e)
-            sys.exit(1)
-
-
-def release(
-    shell_cmd_runner: Callable,
-    args: argparse.Namespace,
-    *,
-    path: Path,
-    username: str,
-    token: str,
-    requests_module: requests,
-    **_kwargs,
-) -> bool:
-    project: str = args.project
-    space: str = args.space
-    git_remote_name: str = args.git_remote_name
-    git_tag_prefix: str = args.git_tag_prefix
-    release_version: str = args.release_version
-
-    changelog_text: str = path(RELEASE_TEXT_FILE).read_text()
-    if not release_version:
-        release_version = find_release_version_in_changelog(changelog_text)
-
-    print("Pushing changes")
-
-    if git_remote_name:
-        shell_cmd_runner("git push --follow-tags {}".format(git_remote_name))
-    else:
-        shell_cmd_runner("git push --follow-tags")
-
-    print("Creating release")
-
-    headers = {'Accept': 'application/vnd.github.v3+json'}
-
-    base_url = "https://api.github.com/repos/{}/{}/releases".format(
-        space, project
-    )
-    git_version = f'{git_tag_prefix}{release_version}'
-    response = requests_module.post(
-        base_url,
-        headers=headers,
-        auth=(username, token),
-        json=build_release_dict(
-            git_version,
-            changelog_text,
-            name="{} {}".format(project, release_version),
-        ),
-    )
-    if response.status_code != 201:
-        print("Wrong response status code: {}".format(response.status_code))
-        print(json.dumps(response.text, indent=4, sort_keys=True))
-        return False
-
-    path(RELEASE_TEXT_FILE).unlink()
     return True
 
 

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -281,12 +281,6 @@ def prepare(
     else:
         release_version: str = args.release_version
 
-    # else:
-    #     if not next_version:
-    #         year, month, minor = release_version.split('.')
-    #         minor = str(int(minor) + 1)
-    #         next_version = '.'.join([year, month, minor, 'dev1'])
-
     print(f"Preparing the release {release_version}")
 
     # guardian

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -182,16 +182,8 @@ def initialize_default_parser() -> argparse.ArgumentParser:
 def parse(args=None) -> Tuple[str, str, argparse.Namespace]:
     parser = initialize_default_parser()
     commandline_arguments = parser.parse_args(args)
-    token = (
-        os.environ['GITHUB_TOKEN']
-        if not args or not 'testcases' in args
-        else 'TOKEN'
-    )
-    user = (
-        os.environ['GITHUB_USER']
-        if not args or not 'testcases' in args
-        else 'USER'
-    )
+    token = os.environ['GITHUB_TOKEN'] if not args else 'TOKEN'
+    user = os.environ['GITHUB_USER'] if not args else 'USER'
     return (user, token, commandline_arguments)
 
 

--- a/pontos/version/__init__.py
+++ b/pontos/version/__init__.py
@@ -27,8 +27,12 @@ from .version import (
     is_version_pep440_compliant,
     get_version_from_pyproject_toml,
 )
-
 from .cmake_version import CMakeVersionParser, CMakeVersionCommand
+from .helper import (
+    calculate_calendar_version,
+    get_current_version,
+    get_next_dev_version,
+)
 
 
 def main(leave=True, args=None):
@@ -50,12 +54,15 @@ def main(leave=True, args=None):
 
 __all__ = [
     '__version__',
-    'VersionCommand',
-    'VersionError',
+    'calculate_calendar_version',
+    'CMakeVersionCommand',
+    'get_version_from_pyproject_toml',
+    'get_current_version',
+    'get_next_dev_version',
+    'is_version_pep440_compliant',
+    'PontosVersionCommand',
     'safe_version',
     'strip_version',
-    'is_version_pep440_compliant',
-    'get_version_from_pyproject_toml',
-    'CMakeVersionCommand',
-    'PontosVersionCommand',
+    'VersionCommand',
+    'VersionError',
 ]

--- a/pontos/version/cmake_version.py
+++ b/pontos/version/cmake_version.py
@@ -89,6 +89,11 @@ class CMakeVersionCommand:
         cmvp = CMakeVersionParser(content)
         self.__print(cmvp.get_current_version())
 
+    def get_current_version(self) -> str:
+        content = self.__cmake_filepath.read_text()
+        cmvp = CMakeVersionParser(content)
+        return cmvp.get_current_version()
+
     def verify_version(self, version: str):
         if not is_version_pep440_compliant(version):
             raise VersionError(

--- a/pontos/version/helper.py
+++ b/pontos/version/helper.py
@@ -1,0 +1,103 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+import datetime
+from pathlib import Path
+import sys
+
+from packaging.version import Version, InvalidVersion
+
+from pontos.version import (
+    PontosVersionCommand,
+    CMakeVersionCommand,
+    VersionError,
+)
+
+
+def get_next_dev_version(release_version: str) -> str:
+    """Get the next dev Version from a valid version"""
+    # will be a dev1 version
+    try:
+        release_version_obj = Version(release_version)
+        next_version_obj = Version(
+            f'{str(release_version_obj.major)}.'
+            f'{str(release_version_obj.minor)}.'
+            f'{str(release_version_obj.micro + 1)}.dev1'
+        )
+        return str(next_version_obj)
+    except InvalidVersion as e:
+        raise (VersionError(e)) from None
+
+
+def get_current_version() -> str:
+    """Get the current Version from a pyproject.toml or
+    a CMakeLists.txt file"""
+
+    available_cmds = [
+        ('CMakeLists.txt', CMakeVersionCommand),
+        ('pyproject.toml', PontosVersionCommand),
+    ]
+    for file_name, cmd in available_cmds:
+        project_definition_path = Path.cwd() / file_name
+        if project_definition_path.exists():
+            current_version: str = cmd().get_current_version()
+            return current_version
+
+    print("No project settings file found")
+    sys.exit(1)
+
+
+def calculate_calendar_version() -> str:
+    """find the correct next calendar version by checking latest version and
+    the today's date"""
+
+    current_version_str: str = get_current_version()
+    current_version = Version(current_version_str)
+
+    today = datetime.date.today()
+
+    if (
+        current_version.major < today.year % 100
+        or current_version.minor < today.month
+    ):
+        release_version = Version(
+            f'{str(today.year  % 100)}.{str(today.month)}.0'
+        )
+        return str(release_version)
+    elif (
+        current_version.major == today.year % 100
+        and current_version.minor == today.month
+    ):
+        if not current_version.dev:
+            release_version = Version(
+                f'{str(today.year  % 100)}.{str(today.month)}.'
+                f'{str(current_version.micro + 1)}'
+            )
+        else:
+            release_version = Version(
+                f'{str(today.year  % 100)}.{str(today.month)}.'
+                f'{str(current_version.micro)}'
+            )
+        return str(release_version)
+    else:
+        print(
+            f"'{str(current_version)}' is higher than "
+            f"'{str(today.year  % 100)}.{str(today.month)}'."
+        )
+        sys.exit(1)

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -40,14 +40,16 @@ _shutil_mock = MagicMock(spec=shutil)
 
 @patch("pontos.release.release.shutil", new=_shutil_mock)
 class PrepareTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        os.environ['GITHUB_TOKEN'] = 'foo'
+        os.environ['GITHUB_USER'] = 'bar'
+
     def test_prepare_successfully(self):
         fake_path_class = MagicMock(spec=Path)
         fake_version = MagicMock(spec=version)
         fake_version.main.return_value = (True, 'MyProject.conf')
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
-        os.environ['GITHUB_TOKEN'] = 'foo'
-        os.environ['GITHUB_USER'] = 'bar'
         args = [
             'prepare',
             '--release-version',
@@ -70,8 +72,7 @@ class PrepareTestCase(unittest.TestCase):
         fake_version.main.return_value = (True, 'MyProject.conf')
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
-        os.environ['GITHUB_TOKEN'] = 'foo'
-        os.environ['GITHUB_USER'] = 'bar'
+
         args = [
             'prepare',
             '--calendar',
@@ -93,8 +94,7 @@ class PrepareTestCase(unittest.TestCase):
         fake_version.main.return_value = (True, 'MyProject.conf')
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
-        os.environ['GITHUB_TOKEN'] = 'foo'
-        os.environ['GITHUB_USER'] = 'bar'
+
         args = [
             'prepare',
             '--git-signing-key',
@@ -128,8 +128,7 @@ class PrepareTestCase(unittest.TestCase):
         fake_path_class = MagicMock(spec=Path)
         fake_version = MagicMock(spec=version)
         fake_changelog = MagicMock(spec=changelog)
-        os.environ['GITHUB_TOKEN'] = 'foo'
-        os.environ['GITHUB_USER'] = 'bar'
+
         args = [
             'prepare',
             '--release-version',
@@ -154,8 +153,7 @@ class PrepareTestCase(unittest.TestCase):
         fake_version.main.return_value = (False, '')
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
-        os.environ['GITHUB_TOKEN'] = 'foo'
-        os.environ['GITHUB_USER'] = 'bar'
+
         args = [
             'prepare',
             '--release-version',
@@ -179,8 +177,7 @@ class PrepareTestCase(unittest.TestCase):
         fake_version.main.return_value = (False, 'MyProject.conf')
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
-        os.environ['GITHUB_TOKEN'] = 'foo'
-        os.environ['GITHUB_USER'] = 'bar'
+
         args = [
             'prepare',
             '--release-version',
@@ -201,10 +198,13 @@ class PrepareTestCase(unittest.TestCase):
 
 @patch("pontos.release.release.shutil", new=_shutil_mock)
 class ReleaseTestCase(unittest.TestCase):
-
-    valid_gh_release_response = (
-        '{"zipball_url": "zip", "tarball_url": "tar", "upload_url":"upload"}'
-    )
+    def setUp(self) -> None:
+        os.environ['GITHUB_TOKEN'] = 'foo'
+        os.environ['GITHUB_USER'] = 'bar'
+        self.valid_gh_release_response = (
+            '{"zipball_url": "zip", "tarball_url":'
+            ' "tar", "upload_url":"upload"}'
+        )
 
     def test_release_successfully(self):
         fake_path_class = MagicMock(spec=Path)
@@ -282,13 +282,13 @@ class ReleaseTestCase(unittest.TestCase):
         args = [
             'release',
             '--project',
-            'testcases',
+            'foo',
             '--release-version',
             '0.0.1',
             '--next-version',
             '0.0.2.dev1',
             '--git-remote-name',
-            'testremote',
+            'upstream',
         ]
 
         called = []
@@ -310,7 +310,7 @@ class ReleaseTestCase(unittest.TestCase):
         )
         self.assertTrue(released)
 
-        self.assertIn('git push --follow-tags testremote', called)
+        self.assertIn('git push --follow-tags upstream', called)
         self.assertIn('git add MyProject.conf', called)
         self.assertIn(
             "git commit -S -m '* Update to version"
@@ -322,10 +322,13 @@ class ReleaseTestCase(unittest.TestCase):
 
 @patch("pontos.release.release.shutil", new=_shutil_mock)
 class SignTestCase(unittest.TestCase):
-
-    valid_gh_release_response = (
-        '{"zipball_url": "zip", "tarball_url": "tar", "upload_url":"upload"}'
-    )
+    def setUp(self) -> None:
+        os.environ['GITHUB_TOKEN'] = 'foo'
+        os.environ['GITHUB_USER'] = 'bar'
+        self.valid_gh_release_response = (
+            '{"zipball_url": "zip", "tarball_url":'
+            ' "tar", "upload_url":"upload"}'
+        )
 
     def test_fail_sign_on_invalid_get_response(self):
         fake_path_class = MagicMock(spec=Path)
@@ -341,7 +344,7 @@ class SignTestCase(unittest.TestCase):
         args = [
             'sign',
             '--project',
-            'testcases',
+            'foo',
             '--release-version',
             '0.0.1',
         ]
@@ -378,7 +381,7 @@ class SignTestCase(unittest.TestCase):
         args = [
             'sign',
             '--project',
-            'testcases',
+            'foo',
             '--release-version',
             '0.0.1',
         ]
@@ -415,7 +418,7 @@ class SignTestCase(unittest.TestCase):
         args = [
             'sign',
             '--project',
-            'testcases',
+            'bar',
             '--release-version',
             '0.0.1',
         ]

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -51,8 +51,6 @@ class PrepareTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
-            '--project',
-            'testcases',
             'prepare',
             '--release-version',
             '0.0.1',
@@ -77,8 +75,6 @@ class PrepareTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
-            '--project',
-            'testcases',
             'prepare',
             '--calendar',
         ]
@@ -100,8 +96,6 @@ class PrepareTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
-            '--project',
-            'testcases',
             'prepare',
             '--git-signing-key',
             '0815',
@@ -137,8 +131,6 @@ class PrepareTestCase(unittest.TestCase):
         fake_version = MagicMock(spec=version)
         fake_changelog = MagicMock(spec=changelog)
         args = [
-            '--project',
-            'testcases',
             'prepare',
             '--release-version',
             '0.0.1',
@@ -329,8 +321,6 @@ class PrepareTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
-            '--project',
-            'testcases',
             'prepare',
             '--release-version',
             '0.0.1',
@@ -356,8 +346,6 @@ class PrepareTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
-            '--project',
-            'testcases',
             'prepare',
             '--release-version',
             '0.0.1',
@@ -396,9 +384,9 @@ class ReleaseTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
+            'release',
             '--project',
             'testcases',
-            'release',
             '--release-version',
             '0.0.1',
         ]
@@ -426,9 +414,9 @@ class ReleaseTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
+            'release',
             '--project',
             'testcases',
-            'release',
             '--release-version',
             '0.0.1',
         ]
@@ -456,9 +444,9 @@ class ReleaseTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
+            'release',
             '--project',
             'testcases',
-            'release',
             '--release-version',
             '0.0.1',
             '--git-remote-name',
@@ -501,9 +489,9 @@ class SignTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
+            'sign',
             '--project',
             'testcases',
-            'sign',
             '--release-version',
             '0.0.1',
         ]
@@ -538,9 +526,9 @@ class SignTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
+            'sign',
             '--project',
             'testcases',
-            'sign',
             '--release-version',
             '0.0.1',
         ]
@@ -575,9 +563,9 @@ class SignTestCase(unittest.TestCase):
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
         args = [
+            'sign',
             '--project',
             'testcases',
-            'sign',
             '--release-version',
             '0.0.1',
         ]

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -17,6 +17,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # pylint: disable=C0413,W0108
 
+import os
 import shutil
 import unittest
 
@@ -45,6 +46,8 @@ class PrepareTestCase(unittest.TestCase):
         fake_version.main.return_value = (True, 'MyProject.conf')
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
+        os.environ['GITHUB_TOKEN'] = 'foo'
+        os.environ['GITHUB_USER'] = 'bar'
         args = [
             'prepare',
             '--release-version',
@@ -67,6 +70,8 @@ class PrepareTestCase(unittest.TestCase):
         fake_version.main.return_value = (True, 'MyProject.conf')
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
+        os.environ['GITHUB_TOKEN'] = 'foo'
+        os.environ['GITHUB_USER'] = 'bar'
         args = [
             'prepare',
             '--calendar',
@@ -88,6 +93,8 @@ class PrepareTestCase(unittest.TestCase):
         fake_version.main.return_value = (True, 'MyProject.conf')
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
+        os.environ['GITHUB_TOKEN'] = 'foo'
+        os.environ['GITHUB_USER'] = 'bar'
         args = [
             'prepare',
             '--git-signing-key',
@@ -121,6 +128,8 @@ class PrepareTestCase(unittest.TestCase):
         fake_path_class = MagicMock(spec=Path)
         fake_version = MagicMock(spec=version)
         fake_changelog = MagicMock(spec=changelog)
+        os.environ['GITHUB_TOKEN'] = 'foo'
+        os.environ['GITHUB_USER'] = 'bar'
         args = [
             'prepare',
             '--release-version',
@@ -145,6 +154,8 @@ class PrepareTestCase(unittest.TestCase):
         fake_version.main.return_value = (False, '')
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
+        os.environ['GITHUB_TOKEN'] = 'foo'
+        os.environ['GITHUB_USER'] = 'bar'
         args = [
             'prepare',
             '--release-version',
@@ -168,6 +179,8 @@ class PrepareTestCase(unittest.TestCase):
         fake_version.main.return_value = (False, 'MyProject.conf')
         fake_changelog = MagicMock(spec=changelog)
         fake_changelog.update.return_value = ('updated', 'changelog')
+        os.environ['GITHUB_TOKEN'] = 'foo'
+        os.environ['GITHUB_USER'] = 'bar'
         args = [
             'prepare',
             '--release-version',

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -295,8 +295,6 @@ class ReleaseTestCase(unittest.TestCase):
 
         def runner(cmd: str):
             called.append(cmd)
-            # if not 'testremote' in cmd:
-            #     raise ValueError('unexpected cmd: {}'.format(cmd))
             return StdOutput('')
 
         released = release.main(

--- a/tests/version/test_cmake_version.py
+++ b/tests/version/test_cmake_version.py
@@ -49,7 +49,7 @@ class CMakeVersionCommandTestCase(unittest.TestCase):
         fake_path.exists.return_value = True
         fake_path.read_text.return_value = ""
         result = CMakeVersionCommand(cmake_lists_path=fake_path).run(
-            args=['verify', 'su_much_version_so_much_wow']
+            args=['verify', 'so_much_version_so_much_wow']
         )
         self.assertTrue(
             isinstance(result, str), "expected result to be an error string"
@@ -106,7 +106,7 @@ class CMakeVersionParserTestCase(unittest.TestCase):
     def test_update_raise_exception_when_version_is_incorrect(self):
         under_test = CMakeVersionParser("project(VERSION 2.3.4)")
         with self.assertRaises(VersionError):
-            under_test.update_version('su_much_version_so_much_wow')
+            under_test.update_version('so_much_version_so_much_wow')
 
     def test_not_confuse_version_outside_project(self):
         under_test = CMakeVersionParser(

--- a/tests/version/test_helper.py
+++ b/tests/version/test_helper.py
@@ -30,8 +30,6 @@ from pontos.version import (
 
 class CalculateNextVersionTestCase(unittest.TestCase):
     def test_calculate_calendar_versions(self):
-        # thats the ugliest mock  I have created. Ever.
-
         today = datetime.datetime.today()
 
         filenames = ['pyproject.toml', 'CMakeLists.txt']

--- a/tests/version/test_helper.py
+++ b/tests/version/test_helper.py
@@ -36,8 +36,8 @@ class CalculateNextVersionTestCase(unittest.TestCase):
 
         filenames = ['pyproject.toml', 'CMakeLists.txt']
         mocks = [
-            'pontos.release.release.PontosVersionCommand',
-            'pontos.release.release.CMakeVersionCommand',
+            'pontos.version.helper.PontosVersionCommand',
+            'pontos.version.helper.CMakeVersionCommand',
         ]
         current_versions = [
             '20.4.1.dev3',

--- a/tests/version/test_helper.py
+++ b/tests/version/test_helper.py
@@ -1,0 +1,79 @@
+# -*- coding: utf-8 -*-
+# Copyright (C) 2021 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import datetime
+import os
+import unittest
+from unittest.mock import patch
+from pathlib import Path
+
+
+from pontos.version import (
+    calculate_calendar_version,
+)
+
+
+class CalculateNextVersionTestCase(unittest.TestCase):
+    def test_calculate_calendar_versions(self):
+        # thats the ugliest mock  I have created. Ever.
+
+        today = datetime.datetime.today()
+
+        filenames = ['pyproject.toml', 'CMakeLists.txt']
+        mocks = [
+            'pontos.release.release.PontosVersionCommand',
+            'pontos.release.release.CMakeVersionCommand',
+        ]
+        current_versions = [
+            '20.4.1.dev3',
+            f'{str(today.year % 100)}.4.1.dev3',
+            f'19.{str(today.month)}.1.dev3',
+            f'{str(today.year % 100)}.{str(today.month)}.1.dev3',
+            f'{str(today.year % 100)}.{str(today.month)}.1',
+        ]
+        assert_versions = [
+            f'{str(today.year % 100)}.{str(today.month)}.0',
+            f'{str(today.year % 100)}.{str(today.month)}.0',
+            f'{str(today.year % 100)}.{str(today.month)}.0',
+            f'{str(today.year % 100)}.{str(today.month)}.1',
+            f'{str(today.year % 100)}.{str(today.month)}.2',
+        ]
+
+        tmp_path = Path.cwd() / 'tmp'
+
+        for filename, mock in zip(filenames, mocks):
+            for current_version, assert_version in zip(
+                current_versions, assert_versions
+            ):
+                tmp_path.mkdir(parents=True, exist_ok=True)
+                os.chdir(tmp_path)
+                proj_file = Path.cwd() / filename
+                proj_file.touch()
+                with patch(mock) as cmd_mock:
+                    cmd_mock.return_value.get_current_version.return_value = (
+                        current_version
+                    )
+
+                    release_version = calculate_calendar_version()
+
+                    self.assertEqual(release_version, assert_version)
+
+                os.chdir('..')
+                proj_file.unlink()
+
+        tmp_path.rmdir()


### PR DESCRIPTION
**What**:

* Changes in pontos:
  * User can use `--calendar` instead of `--release-version` to automatically calculate next calendar version for a release
  * `--next-version` is not required anymore: `next_version` is now calculated on `release_version`

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* Want to introduce GitHub Action workflow for python release - therefore remove argument-complexity from `pontos-release`

<!-- Why are these changes necessary? -->

**How**:

* Use current version (`pontos-version show`) and current date and calculate the correct calendar release version

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
