### PR TITLE
Add API for updating a GitHub PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ the titan of the sea.
 
 ## Table of Contents <!-- omit in toc -->
 
-- [Tools](#tools-and-utilities)
+- [Tools and Utilities](#tools-and-utilities)
 - [Installation](#installation)
   - [Requirements](#requirements)
   - [Install using pip](#install-using-pip)
@@ -61,7 +61,9 @@ pontos-changelog -o <changelog-file>
 * pontos-github` - Handling GitHub operations, like Pull Requests (beta)
 ```bash
 # create a PR on GitHub
-pontos-github pr <orga/repo> <head> <target> <pr_title> [--body <pr_body>]
+pontos-github pr create <orga/repo> <head> <target> <pr_title> [--body <pr_body>]
+# update a PR on GitHub
+pontos-github pr update <orga/repo> <pr> [--target <target_branch>] [--title <pr_title>] [--body <pr_body>]
 # get modified and deleted files in a PR, store in file test.txt
 pontos-github FS <orga/repo> <pull_request> -s modified deleted -o test.txt
 # add labels to an Issue/PR

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -204,7 +204,7 @@ class GitHubRESTApi:
         Args:
             repo: GitHub repository (owner/name) to use
             head_branch: Branch to create a pull request from
-            base_branch: Branch as target for the pull
+            base_branch: Branch as target for the pull request
             title: Title for the pull request
             body: Description for the pull request. Can be formatted in Markdown
 
@@ -218,6 +218,41 @@ class GitHubRESTApi:
             "title": title,
             "body": body.replace('\\n', '\n'),
         }
+        response = self._request(api, data=data, request=requests.post)
+        response.raise_for_status()
+
+    def update_pull_request(
+        self,
+        repo: str,
+        pull_request: int,
+        *,
+        base_branch: Optional[str] = None,
+        title: Optional[str] = None,
+        body: Optional[str] = None,
+    ):
+        """
+        Update a Pull Request on GitHub
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            pull_request: Pull request number
+            base_branch: Branch as target for the pull request. Leave empty for
+                keeping the current one.
+            title: Title for the pull request. Leave empty for keeping the
+                current one.
+            body: Description for the pull request. Can be formatted in
+                Markdown. Leave empty for keeping the current one.
+        """
+        api = f"/repos/{repo}/pulls/{pull_request}"
+
+        data = {}
+        if base_branch:
+            data["base"] = base_branch
+        if title:
+            data["title"] = title
+        if body:
+            data["body"] = body.replace('\\n', '\n')
+
         response = self._request(api, data=data, request=requests.post)
         response.raise_for_status()
 

--- a/pontos/github/cmds.py
+++ b/pontos/github/cmds.py
@@ -25,6 +25,10 @@ from pontos.terminal import error, info, ok, out
 
 
 def pull_request(args: Namespace):
+    args.pr_func(args)
+
+
+def create_pull_request(args: Namespace):
     git = GitHubRESTApi(token=args.token)
 
     try:
@@ -57,6 +61,34 @@ def pull_request(args: Namespace):
         sys.exit(1)
 
     ok("Pull Request created.")
+
+
+def update_pull_request(args: Namespace):
+    git = GitHubRESTApi(token=args.token)
+
+    try:
+        if args.target:
+            # check if branches exist
+            if not git.branch_exists(repo=args.repo, branch=args.target):
+                error(
+                    f"Target branch {args.target} is not existing or "
+                    "authorisation failed."
+                )
+                sys.exit(1)
+
+            ok(f"Target branch {args.target} exists.")
+        git.update_pull_request(
+            repo=args.repo,
+            pull_request=args.pull_request,
+            base_branch=args.target,
+            title=args.title,
+            body=args.body,
+        )
+    except requests.exceptions.RequestException as e:
+        error(str(e))
+        sys.exit(1)
+
+    ok("Pull Request updated.")
 
 
 def file_status(args: Namespace):

--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -120,6 +120,31 @@ class GitHubApiTestCase(unittest.TestCase):
         )
 
     @patch("pontos.github.api.requests.post")
+    def test_update_pull_request(self, requests_mock: MagicMock):
+        api = GitHubRESTApi("12345")
+        api.update_pull_request(
+            "foo/bar",
+            123,
+            base_branch="main",
+            title="Foo",
+            body="This is bar",
+        )
+
+        requests_mock.assert_called_once_with(
+            'https://api.github.com/repos/foo/bar/pulls/123',
+            headers={
+                'Authorization': 'token 12345',
+                'Accept': 'application/vnd.github.v3+json',
+            },
+            params=None,
+            json={
+                'base': 'main',
+                'title': 'Foo',
+                'body': 'This is bar',
+            },
+        )
+
+    @patch("pontos.github.api.requests.post")
     def test_add_pull_request_comment(self, requests_mock: MagicMock):
         api = GitHubRESTApi("12345")
         api.add_pull_request_comment(


### PR DESCRIPTION
**What**:

Add an API and CLI for updating a GitHub pull request. `pontos-github pr` CLI got changed to require either a `create` or `update` sub command.

**Why**:

We want to be able to update a PR in a CI workflow.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
