### PR TITLE
Update Header with correct year, Add GO support.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,13 @@ and this project adheres to [Calendar Versioning](https://calver.org).
 
 ## [Unreleased]
 ### Added
+- Golang support for `pontos-update-header` [#162](https://github.com/greenbone/pontos/pull/162)
+
 ### Changed
 ### Deprecated
 ### Removed
 ### Fixed
+- `pontos-update-header` will now set the correct current year, when adding a header to a new file [#162](https://github.com/greenbone/pontos/pull/162)
 
 [Unreleased]: https://github.com/greenbone/pontos/compare/v21.7.2...HEAD
 

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.bash
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.c
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.cmake
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.go
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.go
@@ -1,0 +1,16 @@
+// Copyright (C) <year> <company>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as
+// published by the Free Software Foundation, either version 3 of the
+// License, or (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.h
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.js
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.nasl
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.nasl
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 # Some text descriptions might be excerpted from (a) referenced
 # source(s), and are Copyright (C) by the respective right holder(s).
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.po
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.po
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.py
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.sh
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.txt
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2020 Company
+Copyright (C) <year> <company>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.xml
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (C) 2020 Company
+Copyright (C) <year> <company>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (C) 2020 Company
+Copyright (C) <year> <company>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/pontos/updateheader/templates/GPL-2.0-only/template.c
+++ b/pontos/updateheader/templates/GPL-2.0-only/template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *

--- a/pontos/updateheader/templates/GPL-2.0-only/template.h
+++ b/pontos/updateheader/templates/GPL-2.0-only/template.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.bash
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.c
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.cmake
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.h
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.js
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.nasl
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.nasl
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 # Some text descriptions might be excerpted from (a) referenced
 # source(s), and are Copyright (C) by the respective right holder(s).
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.po
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.po
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.py
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.sh
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.txt
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2020 Company
+Copyright (C) <year> <company>
 
 SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.xml
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (C) 2020 Company
+Copyright (C) <year> <company>
 
 SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (C) 2020 Company
+Copyright (C) <year> <company>
 
 SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.bash
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.c
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.cmake
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.go
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.go
@@ -1,0 +1,16 @@
+// Copyright (C) <year> <company>
+//
+// SPDX-License-Identifier: GPL-3.0-or-later
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.h
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.h
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.js
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.js
@@ -1,4 +1,4 @@
-/* Copyright (C) 2020 Company
+/* Copyright (C) <year> <company>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.nasl
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.nasl
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 # Some text descriptions might be excerpted from (a) referenced
 # source(s), and are Copyright (C) by the respective right holder(s).
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.po
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.po
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.py
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.py
@@ -1,5 +1,5 @@
 # -*- coding: utf-8 -*-
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.sh
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (C) 2020 Company
+# Copyright (C) <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.txt
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.txt
@@ -1,4 +1,4 @@
-Copyright (C) 2020 Company
+Copyright (C) <year> <company>
 
 SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -34,6 +34,7 @@ SUPPORTED_FILE_TYPES = [
     ".bash",
     ".c",
     ".h",
+    ".go",
     ".cmake",
     ".js",
     ".nasl",

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -86,7 +86,9 @@ def _find_copyright(
     return False, None
 
 
-def _add_header(suffix: str, licence: str, company: str) -> Union[str, None]:
+def _add_header(
+    suffix: str, licence: str, company: str, year: str
+) -> Union[str, None]:
     """Tries to add the header to the file.
     Requirements:
       - file type must be supported
@@ -96,7 +98,11 @@ def _add_header(suffix: str, licence: str, company: str) -> Union[str, None]:
         root = Path(__file__).parent
         licence_file = root / "templates" / licence / f"template{suffix}"
         try:
-            return licence_file.read_text().replace("Company", company)
+            return (
+                licence_file.read_text()
+                .replace("<company>", company)
+                .replace("<year>", year)
+            )
         except FileNotFoundError as e:
             raise e
     else:
@@ -137,13 +143,14 @@ def _update_file(
             if i == 0 and not found:
                 try:
                     header = _add_header(
-                        file.suffix, args.licence, args.company
+                        file.suffix, args.licence, args.company, args.year
                     )
                     if header:
                         fp.seek(0)  # back to beginning of file
                         rest_of_file = fp.read()
                         fp.seek(0)
                         fp.write(header)
+                        fp.write('\n')
                         fp.write(rest_of_file)
                         print(f"{file}: Added licence header.")
                         return 0

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -112,7 +112,7 @@ class UpdateHeaderTestCase(TestCase):
 
     def test_add_header(self):
         expected_header = """# -*- coding: utf-8 -*-
-# Copyright (C) 2020 Greenbone Networks GmbH
+# Copyright (C) 2021 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
@@ -131,7 +131,10 @@ class UpdateHeaderTestCase(TestCase):
 """
 
         header = add_header(
-            suffix=".py", licence='AGPL-3.0-or-later', company=self.args.company
+            suffix=".py",
+            licence='AGPL-3.0-or-later',
+            company=self.args.company,
+            year='2021',
         )
 
         self.assertEqual(header, expected_header)
@@ -143,6 +146,7 @@ class UpdateHeaderTestCase(TestCase):
                 suffix=".prr",
                 licence='AGPL-3.0-or-later',
                 company=self.args.company,
+                year='2021',
             )
 
     def test_add_header_licence_not_found(self):
@@ -152,6 +156,7 @@ class UpdateHeaderTestCase(TestCase):
                 suffix=".py",
                 licence='AAAGPL-3.0-or-later',
                 company=self.args.company,
+                year='2021',
             )
 
     @patch('sys.stdout', new_callable=StringIO)
@@ -271,7 +276,7 @@ class UpdateHeaderTestCase(TestCase):
         self.args.licence = 'AGPL-3.0-or-later'
 
         expected_header = """# -*- coding: utf-8 -*-
-# Copyright (C) 2020 Greenbone Networks GmbH
+# Copyright (C) 1995 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #
@@ -287,6 +292,7 @@ class UpdateHeaderTestCase(TestCase):
 #
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
 """
 
         test_file = self.path / "test.py"


### PR DESCRIPTION
**What**:

- Golang support for `pontos-update-header` 
- `pontos-update-header` will now set the correct current year, when adding a header to a new file 

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry
- [ ] Documentation
