### PR TITLE
Regex Magic to correctly replace Unreleased section of the given version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,13 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 ## [Unreleased]
 ### Added
 ### Changed
+* `pontos-release` checks now if there is a `unreleased` section in the `CHANGELOG.md` for the given release version, instead of using everything that is `unreleased`. If it doesn't find the version, it will look for a general `unreleased` section (like before). [#133](https://github.com/greenbone/pontos/pull/133)
+
 ### Deprecated
 ### Removed
 ### Fixed
+* The replacement of the `unreleased` section in the `CHANGELOG.md`. [#133](https://github.com/greenbone/pontos/pull/133)
+  * e.g. it is able to handle `## [2.1.3] (unreleased)` now and will convert it correctly to `## [2.1.3] - 22.06.2020`
 
 [Unreleased]: https://github.com/greenbone/pontos/compare/v21.6.4...HEAD
 

--- a/pontos/changelog/changelog.py
+++ b/pontos/changelog/changelog.py
@@ -27,7 +27,10 @@ class ChangelogError(Exception):
     """
 
 
-__UNRELEASED_MATCHER = re.compile('unreleased', re.IGNORECASE)
+__UNRELEASED_FOOTER_MATCHER = re.compile('unreleased', re.IGNORECASE)
+__UNRELEASED_HEADER_MATCHER = re.compile(
+    r'[\(\[]{1}[0-9\.]*.*?[Uu]nreleased[\)\]]{1}'
+)
 __MASTER_MATCHER = re.compile('master|HEAD')
 
 __UNRELEASED_SKELETON = """## [Unreleased]
@@ -138,12 +141,12 @@ def _prepare_changelog(
 
         if tt == 'unreleased':
             if new_version:
-                tc = __UNRELEASED_MATCHER.sub(new_version, tc)
+                tc = __UNRELEASED_HEADER_MATCHER.sub(f'[{new_version}]', tc)
                 tc += ' - {}'.format(date.today().isoformat())
             output += tc
         elif tt == 'unreleased_link':
             if new_version:
-                tc = __UNRELEASED_MATCHER.sub(new_version, tc)
+                tc = __UNRELEASED_FOOTER_MATCHER.sub(new_version, tc)
                 tc = __MASTER_MATCHER.sub(git_tag, tc)
             unreleased_link += tc + '\n\n'
         elif 'kw_' in tt:

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -213,11 +213,22 @@ def prepare(
     ok(f"updated version  in {filename} to {release_version}")
 
     change_log_path = path.cwd() / 'CHANGELOG.md'
+
+    # Try to get the unreleased section of the specific version
     updated, changelog_text = changelog_module.update(
         change_log_path.read_text(),
         release_version,
         git_tag_prefix=git_tag_prefix,
+        containing_version=release_version,
     )
+
+    if not updated:
+        # Try to get unversioned unrlease section
+        updated, changelog_text = changelog_module.update(
+            change_log_path.read_text(),
+            release_version,
+            git_tag_prefix=git_tag_prefix,
+        )
 
     if not updated:
         raise ValueError("No unreleased text found in CHANGELOG.md")

--- a/tests/changelog/test_changelog_update.py
+++ b/tests/changelog/test_changelog_update.py
@@ -88,6 +88,74 @@ I don't recognize it anymore
         self.assertEqual(released_md.strip(), updated.strip())
         self.assertEqual(released.strip(), release_notes.strip())
 
+    def test_update_markdown_different_unreleased_sections(self):
+        released_md = """
+## [1.2.4] (Unreleased)
+### fixed
+not so much
+### added
+so little
+### changed
+I don't recognize it anymore
+### security
+[Unreleased]: https://github.com/greenbone/pontos/compare/v1.0.0...master
+
+## [1.2.3] - {}
+### fixed
+so much wow
+### added
+so little
+### changed
+I don't recognize it anymore
+[1.2.3]: https://github.com/greenbone/pontos/compare/v1.0.0...v1.2.3
+""".format(
+            date.today().isoformat()
+        )
+
+        unreleased = """
+## [1.2.4] (Unreleased)
+### fixed
+not so much
+### added
+so little
+### changed
+I don't recognize it anymore
+### security
+[Unreleased]: https://github.com/greenbone/pontos/compare/v1.0.0...master
+
+## [1.2.3] (Unreleased)
+### fixed
+so much wow
+### added
+so little
+### changed
+I don't recognize it anymore
+### security
+[Unreleased]: https://github.com/greenbone/pontos/compare/v1.0.0...master
+"""
+
+        released = """
+## [1.2.3] - {}
+### fixed
+so much wow
+### added
+so little
+### changed
+I don't recognize it anymore
+[1.2.3]: https://github.com/greenbone/pontos/compare/v1.0.0...v1.2.3
+""".format(
+            date.today().isoformat()
+        )
+
+        test_md = unreleased
+        updated, release_notes = changelog.update(
+            test_md, '1.2.3', containing_version='1.2.3'
+        )
+        print(updated)
+        print(release_notes)
+        self.assertEqual(released_md.strip(), updated.strip())
+        self.assertEqual(released.strip(), release_notes.strip())
+
     def test_update_markdown_return_changelog(self):
         released = """
 ## [1.2.3] - {}


### PR DESCRIPTION
**What**:

* Extend the support, if multiple unreleased versions are logged
* `pontos-release` now checks, if there is a unreleased section for the given release version


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* If the `CHANGELOG.md` has two unreleased sections like this:

## [21.10] (unreleased)

## [21.4.1] (unreleased)

it has been converted to

## [21.10] (21.10) - 22.06.2020

## [21.4.1] (unreleased)

instead of 

## [21.10] - 22.06.2020

## [21.4.1] (unreleased)

<!-- Why are these changes necessary? -->

**How**:

* Regex

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [x] Documentation
