### PR TITLE
Add: Allow for debugging the GitHub Actions event data

### DIFF
--- a/pontos/github/actions/event.py
+++ b/pontos/github/actions/event.py
@@ -95,10 +95,13 @@ class GitHubEvent:
 
     def __init__(self, event_path: Path):
         content = event_path.read_text(encoding="utf-8")
-        event_data = json.loads(content) if content else {}
-        pull_request_data = event_data.get("pull_request")
+        self._event_data = json.loads(content) if content else {}
+        pull_request_data = self._event_data.get("pull_request")
         self.pull_request = (
             GitHubPullRequestEvent(pull_request_data)
             if pull_request_data
             else None
         )
+
+    def __str__(self) -> str:
+        return json.dumps(self._event_data, indent=2)


### PR DESCRIPTION
**What**:

Add a GitHubEvent str method to allow for easy debugging/printing the actions event data.

**Why**:

Some decisions in the actions depend on the event data. Without having access to the current event data details it might be difficult to understand failures.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
