### PR TITLE
Switch to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -79,6 +79,5 @@ pontos-update-header = 'pontos.updateheader:main'
 pontos-changelog = 'pontos.changelog:main'
 
 [build-system]
-requires = ["poetry>=0.12"]
-build-backend = "poetry.masonry.api"
-
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
**What**:

Using `poetry-core` allows distribution packages to depend only on the build backend.

**Why**:

[`poetry-core`](https://github.com/python-poetry/poetry-core) is intended to be a light weight, fully compliant, self-contained package allowing PEP 517 compatible build frontends to build Poetry managed projects.

**How**:

See https://github.com/NixOS/nixpkgs/blob/nixos-unstable/pkgs/development/python-modules/pontos/default.nix#L52

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests N/A
- [ ] [CHANGELOG](https://github.com/greenbone/pontos/blob/master/CHANGELOG.md) Entry N/A
- [ ] Documentation N/A
