### PR TITLE
[pontos-release] Fix signing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 ### Deprecated
 ### Removed
 ### Fixed
+* Fixed creating signature files for tarballs and zip files from GitHub releases [#142](https://github.com/greenbone/pontos/pull/142)
 
 [Unreleased]: https://github.com/greenbone/pontos/compare/v21.6.9...HEAD
 

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -18,7 +18,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 import json
-import shutil
 import subprocess
 import tempfile
 
@@ -123,13 +122,14 @@ def download(
        Path to the downloaded file
     """
 
-    file_path = path(tempfile.gettempdir()) / filename
+    file_path: Path = path(tempfile.gettempdir()) / filename
+    response = requests_module.get(url, stream=True)
 
-    with requests_module.get(url, stream=True) as resp, file_path.open(
-        mode='wb'
-    ) as download_file:
-        out(f'Downloading {url}')
-        shutil.copyfileobj(resp.raw, download_file)
+    out(f'Downloading {url}')
+
+    with file_path.open(mode='wb') as download_file:
+        for content in response.iter_content():
+            download_file.write(content)
 
     return file_path
 

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -414,15 +414,23 @@ def sign(
         out(json.dumps(response.text, indent=4, sort_keys=True))
         return False
 
+    zipball_url = (
+        f"https://github.com/{space}/{project}/archive/refs/"
+        f"tags/{git_version}.zip"
+    )
     github_json = json.loads(response.text)
     zip_path = download(
-        github_json['zipball_url'],
+        zipball_url,
         f"{project}-{release_version}.zip",
         path=path,
         requests_module=requests_module,
     )
+    tarball_url = (
+        f"https://github.com/{space}/{project}/archive/refs/"
+        f"tags/{git_version}.tar.gz"
+    )
     tar_path = download(
-        github_json['tarball_url'],
+        tarball_url,
         f"{project}-{release_version}.tar.gz",
         path=path,
         requests_module=requests_module,

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -18,7 +18,6 @@
 # pylint: disable=C0413,W0108
 
 import os
-import shutil
 import unittest
 
 from dataclasses import dataclass
@@ -34,9 +33,6 @@ from pontos import release, changelog
 @dataclass
 class StdOutput:
     stdout: bytes
-
-
-_shutil_mock = MagicMock(spec=shutil)
 
 
 class PrepareTestCase(unittest.TestCase):

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -23,7 +23,7 @@ import unittest
 
 from dataclasses import dataclass
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import requests
 
@@ -39,7 +39,6 @@ class StdOutput:
 _shutil_mock = MagicMock(spec=shutil)
 
 
-@patch("pontos.release.helper.shutil", new=_shutil_mock)
 class PrepareTestCase(unittest.TestCase):
     def setUp(self) -> None:
         os.environ['GITHUB_TOKEN'] = 'foo'
@@ -197,7 +196,6 @@ class PrepareTestCase(unittest.TestCase):
         self.assertFalse(released)
 
 
-@patch("pontos.release.helper.shutil", new=_shutil_mock)
 class ReleaseTestCase(unittest.TestCase):
     def setUp(self) -> None:
         os.environ['GITHUB_TOKEN'] = 'foo'
@@ -316,7 +314,6 @@ class ReleaseTestCase(unittest.TestCase):
         print(called)
 
 
-@patch("pontos.release.helper.shutil", new=_shutil_mock)
 class SignTestCase(unittest.TestCase):
     def setUp(self) -> None:
         os.environ['GITHUB_TOKEN'] = 'foo'


### PR DESCRIPTION
**What**:

Use same urls as in the browser for downloading the to be signed files.

**Why**:

Generated signatures are wrong.

**How**:

Uploaded new signatures for gvm-libs 21.4.1 and tested the asc file for the tarball.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
