### PR TITLE
Add pontos-update-header option to ignore files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 
 ## [Unreleased]
 ### Added
+* Add pontos-update-header option to ignore files [#144](https://github.com/greenbone/pontos/pull/144)
+
 ### Changed
 ### Deprecated
 ### Removed

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -322,7 +322,7 @@ def main() -> None:
     for file in files:
         try:
             if os.path.abspath(str(file)) in exclude_list:
-                print(f"{file}: Matches exclusion list.")
+                print(f"{file}: Ignoring file from exclusion list.")
             else:
                 _update_file(file=file, regex=regex, args=args)
         except (FileNotFoundError, UnicodeDecodeError, ValueError):

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -21,15 +21,13 @@ Also it appends a header if it is missing in the file.
 """
 
 import sys
-import os
 import re
 
 from argparse import ArgumentParser, Namespace, FileType
 from datetime import datetime
-from glob import glob
 
 from subprocess import CalledProcessError, run
-from typing import Dict, Tuple, Union
+from typing import Dict, List, Tuple, Union
 from pathlib import Path
 
 SUPPORTED_FILE_TYPES = [
@@ -195,31 +193,28 @@ def _update_file(
         raise e
 
 
-def _get_exclude_list(exclude_file, directory):
+def _get_exclude_list(exclude_file: Path, directory: Path) -> List[Path]:
     """Tries to get the list of excluded files.
     If a file is given, it will be used. Otherwise the given directory will be
     checked for the default file.
+    The ignore file should only contain relative paths like *.py,
+    not absolute as **/*.py
     """
-    if exclude_file is None:
-        path = os.path.join(directory, ".pontos-header-ignore")
-        try:
-            exclude_file = open(path, "r")
-        except FileNotFoundError:
-            return []
 
-    exclude_lines = exclude_file.readlines()
-    exclude_file.close()
+    if exclude_file is None:
+        exclude_file = Path(directory) / ".pontos-header-ignore"
+    try:
+        exclude_lines = exclude_file.read_text().split('\n')
+    except FileNotFoundError:
+        print("No exclude list file found.")
+        return []
 
     expanded_globs = [
-        glob(os.path.join(directory, line.replace('\n', '')), recursive=True)
-        for line in exclude_lines
-        if line
+        Path(directory).rglob(line.strip()) for line in exclude_lines if line
     ]
 
     return [
-        os.path.abspath(path)
-        for glob_paths in expanded_globs
-        for path in glob_paths
+        path.absolute() for glob_paths in expanded_globs for path in glob_paths
     ]
 
 
@@ -286,6 +281,8 @@ def _parse_args(args=None):
             " ignore when finding files to update in a directory."
             " Will look for '.pontos-header-ignore' in the directory"
             " if none is given."
+            "The ignore file should only contain relative paths like *.py,"
+            "not absolute as **/*.py"
         ),
         type=FileType('r'),
     )
@@ -298,14 +295,11 @@ def main() -> None:
     exclude_list = []
 
     if args.directory:
+        directory = Path(args.directory)
         # get file paths to exclude
         exclude_list = _get_exclude_list(args.exclude_file, args.directory)
         # get files to update
-        files = [
-            Path(file)
-            for file in glob(args.directory + "/**/*", recursive=True)
-            if os.path.isfile(file)
-        ]
+        files = [Path(file) for file in directory.rglob("*") if file.is_file()]
     elif args.files:
         files = [Path(name) for name in args.files]
 
@@ -321,7 +315,7 @@ def main() -> None:
 
     for file in files:
         try:
-            if os.path.abspath(str(file)) in exclude_list:
+            if file.absolute() in exclude_list:
                 print(f"{file}: Ignoring file from exclusion list.")
             else:
                 _update_file(file=file, regex=regex, args=args)

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import os
 import struct
 import re
 
@@ -32,6 +33,7 @@ from pontos.updateheader.updateheader import (
     _find_copyright as find_copyright,
     _add_header as add_header,
     _update_file as update_file,
+    _get_exclude_list as get_exclude_list,
     _parse_args as parse_args,
     main,
 )
@@ -426,6 +428,16 @@ class UpdateHeaderTestCase(TestCase):
         self.assertTrue(args.changed)
         self.assertEqual(args.year, '2021')
         self.assertEqual(args.licence, self.args.licence)
+
+    def test_get_exclude_list(self):
+        # Try to find the current file from two directories up...
+        test_dirname = os.path.dirname(__file__) + "/../.."
+        # with a recursive glob
+        mock_ignore_file = StringIO("**/*.py\n")
+
+        exclude_list = get_exclude_list(mock_ignore_file, test_dirname)
+
+        self.assertIn(__file__, exclude_list)
 
     @patch('pontos.updateheader.updateheader._parse_args')
     def test_main(self, argparser_mock):

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -15,8 +15,6 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-
-import os
 import struct
 import re
 
@@ -431,13 +429,18 @@ class UpdateHeaderTestCase(TestCase):
 
     def test_get_exclude_list(self):
         # Try to find the current file from two directories up...
-        test_dirname = os.path.dirname(__file__) + "/../.."
-        # with a recursive glob
-        mock_ignore_file = StringIO("**/*.py\n")
+        test_dirname = Path(__file__) / "../.."
+        # with a relative glob
+        test_ignore_file = Path('ignore.file')
+        test_ignore_file.write_text("*.py\n")
 
-        exclude_list = get_exclude_list(mock_ignore_file, test_dirname)
+        exclude_list = get_exclude_list(
+            test_ignore_file, test_dirname.resolve()
+        )
 
-        self.assertIn(__file__, exclude_list)
+        self.assertIn(Path(__file__), exclude_list)
+
+        test_ignore_file.unlink()
 
     @patch('pontos.updateheader.updateheader._parse_args')
     def test_main(self, argparser_mock):


### PR DESCRIPTION
**What**:
The script can be passed a file path or check the directory given with
the --directory option for a .pontos-header-ignore file.
All files matching the paths or globs listed in this filed will be
skipped when adding or updating the headers.

**Why**:
To allow skipping build directories and other files that should not have a header.

**How**:
By running the script on a directory with a .pontos-header-ignore file
that has both a normal path and a recursive glob.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
