### PR TITLE
Extend pull_request_files and pull_request_commits to return all data

### DIFF
--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -75,6 +75,7 @@ class GitHubApiTestCase(unittest.TestCase):
     @patch("pontos.github.api.requests.get")
     def test_pull_request_commits(self, requests_mock: MagicMock):
         response = MagicMock()
+        response.links = None
         response.json.return_value = [{"sha": "1"}]
         requests_mock.return_value = response
         api = GitHubRESTApi("12345")
@@ -364,6 +365,7 @@ class GitHubApiTestCase(unittest.TestCase):
     @patch("pontos.github.api.requests.get")
     def test_modified_files_in_pr(self, requests_mock: MagicMock):
         response = MagicMock()
+        response.links = None
         response.json.return_value = json.loads(
             (here / "pr-files.json").read_text(encoding="utf-8")
         )
@@ -401,6 +403,7 @@ class GitHubApiTestCase(unittest.TestCase):
     @patch("pontos.github.api.requests.get")
     def test_added_files_in_pr(self, requests_mock: MagicMock):
         response = MagicMock()
+        response.links = None
         response.json.return_value = json.loads(
             (here / "pr-files.json").read_text(encoding="utf-8")
         )


### PR DESCRIPTION
**What**:

Implement following the GitHub pagination with an internal _request_all
method to be able to load all commits and files of a pull request.

**Why**:

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
