### PR TITLE
Replace requests with httpx

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -7,6 +7,24 @@ optional = false
 python-versions = "*"
 
 [[package]]
+name = "anyio"
+version = "3.6.1"
+description = "High level compatibility layer for multiple asynchronous event loop implementations"
+category = "main"
+optional = false
+python-versions = ">=3.6.2"
+
+[package.dependencies]
+idna = ">=2.8"
+sniffio = ">=1.1"
+typing-extensions = {version = "*", markers = "python_version < \"3.8\""}
+
+[package.extras]
+doc = ["packaging", "sphinx-rtd-theme", "sphinx-autodoc-typehints (>=1.2.0)"]
+test = ["coverage[toml] (>=4.5)", "hypothesis (>=4.0)", "pytest (>=7.0)", "pytest-mock (>=3.6.1)", "trustme", "contextlib2", "uvloop (<0.15)", "mock (>=4)", "uvloop (>=0.15)"]
+trio = ["trio (>=0.16)"]
+
+[[package]]
 name = "astroid"
 version = "2.11.7"
 description = "An abstract syntax tree for Python with inference support."
@@ -182,6 +200,52 @@ description = "Docutils -- Python Documentation Utilities"
 category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+
+[[package]]
+name = "h11"
+version = "0.12.0"
+description = "A pure-Python, bring-your-own-I/O implementation of HTTP/1.1"
+category = "main"
+optional = false
+python-versions = ">=3.6"
+
+[[package]]
+name = "httpcore"
+version = "0.15.0"
+description = "A minimal low-level HTTP client."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+anyio = ">=3.0.0,<4.0.0"
+certifi = "*"
+h11 = ">=0.11,<0.13"
+sniffio = ">=1.0.0,<2.0.0"
+
+[package.extras]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (>=1.0.0,<2.0.0)"]
+
+[[package]]
+name = "httpx"
+version = "0.23.0"
+description = "The next generation HTTP client."
+category = "main"
+optional = false
+python-versions = ">=3.7"
+
+[package.dependencies]
+certifi = "*"
+httpcore = ">=0.15.0,<0.16.0"
+rfc3986 = {version = ">=1.3,<2", extras = ["idna2008"]}
+sniffio = "*"
+
+[package.extras]
+brotli = ["brotlicffi", "brotli"]
+cli = ["click (>=8.0.0,<9.0.0)", "rich (>=10,<13)", "pygments (>=2.0.0,<3.0.0)"]
+http2 = ["h2 (>=3,<5)"]
+socks = ["socksio (>=1.0.0,<2.0.0)"]
 
 [[package]]
 name = "idna"
@@ -470,6 +534,20 @@ socks = ["PySocks (>=1.5.6,!=1.5.7)"]
 use_chardet_on_py3 = ["chardet (>=3.0.2,<6)"]
 
 [[package]]
+name = "rfc3986"
+version = "1.5.0"
+description = "Validating URI References per RFC 3986"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+idna = {version = "*", optional = true, markers = "extra == \"idna2008\""}
+
+[package.extras]
+idna2008 = ["idna"]
+
+[[package]]
 name = "rope"
 version = "1.2.0"
 description = "a python refactoring library..."
@@ -483,6 +561,14 @@ pytoolconfig = ">=1.1.2"
 [package.extras]
 dev = ["pytest (>=7.0.1)", "pytest-timeout (>=2.1.0)", "build (>=0.7.0)"]
 doc = ["pytoolconfig", "sphinx (>=4.5.0)", "sphinx-autodoc-typehints (>=1.18.1)", "sphinx-rtd-theme (>=1.0.0)"]
+
+[[package]]
+name = "sniffio"
+version = "1.2.0"
+description = "Sniff out which async library your code is running under"
+category = "main"
+optional = false
+python-versions = ">=3.5"
 
 [[package]]
 name = "snowballstemmer"
@@ -638,7 +724,7 @@ python-versions = ">=3.6"
 name = "typing-extensions"
 version = "4.3.0"
 description = "Backported and Experimental Type Hints for Python 3.7+"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.7"
 
@@ -678,16 +764,29 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "37839c283a8a58d24c2d977420d15d76da5c2f5a7b7e26ca0446bf125499cfa6"
+content-hash = "2c90824a6290567ab24e497920419b4ca0a9bbd23e24d243694987a002b165b2"
 
 [metadata.files]
 alabaster = [
     {file = "alabaster-0.7.12-py2.py3-none-any.whl", hash = "sha256:446438bdcca0e05bd45ea2de1668c1d9b032e1a9154c2c259092d77031ddd359"},
     {file = "alabaster-0.7.12.tar.gz", hash = "sha256:a661d72d58e6ea8a57f7a86e37d86716863ee5e92788398526d58b26a4e4dc02"},
 ]
-astroid = []
-autohooks = []
-autohooks-plugin-black = []
+anyio = [
+    {file = "anyio-3.6.1-py3-none-any.whl", hash = "sha256:cb29b9c70620506a9a8f87a309591713446953302d7d995344d0d7c6c0c9a7be"},
+    {file = "anyio-3.6.1.tar.gz", hash = "sha256:413adf95f93886e442aea925f3ee43baa5a765a64a0f52c6081894f9992fdd0b"},
+]
+astroid = [
+    {file = "astroid-2.11.7-py3-none-any.whl", hash = "sha256:86b0a340a512c65abf4368b80252754cda17c02cdbbd3f587dddf98112233e7b"},
+    {file = "astroid-2.11.7.tar.gz", hash = "sha256:bb24615c77f4837c707669d16907331374ae8a964650a66999da3f5ca68dc946"},
+]
+autohooks = [
+    {file = "autohooks-22.7.2-py3-none-any.whl", hash = "sha256:8fd967717ac60ac69f09ff5deb8cfdba6dd007fa293f49903e111ce9a06d626e"},
+    {file = "autohooks-22.7.2.tar.gz", hash = "sha256:7dc86b0d85a74968f72c27d7b817978ae6f8100706f730c63321e7b59b1c75b9"},
+]
+autohooks-plugin-black = [
+    {file = "autohooks-plugin-black-22.7.0.tar.gz", hash = "sha256:39193d8a85df4d0d80b920b1b8b5cf6d257ad502364d0c0bf5c7ff0717b14091"},
+    {file = "autohooks_plugin_black-22.7.0-py3-none-any.whl", hash = "sha256:a420e1e351346e4326aba5d68db2a8c953742ea859e07dd27df6d1957e4a879b"},
+]
 autohooks-plugin-isort = [
     {file = "autohooks_plugin_isort-22.3.0-py3-none-any.whl", hash = "sha256:4b85ee96a501d6cb29c005dca44dc4638d0b548a0302e8bbfa1bea0fad7d3f40"},
 ]
@@ -695,33 +794,138 @@ autohooks-plugin-pylint = [
     {file = "autohooks-plugin-pylint-21.6.0.tar.gz", hash = "sha256:6f1a486f19c8012618fecd9eaa985f5da3ef5c954b32d823323439547b947302"},
     {file = "autohooks_plugin_pylint-21.6.0-py3-none-any.whl", hash = "sha256:0d6ab34739d4c494012aa1647c02e6a4fb9474e4050432ee82f378fcd05c70e4"},
 ]
-babel = []
-black = []
-certifi = []
-charset-normalizer = []
-click = []
-colorama = []
+babel = [
+    {file = "Babel-2.10.3-py3-none-any.whl", hash = "sha256:ff56f4892c1c4bf0d814575ea23471c230d544203c7748e8c68f0089478d48eb"},
+    {file = "Babel-2.10.3.tar.gz", hash = "sha256:7614553711ee97490f732126dc077f8d0ae084ebc6a96e23db1482afabdb2c51"},
+]
+black = [
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:f586c26118bc6e714ec58c09df0157fe2d9ee195c764f630eb0d8e7ccce72e69"},
+    {file = "black-22.6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:b270a168d69edb8b7ed32c193ef10fd27844e5c60852039599f9184460ce0807"},
+    {file = "black-22.6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6797f58943fceb1c461fb572edbe828d811e719c24e03375fd25170ada53825e"},
+    {file = "black-22.6.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c85928b9d5f83b23cee7d0efcb310172412fbf7cb9d9ce963bd67fd141781def"},
+    {file = "black-22.6.0-cp310-cp310-win_amd64.whl", hash = "sha256:f6fe02afde060bbeef044af7996f335fbe90b039ccf3f5eb8f16df8b20f77666"},
+    {file = "black-22.6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:cfaf3895a9634e882bf9d2363fed5af8888802d670f58b279b0bece00e9a872d"},
+    {file = "black-22.6.0-cp36-cp36m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:94783f636bca89f11eb5d50437e8e17fbc6a929a628d82304c80fa9cd945f256"},
+    {file = "black-22.6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:2ea29072e954a4d55a2ff58971b83365eba5d3d357352a07a7a4df0d95f51c78"},
+    {file = "black-22.6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e439798f819d49ba1c0bd9664427a05aab79bfba777a6db94fd4e56fae0cb849"},
+    {file = "black-22.6.0-cp37-cp37m-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:187d96c5e713f441a5829e77120c269b6514418f4513a390b0499b0987f2ff1c"},
+    {file = "black-22.6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:074458dc2f6e0d3dab7928d4417bb6957bb834434516f21514138437accdbe90"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:a218d7e5856f91d20f04e931b6f16d15356db1c846ee55f01bac297a705ca24f"},
+    {file = "black-22.6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:568ac3c465b1c8b34b61cd7a4e349e93f91abf0f9371eda1cf87194663ab684e"},
+    {file = "black-22.6.0-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:6c1734ab264b8f7929cef8ae5f900b85d579e6cbfde09d7387da8f04771b51c6"},
+    {file = "black-22.6.0-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:c9a3ac16efe9ec7d7381ddebcc022119794872abce99475345c5a61aa18c45ad"},
+    {file = "black-22.6.0-cp38-cp38-win_amd64.whl", hash = "sha256:b9fd45787ba8aa3f5e0a0a98920c1012c884622c6c920dbe98dbd05bc7c70fbf"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:7ba9be198ecca5031cd78745780d65a3f75a34b2ff9be5837045dce55db83d1c"},
+    {file = "black-22.6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a3db5b6409b96d9bd543323b23ef32a1a2b06416d525d27e0f67e74f1446c8f2"},
+    {file = "black-22.6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:560558527e52ce8afba936fcce93a7411ab40c7d5fe8c2463e279e843c0328ee"},
+    {file = "black-22.6.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b154e6bbde1e79ea3260c4b40c0b7b3109ffcdf7bc4ebf8859169a6af72cd70b"},
+    {file = "black-22.6.0-cp39-cp39-win_amd64.whl", hash = "sha256:4af5bc0e1f96be5ae9bd7aaec219c901a94d6caa2484c21983d043371c733fc4"},
+    {file = "black-22.6.0-py3-none-any.whl", hash = "sha256:ac609cf8ef5e7115ddd07d85d988d074ed00e10fbc3445aee393e70164a2219c"},
+    {file = "black-22.6.0.tar.gz", hash = "sha256:6c6d39e28aed379aec40da1c65434c77d75e65bb59a1e1c283de545fb4e7c6c9"},
+]
+certifi = [
+    {file = "certifi-2022.6.15-py3-none-any.whl", hash = "sha256:fe86415d55e84719d75f8b69414f6438ac3547d2078ab91b67e779ef69378412"},
+    {file = "certifi-2022.6.15.tar.gz", hash = "sha256:84c85a9078b11105f04f3036a9482ae10e4621616db313fe045dd24743a0820d"},
+]
+charset-normalizer = [
+    {file = "charset-normalizer-2.1.0.tar.gz", hash = "sha256:575e708016ff3a5e3681541cb9d79312c416835686d054a23accb873b254f413"},
+    {file = "charset_normalizer-2.1.0-py3-none-any.whl", hash = "sha256:5189b6f22b01957427f35b6a08d9a0bc45b46d3788ef5a92e978433c7a35f8a5"},
+]
+click = [
+    {file = "click-8.1.3-py3-none-any.whl", hash = "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"},
+    {file = "click-8.1.3.tar.gz", hash = "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e"},
+]
+colorama = [
+    {file = "colorama-0.4.5-py2.py3-none-any.whl", hash = "sha256:854bf444933e37f5824ae7bfc1e98d5bce2ebe4160d46b5edf346a89358e99da"},
+    {file = "colorama-0.4.5.tar.gz", hash = "sha256:e6c6b4334fc50988a639d9b98aa429a0b57da6e17b9a44f0451f930b6967b7a4"},
+]
 colorful = [
     {file = "colorful-0.5.4-py2.py3-none-any.whl", hash = "sha256:8d264b52a39aae4c0ba3e2a46afbaec81b0559a99be0d2cfe2aba4cf94531348"},
     {file = "colorful-0.5.4.tar.gz", hash = "sha256:86848ad4e2eda60cd2519d8698945d22f6f6551e23e95f3f14dfbb60997807ea"},
 ]
-coverage = []
-dill = []
+coverage = [
+    {file = "coverage-6.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:a9032f9b7d38bdf882ac9f66ebde3afb8145f0d4c24b2e600bc4c6304aafb87e"},
+    {file = "coverage-6.4.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:e0524adb49c716ca763dbc1d27bedce36b14f33e6b8af6dba56886476b42957c"},
+    {file = "coverage-6.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4548be38a1c810d79e097a38107b6bf2ff42151900e47d49635be69943763d8"},
+    {file = "coverage-6.4.2-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f23876b018dfa5d3e98e96f5644b109090f16a4acb22064e0f06933663005d39"},
+    {file = "coverage-6.4.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6fe75dcfcb889b6800f072f2af5a331342d63d0c1b3d2bf0f7b4f6c353e8c9c0"},
+    {file = "coverage-6.4.2-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:2f8553878a24b00d5ab04b7a92a2af50409247ca5c4b7a2bf4eabe94ed20d3ee"},
+    {file = "coverage-6.4.2-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:d774d9e97007b018a651eadc1b3970ed20237395527e22cbeb743d8e73e0563d"},
+    {file = "coverage-6.4.2-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:d56f105592188ce7a797b2bd94b4a8cb2e36d5d9b0d8a1d2060ff2a71e6b9bbc"},
+    {file = "coverage-6.4.2-cp310-cp310-win32.whl", hash = "sha256:d230d333b0be8042ac34808ad722eabba30036232e7a6fb3e317c49f61c93386"},
+    {file = "coverage-6.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:5ef42e1db047ca42827a85e34abe973971c635f83aed49611b7f3ab49d0130f0"},
+    {file = "coverage-6.4.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:25b7ec944f114f70803d6529394b64f8749e93cbfac0fe6c5ea1b7e6c14e8a46"},
+    {file = "coverage-6.4.2-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bb00521ab4f99fdce2d5c05a91bddc0280f0afaee0e0a00425e28e209d4af07"},
+    {file = "coverage-6.4.2-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2dff52b3e7f76ada36f82124703f4953186d9029d00d6287f17c68a75e2e6039"},
+    {file = "coverage-6.4.2-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:147605e1702d996279bb3cc3b164f408698850011210d133a2cb96a73a2f7996"},
+    {file = "coverage-6.4.2-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:422fa44070b42fef9fb8dabd5af03861708cdd6deb69463adc2130b7bf81332f"},
+    {file = "coverage-6.4.2-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:8af6c26ba8df6338e57bedbf916d76bdae6308e57fc8f14397f03b5da8622b4e"},
+    {file = "coverage-6.4.2-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:5336e0352c0b12c7e72727d50ff02557005f79a0b8dcad9219c7c4940a930083"},
+    {file = "coverage-6.4.2-cp37-cp37m-win32.whl", hash = "sha256:0f211df2cba951ffcae210ee00e54921ab42e2b64e0bf2c0befc977377fb09b7"},
+    {file = "coverage-6.4.2-cp37-cp37m-win_amd64.whl", hash = "sha256:a13772c19619118903d65a91f1d5fea84be494d12fd406d06c849b00d31bf120"},
+    {file = "coverage-6.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f7bd0ffbcd03dc39490a1f40b2669cc414fae0c4e16b77bb26806a4d0b7d1452"},
+    {file = "coverage-6.4.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:0895ea6e6f7f9939166cc835df8fa4599e2d9b759b02d1521b574e13b859ac32"},
+    {file = "coverage-6.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d4e7ced84a11c10160c0697a6cc0b214a5d7ab21dfec1cd46e89fbf77cc66fae"},
+    {file = "coverage-6.4.2-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:80db4a47a199c4563d4a25919ff29c97c87569130375beca3483b41ad5f698e8"},
+    {file = "coverage-6.4.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3def6791adf580d66f025223078dc84c64696a26f174131059ce8e91452584e1"},
+    {file = "coverage-6.4.2-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:4f89d8e03c8a3757aae65570d14033e8edf192ee9298303db15955cadcff0c63"},
+    {file = "coverage-6.4.2-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:6d0b48aff8e9720bdec315d67723f0babd936a7211dc5df453ddf76f89c59933"},
+    {file = "coverage-6.4.2-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2b20286c2b726f94e766e86a3fddb7b7e37af5d0c635bdfa7e4399bc523563de"},
+    {file = "coverage-6.4.2-cp38-cp38-win32.whl", hash = "sha256:d714af0bdba67739598849c9f18efdcc5a0412f4993914a0ec5ce0f1e864d783"},
+    {file = "coverage-6.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:5f65e5d3ff2d895dab76b1faca4586b970a99b5d4b24e9aafffc0ce94a6022d6"},
+    {file = "coverage-6.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:a697977157adc052284a7160569b36a8bbec09db3c3220642e6323b47cec090f"},
+    {file = "coverage-6.4.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:c77943ef768276b61c96a3eb854eba55633c7a3fddf0a79f82805f232326d33f"},
+    {file = "coverage-6.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:54d8d0e073a7f238f0666d3c7c0d37469b2aa43311e4024c925ee14f5d5a1cbe"},
+    {file = "coverage-6.4.2-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:f22325010d8824594820d6ce84fa830838f581a7fd86a9235f0d2ed6deb61e29"},
+    {file = "coverage-6.4.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:24b04d305ea172ccb21bee5bacd559383cba2c6fcdef85b7701cf2de4188aa55"},
+    {file = "coverage-6.4.2-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:866ebf42b4c5dbafd64455b0a1cd5aa7b4837a894809413b930026c91e18090b"},
+    {file = "coverage-6.4.2-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:e36750fbbc422c1c46c9d13b937ab437138b998fe74a635ec88989afb57a3978"},
+    {file = "coverage-6.4.2-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:79419370d6a637cb18553ecb25228893966bd7935a9120fa454e7076f13b627c"},
+    {file = "coverage-6.4.2-cp39-cp39-win32.whl", hash = "sha256:b5e28db9199dd3833cc8a07fa6cf429a01227b5d429facb56eccd765050c26cd"},
+    {file = "coverage-6.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:edfdabe7aa4f97ed2b9dd5dde52d2bb29cb466993bb9d612ddd10d0085a683cf"},
+    {file = "coverage-6.4.2-pp36.pp37.pp38-none-any.whl", hash = "sha256:e2618cb2cf5a7cc8d698306e42ebcacd02fb7ef8cfc18485c59394152c70be97"},
+    {file = "coverage-6.4.2.tar.gz", hash = "sha256:6c3ccfe89c36f3e5b9837b9ee507472310164f352c9fe332120b764c9d60adbe"},
+]
+dill = [
+    {file = "dill-0.3.5.1-py2.py3-none-any.whl", hash = "sha256:33501d03270bbe410c72639b350e941882a8b0fd55357580fbc873fba0c59302"},
+    {file = "dill-0.3.5.1.tar.gz", hash = "sha256:d75e41f3eff1eee599d738e76ba8f4ad98ea229db8b085318aa2b3333a208c86"},
+]
 docutils = [
     {file = "docutils-0.18.1-py2.py3-none-any.whl", hash = "sha256:23010f129180089fbcd3bc08cfefccb3b890b0050e1ca00c867036e9d161b98c"},
     {file = "docutils-0.18.1.tar.gz", hash = "sha256:679987caf361a7539d76e584cbeddc311e3aee937877c87346f31debc63e9d06"},
+]
+h11 = [
+    {file = "h11-0.12.0-py3-none-any.whl", hash = "sha256:36a3cb8c0a032f56e2da7084577878a035d3b61d104230d4bd49c0c6b555a9c6"},
+    {file = "h11-0.12.0.tar.gz", hash = "sha256:47222cb6067e4a307d535814917cd98fd0a57b6788ce715755fa2b6c28b56042"},
+]
+httpcore = [
+    {file = "httpcore-0.15.0-py3-none-any.whl", hash = "sha256:1105b8b73c025f23ff7c36468e4432226cbb959176eab66864b8e31c4ee27fa6"},
+    {file = "httpcore-0.15.0.tar.gz", hash = "sha256:18b68ab86a3ccf3e7dc0f43598eaddcf472b602aba29f9aa6ab85fe2ada3980b"},
+]
+httpx = [
+    {file = "httpx-0.23.0-py3-none-any.whl", hash = "sha256:42974f577483e1e932c3cdc3cd2303e883cbfba17fe228b0f63589764d7b9c4b"},
+    {file = "httpx-0.23.0.tar.gz", hash = "sha256:f28eac771ec9eb4866d3fb4ab65abd42d38c424739e80c08d8d20570de60b0ef"},
 ]
 idna = [
     {file = "idna-3.3-py3-none-any.whl", hash = "sha256:84d9dd047ffa80596e0f246e2eab0b391788b0503584e8945f2368256d2735ff"},
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
-imagesize = []
-importlib-metadata = []
+imagesize = [
+    {file = "imagesize-1.4.1-py2.py3-none-any.whl", hash = "sha256:0d8d18d08f840c19d0ee7ca1fd82490fdc3729b7ac93f49870406ddde8ef8d8b"},
+    {file = "imagesize-1.4.1.tar.gz", hash = "sha256:69150444affb9cb0d5cc5a92b3676f0b2fb7cd9ae39e947a5e11a36b4497cd4a"},
+]
+importlib-metadata = [
+    {file = "importlib_metadata-4.12.0-py3-none-any.whl", hash = "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"},
+    {file = "importlib_metadata-4.12.0.tar.gz", hash = "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670"},
+]
 isort = [
     {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
     {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
-jinja2 = []
+jinja2 = [
+    {file = "Jinja2-3.1.2-py3-none-any.whl", hash = "sha256:6088930bfe239f0e6710546ab9c19c9ef35e29792895fed6e6e31a023a182a61"},
+    {file = "Jinja2-3.1.2.tar.gz", hash = "sha256:31351a702a408a9e7595a8fc6150fc3f43bb6bf7e319770cbc0db9df9437e852"},
+]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.7.1.tar.gz", hash = "sha256:d609c75b986def706743cdebe5e47553f4a5a1da9c5ff66d76013ef396b5a8a4"},
     {file = "lazy_object_proxy-1.7.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bb8c5fd1684d60a9902c60ebe276da1f2281a318ca16c1d0a96db28f62e9166b"},
@@ -761,7 +965,10 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.7.1-cp39-cp39-win_amd64.whl", hash = "sha256:677ea950bef409b47e51e733283544ac3d660b709cfce7b187f5ace137960d61"},
     {file = "lazy_object_proxy-1.7.1-pp37.pp38-none-any.whl", hash = "sha256:d66906d5785da8e0be7360912e99c9188b70f52c422f9fc18223347235691a84"},
 ]
-markdown-it-py = []
+markdown-it-py = [
+    {file = "markdown-it-py-2.1.0.tar.gz", hash = "sha256:cf7e59fed14b5ae17c0006eff14a2d9a00ed5f3a846148153899a0224e2c07da"},
+    {file = "markdown_it_py-2.1.0-py3-none-any.whl", hash = "sha256:93de681e5c021a432c63147656fe21790bc01231e0cd2da73626f1aa3ac0fe27"},
+]
 markupsafe = [
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:86b1f75c4e7c2ac2ccdaec2b9022845dbb81880ca318bb7a0a01fbf7813e3812"},
     {file = "MarkupSafe-2.1.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a"},
@@ -808,13 +1015,22 @@ mccabe = [
     {file = "mccabe-0.7.0-py2.py3-none-any.whl", hash = "sha256:6c2d30ab6be0e4a46919781807b4f0d834ebdd6c6e3dca0bda5a15f863427b6e"},
     {file = "mccabe-0.7.0.tar.gz", hash = "sha256:348e0240c33b60bbdf4e523192ef919f28cb2c3d7d5c7794f74009290f236325"},
 ]
-mdit-py-plugins = []
-mdurl = []
+mdit-py-plugins = [
+    {file = "mdit-py-plugins-0.3.0.tar.gz", hash = "sha256:ecc24f51eeec6ab7eecc2f9724e8272c2fb191c2e93cf98109120c2cace69750"},
+    {file = "mdit_py_plugins-0.3.0-py3-none-any.whl", hash = "sha256:b1279701cee2dbf50e188d3da5f51fee8d78d038cdf99be57c6b9d1aa93b4073"},
+]
+mdurl = [
+    {file = "mdurl-0.1.1-py3-none-any.whl", hash = "sha256:6a8f6804087b7128040b2fb2ebe242bdc2affaeaa034d5fc9feeed30b443651b"},
+    {file = "mdurl-0.1.1.tar.gz", hash = "sha256:f79c9709944df218a4cdb0fcc0b0c7ead2f44594e3e84dc566606f04ad749c20"},
+]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
     {file = "mypy_extensions-0.4.3.tar.gz", hash = "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"},
 ]
-myst-parser = []
+myst-parser = [
+    {file = "myst-parser-0.18.0.tar.gz", hash = "sha256:739a4d96773a8e55a2cacd3941ce46a446ee23dcd6b37e06f73f551ad7821d86"},
+    {file = "myst_parser-0.18.0-py3-none-any.whl", hash = "sha256:4965e51918837c13bf1c6f6fe2c6bddddf193148360fbdaefe743a4981358f6a"},
+]
 packaging = [
     {file = "packaging-21.3-py3-none-any.whl", hash = "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"},
     {file = "packaging-21.3.tar.gz", hash = "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb"},
@@ -827,23 +1043,89 @@ platformdirs = [
     {file = "platformdirs-2.5.2-py3-none-any.whl", hash = "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788"},
     {file = "platformdirs-2.5.2.tar.gz", hash = "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"},
 ]
-pygments = []
-pylint = []
-pyparsing = []
-pytoolconfig = []
+pygments = [
+    {file = "Pygments-2.12.0-py3-none-any.whl", hash = "sha256:dc9c10fb40944260f6ed4c688ece0cd2048414940f1cea51b8b226318411c519"},
+    {file = "Pygments-2.12.0.tar.gz", hash = "sha256:5eb116118f9612ff1ee89ac96437bb6b49e8f04d8a13b514ba26f620208e26eb"},
+]
+pylint = [
+    {file = "pylint-2.13.9-py3-none-any.whl", hash = "sha256:705c620d388035bdd9ff8b44c5bcdd235bfb49d276d488dd2c8ff1736aa42526"},
+    {file = "pylint-2.13.9.tar.gz", hash = "sha256:095567c96e19e6f57b5b907e67d265ff535e588fe26b12b5ebe1fc5645b2c731"},
+]
+pyparsing = [
+    {file = "pyparsing-3.0.9-py3-none-any.whl", hash = "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"},
+    {file = "pyparsing-3.0.9.tar.gz", hash = "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb"},
+]
+pytoolconfig = [
+    {file = "pytoolconfig-1.2.1-py3-none-any.whl", hash = "sha256:5f291567f0363a7314406be4f2381ece4e552a8608d2629544679e4d36d0df2b"},
+    {file = "pytoolconfig-1.2.1.tar.gz", hash = "sha256:5ac82f78d731531f9f82e5cc7f5ebae9473b1404c0e75aa5ac0b8b41cd99b510"},
+]
 pytz = [
     {file = "pytz-2022.1-py2.py3-none-any.whl", hash = "sha256:e68985985296d9a66a881eb3193b0906246245294a881e7c8afe623866ac6a5c"},
     {file = "pytz-2022.1.tar.gz", hash = "sha256:1e760e2fe6a8163bc0b3d9a19c4f84342afa0a2affebfaa84b01b978a02ecaa7"},
 ]
-pyyaml = []
-requests = []
-rope = []
+pyyaml = [
+    {file = "PyYAML-6.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:d4db7c7aef085872ef65a8fd7d6d09a14ae91f691dec3e87ee5ee0539d516f53"},
+    {file = "PyYAML-6.0-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:9df7ed3b3d2e0ecfe09e14741b857df43adb5a3ddadc919a2d94fbdf78fea53c"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:77f396e6ef4c73fdc33a9157446466f1cff553d979bd00ecb64385760c6babdc"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:a80a78046a72361de73f8f395f1f1e49f956c6be882eed58505a15f3e430962b"},
+    {file = "PyYAML-6.0-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:f84fbc98b019fef2ee9a1cb3ce93e3187a6df0b2538a651bfb890254ba9f90b5"},
+    {file = "PyYAML-6.0-cp310-cp310-win32.whl", hash = "sha256:2cd5df3de48857ed0544b34e2d40e9fac445930039f3cfe4bcc592a1f836d513"},
+    {file = "PyYAML-6.0-cp310-cp310-win_amd64.whl", hash = "sha256:daf496c58a8c52083df09b80c860005194014c3698698d1a57cbcfa182142a3a"},
+    {file = "PyYAML-6.0-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:897b80890765f037df3403d22bab41627ca8811ae55e9a722fd0392850ec4d86"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:50602afada6d6cbfad699b0c7bb50d5ccffa7e46a3d738092afddc1f9758427f"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:48c346915c114f5fdb3ead70312bd042a953a8ce5c7106d5bfb1a5254e47da92"},
+    {file = "PyYAML-6.0-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98c4d36e99714e55cfbaaee6dd5badbc9a1ec339ebfc3b1f52e293aee6bb71a4"},
+    {file = "PyYAML-6.0-cp36-cp36m-win32.whl", hash = "sha256:0283c35a6a9fbf047493e3a0ce8d79ef5030852c51e9d911a27badfde0605293"},
+    {file = "PyYAML-6.0-cp36-cp36m-win_amd64.whl", hash = "sha256:07751360502caac1c067a8132d150cf3d61339af5691fe9e87803040dbc5db57"},
+    {file = "PyYAML-6.0-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:819b3830a1543db06c4d4b865e70ded25be52a2e0631ccd2f6a47a2822f2fd7c"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:473f9edb243cb1935ab5a084eb238d842fb8f404ed2193a915d1784b5a6b5fc0"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:0ce82d761c532fe4ec3f87fc45688bdd3a4c1dc5e0b4a19814b9009a29baefd4"},
+    {file = "PyYAML-6.0-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:231710d57adfd809ef5d34183b8ed1eeae3f76459c18fb4a0b373ad56bedcdd9"},
+    {file = "PyYAML-6.0-cp37-cp37m-win32.whl", hash = "sha256:c5687b8d43cf58545ade1fe3e055f70eac7a5a1a0bf42824308d868289a95737"},
+    {file = "PyYAML-6.0-cp37-cp37m-win_amd64.whl", hash = "sha256:d15a181d1ecd0d4270dc32edb46f7cb7733c7c508857278d3d378d14d606db2d"},
+    {file = "PyYAML-6.0-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0b4624f379dab24d3725ffde76559cff63d9ec94e1736b556dacdfebe5ab6d4b"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:213c60cd50106436cc818accf5baa1aba61c0189ff610f64f4a3e8c6726218ba"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9fa600030013c4de8165339db93d182b9431076eb98eb40ee068700c9c813e34"},
+    {file = "PyYAML-6.0-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:277a0ef2981ca40581a47093e9e2d13b3f1fbbeffae064c1d21bfceba2030287"},
+    {file = "PyYAML-6.0-cp38-cp38-win32.whl", hash = "sha256:d4eccecf9adf6fbcc6861a38015c2a64f38b9d94838ac1810a9023a0609e1b78"},
+    {file = "PyYAML-6.0-cp38-cp38-win_amd64.whl", hash = "sha256:1e4747bc279b4f613a09eb64bba2ba602d8a6664c6ce6396a4d0cd413a50ce07"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:055d937d65826939cb044fc8c9b08889e8c743fdc6a32b33e2390f66013e449b"},
+    {file = "PyYAML-6.0-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:e61ceaab6f49fb8bdfaa0f92c4b57bcfbea54c09277b1b4f7ac376bfb7a7c174"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d67d839ede4ed1b28a4e8909735fc992a923cdb84e618544973d7dfc71540803"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cba8c411ef271aa037d7357a2bc8f9ee8b58b9965831d9e51baf703280dc73d3"},
+    {file = "PyYAML-6.0-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:40527857252b61eacd1d9af500c3337ba8deb8fc298940291486c465c8b46ec0"},
+    {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
+    {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
+    {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
+]
+requests = [
+    {file = "requests-2.28.1-py3-none-any.whl", hash = "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"},
+    {file = "requests-2.28.1.tar.gz", hash = "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983"},
+]
+rfc3986 = [
+    {file = "rfc3986-1.5.0-py2.py3-none-any.whl", hash = "sha256:a86d6e1f5b1dc238b218b012df0aa79409667bb209e58da56d0b94704e712a97"},
+    {file = "rfc3986-1.5.0.tar.gz", hash = "sha256:270aaf10d87d0d4e095063c65bf3ddbc6ee3d0b226328ce21e036f946e421835"},
+]
+rope = [
+    {file = "rope-1.2.0-py3-none-any.whl", hash = "sha256:14e2e9b74ff345d038988fd62b7ef4226351e4a1181123596abb3a147fea9019"},
+    {file = "rope-1.2.0.tar.gz", hash = "sha256:f762542c9cfe52124aa55d33822a269fc4b0da70fe3170c6086de2733ed52f22"},
+]
+sniffio = [
+    {file = "sniffio-1.2.0-py3-none-any.whl", hash = "sha256:471b71698eac1c2112a40ce2752bb2f4a4814c22a54a3eed3676bc0f5ca9f663"},
+    {file = "sniffio-1.2.0.tar.gz", hash = "sha256:c4666eecec1d3f50960c6bdf61ab7bc350648da6c126e3cf6898d8cd4ddcd3de"},
+]
 snowballstemmer = [
     {file = "snowballstemmer-2.2.0-py2.py3-none-any.whl", hash = "sha256:c8e1716e83cc398ae16824e5572ae04e0d9fc2c6b985fb0f900f5f0c96ecba1a"},
     {file = "snowballstemmer-2.2.0.tar.gz", hash = "sha256:09b16deb8547d3412ad7b590689584cd0fe25ec8db3be37788be3810cbf19cb1"},
 ]
-sphinx = []
-sphinx-autodoc-typehints = []
+sphinx = [
+    {file = "Sphinx-5.0.2-py3-none-any.whl", hash = "sha256:d3e57663eed1d7c5c50895d191fdeda0b54ded6f44d5621b50709466c338d1e8"},
+    {file = "Sphinx-5.0.2.tar.gz", hash = "sha256:b18e978ea7565720f26019c702cd85c84376e948370f1cd43d60265010e1c7b0"},
+]
+sphinx-autodoc-typehints = [
+    {file = "sphinx_autodoc_typehints-1.18.3-py3-none-any.whl", hash = "sha256:20294de2a818bda04953c5cb302ec5af46138c81980ad9efa6d8fc1fc4242518"},
+    {file = "sphinx_autodoc_typehints-1.18.3.tar.gz", hash = "sha256:c04d8f8d70e988960e25b206af39a90df84e7e2c085bb24e123bc3684021b313"},
+]
 sphinxcontrib-applehelp = [
     {file = "sphinxcontrib-applehelp-1.0.2.tar.gz", hash = "sha256:a072735ec80e7675e3f432fcae8610ecf509c5f1869d17e2eecff44389cdbc58"},
     {file = "sphinxcontrib_applehelp-1.0.2-py2.py3-none-any.whl", hash = "sha256:806111e5e962be97c29ec4c1e7fe277bfd19e9652fb1a4392105b43e01af885a"},
@@ -872,9 +1154,111 @@ tomli = [
     {file = "tomli-2.0.1-py3-none-any.whl", hash = "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc"},
     {file = "tomli-2.0.1.tar.gz", hash = "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"},
 ]
-tomlkit = []
-typed-ast = []
-typing-extensions = []
-urllib3 = []
-wrapt = []
-zipp = []
+tomlkit = [
+    {file = "tomlkit-0.11.1-py3-none-any.whl", hash = "sha256:1c5bebdf19d5051e2e1de6cf70adfc5948d47221f097fcff7a3ffc91e953eaf5"},
+    {file = "tomlkit-0.11.1.tar.gz", hash = "sha256:61901f81ff4017951119cd0d1ed9b7af31c821d6845c8c477587bbdcd5e5854e"},
+]
+typed-ast = [
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:669dd0c4167f6f2cd9f57041e03c3c2ebf9063d0757dc89f79ba1daa2bfca9d4"},
+    {file = "typed_ast-1.5.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:211260621ab1cd7324e0798d6be953d00b74e0428382991adfddb352252f1d62"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:267e3f78697a6c00c689c03db4876dd1efdfea2f251a5ad6555e82a26847b4ac"},
+    {file = "typed_ast-1.5.4-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:c542eeda69212fa10a7ada75e668876fdec5f856cd3d06829e6aa64ad17c8dfe"},
+    {file = "typed_ast-1.5.4-cp310-cp310-win_amd64.whl", hash = "sha256:a9916d2bb8865f973824fb47436fa45e1ebf2efd920f2b9f99342cb7fab93f72"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:79b1e0869db7c830ba6a981d58711c88b6677506e648496b1f64ac7d15633aec"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a94d55d142c9265f4ea46fab70977a1944ecae359ae867397757d836ea5a3f47"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:183afdf0ec5b1b211724dfef3d2cad2d767cbefac291f24d69b00546c1837fb6"},
+    {file = "typed_ast-1.5.4-cp36-cp36m-win_amd64.whl", hash = "sha256:639c5f0b21776605dd6c9dbe592d5228f021404dafd377e2b7ac046b0349b1a1"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:cf4afcfac006ece570e32d6fa90ab74a17245b83dfd6655a6f68568098345ff6"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ed855bbe3eb3715fca349c80174cfcfd699c2f9de574d40527b8429acae23a66"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:6778e1b2f81dfc7bc58e4b259363b83d2e509a65198e85d5700dfae4c6c8ff1c"},
+    {file = "typed_ast-1.5.4-cp37-cp37m-win_amd64.whl", hash = "sha256:0261195c2062caf107831e92a76764c81227dae162c4f75192c0d489faf751a2"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2efae9db7a8c05ad5547d522e7dbe62c83d838d3906a3716d1478b6c1d61388d"},
+    {file = "typed_ast-1.5.4-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:7d5d014b7daa8b0bf2eaef684295acae12b036d79f54178b92a2b6a56f92278f"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:370788a63915e82fd6f212865a596a0fefcbb7d408bbbb13dea723d971ed8bdc"},
+    {file = "typed_ast-1.5.4-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4e964b4ff86550a7a7d56345c7864b18f403f5bd7380edf44a3c1fb4ee7ac6c6"},
+    {file = "typed_ast-1.5.4-cp38-cp38-win_amd64.whl", hash = "sha256:683407d92dc953c8a7347119596f0b0e6c55eb98ebebd9b23437501b28dcbb8e"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:4879da6c9b73443f97e731b617184a596ac1235fe91f98d279a7af36c796da35"},
+    {file = "typed_ast-1.5.4-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:3e123d878ba170397916557d31c8f589951e353cc95fb7f24f6bb69adc1a8a97"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ebd9d7f80ccf7a82ac5f88c521115cc55d84e35bf8b446fcd7836eb6b98929a3"},
+    {file = "typed_ast-1.5.4-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:98f80dee3c03455e92796b58b98ff6ca0b2a6f652120c263efdba4d6c5e58f72"},
+    {file = "typed_ast-1.5.4-cp39-cp39-win_amd64.whl", hash = "sha256:0fdbcf2fef0ca421a3f5912555804296f0b0960f0418c440f5d6d3abb549f3e1"},
+    {file = "typed_ast-1.5.4.tar.gz", hash = "sha256:39e21ceb7388e4bb37f4c679d72707ed46c2fbf2a5609b8b8ebc4b067d977df2"},
+]
+typing-extensions = [
+    {file = "typing_extensions-4.3.0-py3-none-any.whl", hash = "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02"},
+    {file = "typing_extensions-4.3.0.tar.gz", hash = "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"},
+]
+urllib3 = [
+    {file = "urllib3-1.26.10-py2.py3-none-any.whl", hash = "sha256:8298d6d56d39be0e3bc13c1c97d133f9b45d797169a0e11cdd0e0489d786f7ec"},
+    {file = "urllib3-1.26.10.tar.gz", hash = "sha256:879ba4d1e89654d9769ce13121e0f94310ea32e8d2f8cf587b77c08bbcdb30d6"},
+]
+wrapt = [
+    {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:903500616422a40a98a5a3c4ff4ed9d0066f3b4c951fa286018ecdf0750194ef"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:5a9a0d155deafd9448baff28c08e150d9b24ff010e899311ddd63c45c2445e28"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_i686.whl", hash = "sha256:ddaea91abf8b0d13443f6dac52e89051a5063c7d014710dcb4d4abb2ff811a59"},
+    {file = "wrapt-1.14.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:36f582d0c6bc99d5f39cd3ac2a9062e57f3cf606ade29a0a0d6b323462f4dd87"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:7ef58fb89674095bfc57c4069e95d7a31cfdc0939e2a579882ac7d55aadfd2a1"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:e2f83e18fe2f4c9e7db597e988f72712c0c3676d337d8b101f6758107c42425b"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_i686.whl", hash = "sha256:ee2b1b1769f6707a8a445162ea16dddf74285c3964f605877a20e38545c3c462"},
+    {file = "wrapt-1.14.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:833b58d5d0b7e5b9832869f039203389ac7cbf01765639c7309fd50ef619e0b1"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:80bb5c256f1415f747011dc3604b59bc1f91c6e7150bd7db03b19170ee06b320"},
+    {file = "wrapt-1.14.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:07f7a7d0f388028b2df1d916e94bbb40624c59b48ecc6cbc232546706fac74c2"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:02b41b633c6261feff8ddd8d11c711df6842aba629fdd3da10249a53211a72c4"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:2fe803deacd09a233e4762a1adcea5db5d31e6be577a43352936179d14d90069"},
+    {file = "wrapt-1.14.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:257fd78c513e0fb5cdbe058c27a0624c9884e735bbd131935fd49e9fe719d310"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:4fcc4649dc762cddacd193e6b55bc02edca674067f5f98166d7713b193932b7f"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_i686.whl", hash = "sha256:11871514607b15cfeb87c547a49bca19fde402f32e2b1c24a632506c0a756656"},
+    {file = "wrapt-1.14.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:8ad85f7f4e20964db4daadcab70b47ab05c7c1cf2a7c1e51087bfaa83831854c"},
+    {file = "wrapt-1.14.1-cp310-cp310-win32.whl", hash = "sha256:a9a52172be0b5aae932bef82a79ec0a0ce87288c7d132946d645eba03f0ad8a8"},
+    {file = "wrapt-1.14.1-cp310-cp310-win_amd64.whl", hash = "sha256:6d323e1554b3d22cfc03cd3243b5bb815a51f5249fdcbb86fda4bf62bab9e164"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:43ca3bbbe97af00f49efb06e352eae40434ca9d915906f77def219b88e85d907"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6b1a564e6cb69922c7fe3a678b9f9a3c54e72b469875aa8018f18b4d1dd1adf3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_i686.whl", hash = "sha256:00b6d4ea20a906c0ca56d84f93065b398ab74b927a7a3dbd470f6fc503f95dc3"},
+    {file = "wrapt-1.14.1-cp35-cp35m-manylinux2010_x86_64.whl", hash = "sha256:a85d2b46be66a71bedde836d9e41859879cc54a2a04fad1191eb50c2066f6e9d"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win32.whl", hash = "sha256:dbcda74c67263139358f4d188ae5faae95c30929281bc6866d00573783c422b7"},
+    {file = "wrapt-1.14.1-cp35-cp35m-win_amd64.whl", hash = "sha256:b21bb4c09ffabfa0e85e3a6b623e19b80e7acd709b9f91452b8297ace2a8ab00"},
+    {file = "wrapt-1.14.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:9e0fd32e0148dd5dea6af5fee42beb949098564cc23211a88d799e434255a1f4"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9736af4641846491aedb3c3f56b9bc5568d92b0692303b5a305301a95dfd38b1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:5b02d65b9ccf0ef6c34cba6cf5bf2aab1bb2f49c6090bafeecc9cd81ad4ea1c1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:21ac0156c4b089b330b7666db40feee30a5d52634cc4560e1905d6529a3897ff"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_aarch64.whl", hash = "sha256:9f3e6f9e05148ff90002b884fbc2a86bd303ae847e472f44ecc06c2cd2fcdb2d"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_i686.whl", hash = "sha256:6e743de5e9c3d1b7185870f480587b75b1cb604832e380d64f9504a0535912d1"},
+    {file = "wrapt-1.14.1-cp36-cp36m-musllinux_1_1_x86_64.whl", hash = "sha256:d79d7d5dc8a32b7093e81e97dad755127ff77bcc899e845f41bf71747af0c569"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win32.whl", hash = "sha256:81b19725065dcb43df02b37e03278c011a09e49757287dca60c5aecdd5a0b8ed"},
+    {file = "wrapt-1.14.1-cp36-cp36m-win_amd64.whl", hash = "sha256:b014c23646a467558be7da3d6b9fa409b2c567d2110599b7cf9a0c5992b3b471"},
+    {file = "wrapt-1.14.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:88bd7b6bd70a5b6803c1abf6bca012f7ed963e58c68d76ee20b9d751c74a3248"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b5901a312f4d14c59918c221323068fad0540e34324925c8475263841dbdfe68"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d77c85fedff92cf788face9bfa3ebaa364448ebb1d765302e9af11bf449ca36d"},
+    {file = "wrapt-1.14.1-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8d649d616e5c6a678b26d15ece345354f7c2286acd6db868e65fcc5ff7c24a77"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_aarch64.whl", hash = "sha256:7d2872609603cb35ca513d7404a94d6d608fc13211563571117046c9d2bcc3d7"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_i686.whl", hash = "sha256:ee6acae74a2b91865910eef5e7de37dc6895ad96fa23603d1d27ea69df545015"},
+    {file = "wrapt-1.14.1-cp37-cp37m-musllinux_1_1_x86_64.whl", hash = "sha256:2b39d38039a1fdad98c87279b48bc5dce2c0ca0d73483b12cb72aa9609278e8a"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win32.whl", hash = "sha256:60db23fa423575eeb65ea430cee741acb7c26a1365d103f7b0f6ec412b893853"},
+    {file = "wrapt-1.14.1-cp37-cp37m-win_amd64.whl", hash = "sha256:709fe01086a55cf79d20f741f39325018f4df051ef39fe921b1ebe780a66184c"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:8c0ce1e99116d5ab21355d8ebe53d9460366704ea38ae4d9f6933188f327b456"},
+    {file = "wrapt-1.14.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:e3fb1677c720409d5f671e39bac6c9e0e422584e5f518bfd50aa4cbbea02433f"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:642c2e7a804fcf18c222e1060df25fc210b9c58db7c91416fb055897fc27e8cc"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:7b7c050ae976e286906dd3f26009e117eb000fb2cf3533398c5ad9ccc86867b1"},
+    {file = "wrapt-1.14.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef3f72c9666bba2bab70d2a8b79f2c6d2c1a42a7f7e2b0ec83bb2f9e383950af"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_aarch64.whl", hash = "sha256:01c205616a89d09827986bc4e859bcabd64f5a0662a7fe95e0d359424e0e071b"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_i686.whl", hash = "sha256:5a0f54ce2c092aaf439813735584b9537cad479575a09892b8352fea5e988dc0"},
+    {file = "wrapt-1.14.1-cp38-cp38-musllinux_1_1_x86_64.whl", hash = "sha256:2cf71233a0ed05ccdabe209c606fe0bac7379fdcf687f39b944420d2a09fdb57"},
+    {file = "wrapt-1.14.1-cp38-cp38-win32.whl", hash = "sha256:aa31fdcc33fef9eb2552cbcbfee7773d5a6792c137b359e82879c101e98584c5"},
+    {file = "wrapt-1.14.1-cp38-cp38-win_amd64.whl", hash = "sha256:d1967f46ea8f2db647c786e78d8cc7e4313dbd1b0aca360592d8027b8508e24d"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:3232822c7d98d23895ccc443bbdf57c7412c5a65996c30442ebe6ed3df335383"},
+    {file = "wrapt-1.14.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:988635d122aaf2bdcef9e795435662bcd65b02f4f4c1ae37fbee7401c440b3a7"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9cca3c2cdadb362116235fdbd411735de4328c61425b0aa9f872fd76d02c4e86"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_i686.manylinux1_i686.manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:d52a25136894c63de15a35bc0bdc5adb4b0e173b9c0d07a2be9d3ca64a332735"},
+    {file = "wrapt-1.14.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:40e7bc81c9e2b2734ea4bc1aceb8a8f0ceaac7c5299bc5d69e37c44d9081d43b"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_aarch64.whl", hash = "sha256:b9b7a708dd92306328117d8c4b62e2194d00c365f18eff11a9b53c6f923b01e3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_i686.whl", hash = "sha256:6a9a25751acb379b466ff6be78a315e2b439d4c94c1e99cb7266d40a537995d3"},
+    {file = "wrapt-1.14.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:34aa51c45f28ba7f12accd624225e2b1e5a3a45206aa191f6f9aac931d9d56fe"},
+    {file = "wrapt-1.14.1-cp39-cp39-win32.whl", hash = "sha256:dee0ce50c6a2dd9056c20db781e9c1cfd33e77d2d569f5d1d9321c641bb903d5"},
+    {file = "wrapt-1.14.1-cp39-cp39-win_amd64.whl", hash = "sha256:dee60e1de1898bde3b238f18340eec6148986da0455d8ba7848d50470a7a32fb"},
+    {file = "wrapt-1.14.1.tar.gz", hash = "sha256:380a85cf89e0e69b7cfbe2ea9f765f004ff419f34194018a6827ac0e3edfed4d"},
+]
+zipp = [
+    {file = "zipp-3.8.1-py3-none-any.whl", hash = "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"},
+    {file = "zipp-3.8.1.tar.gz", hash = "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2"},
+]

--- a/poetry.lock
+++ b/poetry.lock
@@ -133,7 +133,7 @@ python-versions = ">=3.6"
 name = "charset-normalizer"
 version = "2.1.0"
 description = "The Real First Universal Charset Detector. Open, modern and actively maintained alternative to Chardet."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.6.0"
 
@@ -519,7 +519,7 @@ python-versions = ">=3.6"
 name = "requests"
 version = "2.28.1"
 description = "Python HTTP for Humans."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=3.7, <4"
 
@@ -732,7 +732,7 @@ python-versions = ">=3.7"
 name = "urllib3"
 version = "1.26.10"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
-category = "main"
+category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*, !=3.5.*, <4"
 
@@ -764,7 +764,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "2c90824a6290567ab24e497920419b4ca0a9bbd23e24d243694987a002b165b2"
+content-hash = "33699c68add71ad75c6b35ec6e4afe318a5b82b1adf8b08508a276478289f594"
 
 [metadata.files]
 alabaster = [

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -68,12 +68,15 @@ class GitHubRESTApi:
             headers["Authorization"] = f"token {self.token}"
 
         request = request or httpx.get
+        kwargs = {}
+        if data is not None:
+            kwargs["json"] = data
         return request(
             f"{url}",
             headers=headers,
             params=params,
-            json=data,
             follow_redirects=True,
+            **kwargs,
         )
 
     def _request(

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -18,7 +18,15 @@
 from collections import defaultdict
 from enum import Enum
 from pathlib import Path
-from typing import Callable, Dict, Generator, Iterable, Iterator, List, Optional
+from typing import (
+    Callable,
+    ContextManager,
+    Dict,
+    Iterable,
+    Iterator,
+    List,
+    Optional,
+)
 
 import httpx
 
@@ -328,7 +336,7 @@ class GitHubRESTApi:
 
     def download_release_tarball(
         self, repo: str, tag: str, destination: Path
-    ) -> Generator[DownloadProgressIterable, None, None]:
+    ) -> ContextManager[DownloadProgressIterable]:
         """
         Download a release tarball (tar.gz) file
 
@@ -345,7 +353,7 @@ class GitHubRESTApi:
 
     def download_release_zip(
         self, repo: str, tag: str, destination: Path
-    ) -> Generator[DownloadProgressIterable, None, None]:
+    ) -> ContextManager[DownloadProgressIterable]:
         """
         Download a release zip file
 

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -376,6 +376,16 @@ class GitHubRESTApi:
         repo: str,
         tag: str,
     ) -> Iterator[DownloadProgressIterable]:
+        """
+        Download release assets
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            tag: The git tag for the release
+
+        Raises:
+            HTTPError if the request was invalid
+        """
         release_json = self.release(repo, tag)
         assets_url = release_json.get("assets_url")
         if not assets_url:

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -46,7 +46,9 @@ def _get_next_url(response) -> Optional[str]:
 
 class GitHubRESTApi:
     def __init__(
-        self, token: str, url: Optional[str] = DEFAULT_GITHUB_API_URL
+        self,
+        token: Optional[str] = None,
+        url: Optional[str] = DEFAULT_GITHUB_API_URL,
     ) -> None:
         self.token = token
         self.url = url
@@ -60,9 +62,11 @@ class GitHubRESTApi:
         request: Optional[Callable] = None,
     ) -> httpx.Response:
         headers = {
-            "Authorization": f"token {self.token}",
             "Accept": "application/vnd.github.v3+json",
         }
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+
         request = request or httpx.get
         return request(
             f"{url}",

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -67,6 +67,7 @@ class GitHubRESTApi:
         *,
         params: Optional[Dict[str, str]] = None,
         data: Optional[Dict[str, str]] = None,
+        content: Optional[bytes] = None,
         request: Optional[Callable] = None,
     ) -> httpx.Response:
         headers = {
@@ -79,6 +80,8 @@ class GitHubRESTApi:
         kwargs = {}
         if data is not None:
             kwargs["json"] = data
+        if content is not None:
+            kwargs["content"] = content
         return request(
             f"{url}",
             headers=headers,

--- a/pontos/github/cmds.py
+++ b/pontos/github/cmds.py
@@ -18,7 +18,7 @@
 import sys
 from argparse import Namespace
 
-import requests
+import httpx
 
 from pontos.github.api import GitHubRESTApi
 from pontos.terminal import Terminal
@@ -58,7 +58,7 @@ def create_pull_request(terminal: Terminal, args: Namespace):
             title=args.title,
             body=args.body,
         )
-    except requests.exceptions.RequestException as e:
+    except httpx.HTTPError as e:
         terminal.error(str(e))
         sys.exit(1)
 
@@ -86,7 +86,7 @@ def update_pull_request(terminal: Terminal, args: Namespace):
             title=args.title,
             body=args.body,
         )
-    except requests.exceptions.RequestException as e:
+    except httpx.HTTPError as e:
         terminal.error(str(e))
         sys.exit(1)
 
@@ -123,7 +123,7 @@ def file_status(terminal: Terminal, args: Namespace):
             if args.output:
                 args.output.write("\n".join(files) + "\n")
 
-    except requests.exceptions.RequestException as e:
+    except httpx.HTTPError as e:
         terminal.error(str(e))
         sys.exit(1)
 
@@ -150,6 +150,6 @@ def labels(terminal: Terminal, args: Namespace):
 
         git.set_labels(repo=args.repo, issue=args.issue, labels=issue_labels)
 
-    except requests.exceptions.RequestException as e:
+    except httpx.HTTPError as e:
         terminal.error(str(e))
         sys.exit(1)

--- a/pontos/release/main.py
+++ b/pontos/release/main.py
@@ -25,9 +25,6 @@ from argparse import ArgumentParser, FileType, Namespace
 from pathlib import Path
 from typing import Tuple
 
-import requests
-
-from pontos import changelog, version
 from pontos.terminal.terminal import ConsoleTerminal
 
 from .prepare import prepare
@@ -225,10 +222,6 @@ def parse_args(args) -> Tuple[str, str, Namespace]:
 
 
 def main(
-    _path: Path = Path,
-    _requests: requests = requests,
-    _version: version = version,
-    _changelog: changelog = changelog,
     leave: bool = True,
     args=None,
 ):

--- a/pontos/release/main.py
+++ b/pontos/release/main.py
@@ -216,8 +216,8 @@ def parse_args(args) -> Tuple[str, str, Namespace]:
         "--dry-run", action="store_true", help="Do not upload signed files."
     )
     parsed_args = parser.parse_args(args)
-    token = os.environ["GITHUB_TOKEN"] if not args else "TOKEN"
-    user = os.environ["GITHUB_USER"] if not args else "USER"
+    token = os.getenv("GITHUB_TOKEN") if not args else "TOKEN"
+    user = os.getenv("GITHUB_USER") if not args else "USER"
     return user, token, parsed_args
 
 

--- a/pontos/release/sign.py
+++ b/pontos/release/sign.py
@@ -1,5 +1,3 @@
-# -*- coding: utf-8 -*-
-# pontos/release/release.py
 # Copyright (C) 2020-2022 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
@@ -18,22 +16,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-import json
 from argparse import Namespace
+from pathlib import Path
 
-import requests
-
+from pontos.github.api import GitHubRESTApi
 from pontos.helper import DownloadProgressIterable, shell_cmd_runner
 from pontos.terminal import Terminal
 from pontos.terminal.terminal import Signs
 
-from .helper import (
-    download,
-    download_assets,
-    get_current_version,
-    get_project_name,
-    upload_assets,
-)
+from .helper import get_current_version, get_project_name, upload_assets
 
 
 def display_download_progress(
@@ -60,7 +51,6 @@ def sign(
     terminal: Terminal,
     args: Namespace,
     *,
-    username: str,
     token: str,
     **_kwargs,
 ) -> bool:
@@ -78,57 +68,30 @@ def sign(
     )
     signing_key: str = args.signing_key
 
-    headers = {"Accept": "application/vnd.github.v3+json"}
-
     git_version: str = f"{git_tag_prefix}{release_version}"
+    repo = f"{space}/{project}"
 
-    base_url = (
-        f"https://api.github.com/repos/{space}/{project}"
-        f"/releases/tags/{git_version}"
-    )
+    github = GitHubRESTApi(token=token)
 
-    response = requests.get(
-        base_url,
-        headers=headers,
-    )
-    if response.status_code != 200:
-        terminal.error(
-            f"Wrong response status code {response.status_code} for request "
-            f"{base_url}"
-        )
-        terminal.print(json.dumps(response.text, indent=4, sort_keys=True))
+    if not github.release_exists(repo, git_version):
+        terminal.error(f"Release version {git_version} does not exist.")
         return False
 
-    zipball_url = (
-        f"https://github.com/{space}/{project}/archive/refs/"
-        f"tags/{git_version}.zip"
-    )
-    github_json = json.loads(response.text)
-    zip_progress = download(
-        terminal,
-        zipball_url,
-        f"{project}-{release_version}.zip",
-    )
-    display_download_progress(terminal, zip_progress)
+    zip_destination = Path(f"{project}-{release_version}.zip")
+    with github.download_release_zip(
+        repo, git_version, zip_destination
+    ) as zip_progress:
+        display_download_progress(terminal, zip_progress)
 
-    tarball_url = (
-        f"https://github.com/{space}/{project}/archive/refs/"
-        f"tags/{git_version}.tar.gz"
-    )
-    tar_progress = download(
-        terminal,
-        tarball_url,
-        f"{project}-{release_version}.tar.gz",
-    )
-    display_download_progress(terminal, tar_progress)
+    tarball_destination = Path(f"{project}-{release_version}.tar.gz")
+    with github.download_release_tarball(
+        repo, git_version, tarball_destination
+    ) as tar_progress:
+        display_download_progress(terminal, tar_progress)
 
-    file_paths = [zip_progress.destination, tar_progress.destination]
+    file_paths = [zip_destination, tarball_destination]
 
-    assets_progress = download_assets(
-        terminal,
-        github_json.get("assets_url"),
-    )
-    for progress in assets_progress:
+    for progress in github.download_release_assets(repo, git_version):
         file_paths.append(progress.destination)
         display_download_progress(terminal, progress)
 
@@ -150,10 +113,11 @@ def sign(
     if args.dry_run:
         return True
 
+    github_json = github.release(repo, git_version)
+    asset_url = github_json["upload_url"].replace("{?name,label}", "")
     return upload_assets(
         terminal,
-        username,
         token,
         file_paths,
-        github_json,
+        asset_url,
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ python = "^3.7"
 colorful = "^0.5.4"
 tomlkit = ">=0.5.11"
 packaging = ">=20.3"
-requests = "^2.24.0"
 httpx = "^0.23.0"
 
 [tool.poetry.dev-dependencies]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,7 @@ colorful = "^0.5.4"
 tomlkit = ">=0.5.11"
 packaging = ">=20.3"
 requests = "^2.24.0"
+httpx = "^0.23.0"
 
 [tool.poetry.dev-dependencies]
 autohooks = ">=22.7.0"

--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -44,7 +44,6 @@ class GitHubApiTestCase(unittest.TestCase):
                 "Accept": "application/vnd.github.v3+json",
             },
             params=None,
-            json=None,
         )
         self.assertTrue(exists)
 
@@ -65,7 +64,6 @@ class GitHubApiTestCase(unittest.TestCase):
                 "Accept": "application/vnd.github.v3+json",
             },
             params=None,
-            json=None,
         )
         self.assertFalse(exists)
 
@@ -85,7 +83,6 @@ class GitHubApiTestCase(unittest.TestCase):
                 "Accept": "application/vnd.github.v3+json",
             },
             params={"per_page": "100"},
-            json=None,
             follow_redirects=True,
         )
 
@@ -176,7 +173,6 @@ class GitHubApiTestCase(unittest.TestCase):
                 "Accept": "application/vnd.github.v3+json",
             },
             params=None,
-            json=None,
         )
 
     @patch("pontos.github.api.httpx.post")
@@ -224,7 +220,6 @@ class GitHubApiTestCase(unittest.TestCase):
                 "Accept": "application/vnd.github.v3+json",
             },
             params=None,
-            json=None,
         )
         self.assertTrue(exists)
 
@@ -248,7 +243,6 @@ class GitHubApiTestCase(unittest.TestCase):
                 "Accept": "application/vnd.github.v3+json",
             },
             params=None,
-            json=None,
         )
 
         self.assertEqual(data["id"], 52499047)
@@ -394,7 +388,6 @@ class GitHubApiTestCase(unittest.TestCase):
                 "Accept": "application/vnd.github.v3+json",
             },
             params={"per_page": "100"},
-            json=None,
         )
 
         self.assertEqual(
@@ -433,7 +426,6 @@ class GitHubApiTestCase(unittest.TestCase):
                 "Accept": "application/vnd.github.v3+json",
             },
             params={"per_page": "100"},
-            json=None,
         )
 
         self.assertEqual(

--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -31,7 +31,7 @@ here = Path(__file__).parent
 
 
 class GitHubApiTestCase(unittest.TestCase):
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.get")
     def test_branch_exists(self, requests_mock: MagicMock):
         response = MagicMock()
         response.ok = True
@@ -42,6 +42,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/foo/bar/branches/main",
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -51,10 +52,10 @@ class GitHubApiTestCase(unittest.TestCase):
         )
         self.assertTrue(exists)
 
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.get")
     def test_branch_not_exists(self, requests_mock: MagicMock):
         response = MagicMock()
-        response.ok = False
+        response.is_success = False
         requests_mock.return_value = response
 
         api = GitHubRESTApi("12345")
@@ -62,6 +63,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/foo/bar/branches/main",
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -71,7 +73,7 @@ class GitHubApiTestCase(unittest.TestCase):
         )
         self.assertFalse(exists)
 
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.get")
     def test_pull_request_commits(self, requests_mock: MagicMock):
         response = MagicMock()
         response.links = None
@@ -88,12 +90,13 @@ class GitHubApiTestCase(unittest.TestCase):
             },
             params={"per_page": "100"},
             json=None,
+            follow_redirects=True,
         )
 
         self.assertEqual(len(commits), 1)
         self.assertEqual(commits[0]["sha"], "1")
 
-    @patch("pontos.github.api.requests.post")
+    @patch("pontos.github.api.httpx.post")
     def test_create_pull_request(self, requests_mock: MagicMock):
         api = GitHubRESTApi("12345")
         api.create_pull_request(
@@ -106,6 +109,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/foo/bar/pulls",
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -119,7 +123,7 @@ class GitHubApiTestCase(unittest.TestCase):
             },
         )
 
-    @patch("pontos.github.api.requests.post")
+    @patch("pontos.github.api.httpx.post")
     def test_update_pull_request(self, requests_mock: MagicMock):
         api = GitHubRESTApi("12345")
         api.update_pull_request(
@@ -132,6 +136,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/foo/bar/pulls/123",
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -144,7 +149,7 @@ class GitHubApiTestCase(unittest.TestCase):
             },
         )
 
-    @patch("pontos.github.api.requests.post")
+    @patch("pontos.github.api.httpx.post")
     def test_add_pull_request_comment(self, requests_mock: MagicMock):
         api = GitHubRESTApi("12345")
         api.add_pull_request_comment(
@@ -153,6 +158,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/foo/bar/issues/123/comments",
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -161,13 +167,14 @@ class GitHubApiTestCase(unittest.TestCase):
             json={"body": "This is a comment"},
         )
 
-    @patch("pontos.github.api.requests.delete")
+    @patch("pontos.github.api.httpx.delete")
     def test_delete_branch(self, requests_mock: MagicMock):
         api = GitHubRESTApi("12345")
         api.delete_branch("foo/bar", "foo")
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/foo/bar/git/refs/foo",
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -176,7 +183,7 @@ class GitHubApiTestCase(unittest.TestCase):
             json=None,
         )
 
-    @patch("pontos.github.api.requests.post")
+    @patch("pontos.github.api.httpx.post")
     def test_create_release(self, requests_mock: MagicMock):
         api = GitHubRESTApi("12345")
         api.create_release(
@@ -188,6 +195,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/foo/bar/releases",
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -203,7 +211,7 @@ class GitHubApiTestCase(unittest.TestCase):
             },
         )
 
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.get")
     def test_release_exists(self, requests_mock: MagicMock):
         response = MagicMock()
         response.ok = True
@@ -214,6 +222,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/foo/bar/releases/tags/v1.2.3",
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -223,7 +232,7 @@ class GitHubApiTestCase(unittest.TestCase):
         )
         self.assertTrue(exists)
 
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.get")
     def test_release(self, requests_mock: MagicMock):
         response = MagicMock()
         response.json.return_value = json.loads(
@@ -237,6 +246,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/greenbone/pontos/releases/tags/v21.11.0",  # pylint: disable=line-too-long
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -248,120 +258,126 @@ class GitHubApiTestCase(unittest.TestCase):
         self.assertEqual(data["id"], 52499047)
 
     @patch("pontos.github.api.Path")
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.stream")
     def test_download_release_tarball(
         self, requests_mock: MagicMock, path_mock: MagicMock
     ):
         response = MagicMock()
-        response.iter_content.return_value = ["foo", "bar", "baz"]
+        response.iter_bytes.return_value = [b"foo", b"bar", b"baz"]
         response_headers = MagicMock()
         response.headers = response_headers
         response_headers.get.return_value = None
-        requests_mock.return_value = response
+        response_stream = MagicMock()
+        response_stream.__enter__.return_value = response
+        requests_mock.return_value = response_stream
 
         api = GitHubRESTApi("12345")
         download_file = path_mock()
-        download_progress = api.download_release_tarball(
+        with api.download_release_tarball(
             "greenbone/pontos", "v21.11.0", download_file
-        )
+        ) as download_progress:
+            requests_mock.assert_called_once_with(
+                "GET",
+                "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
+                follow_redirects=True,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            response_headers.get.assert_called_once_with("content-length")
 
-        requests_mock.assert_called_once_with(
-            "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
-            stream=True,
-            timeout=DEFAULT_TIMEOUT,
-        )
-        response_headers.get.assert_called_once_with("content-length")
+            self.assertIsNone(download_progress.length)
 
-        self.assertIsNone(download_progress.length)
+            it = iter(download_progress)
+            progress = next(it)
+            self.assertIsNone(progress)
+            progress = next(it)
+            self.assertIsNone(progress)
+            progress = next(it)
+            self.assertIsNone(progress)
 
-        it = iter(download_progress)
-        progress = next(it)
-        self.assertIsNone(progress)
-        progress = next(it)
-        self.assertIsNone(progress)
-        progress = next(it)
-        self.assertIsNone(progress)
-
-        with self.assertRaises(StopIteration):
-            next(it)
+            with self.assertRaises(StopIteration):
+                next(it)
 
     @patch("pontos.github.api.Path")
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.stream")
     def test_download_release_tarball_with_content_length(
         self, requests_mock: MagicMock, path_mock: MagicMock
     ):
         response = MagicMock()
-        response.iter_content.return_value = ["foo", "bar", "baz"]
+        response.iter_bytes.return_value = [b"foo", b"bar", b"baz"]
         response_headers = MagicMock()
         response.headers = response_headers
         response_headers.get.return_value = "9"
-        requests_mock.return_value = response
+        response_stream = MagicMock()
+        response_stream.__enter__.return_value = response
+        requests_mock.return_value = response_stream
 
         api = GitHubRESTApi("12345")
         download_file = path_mock()
-        download_progress = api.download_release_tarball(
+        with api.download_release_tarball(
             "greenbone/pontos", "v21.11.0", download_file
-        )
+        ) as download_progress:
+            requests_mock.assert_called_once_with(
+                "GET",
+                "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
+                follow_redirects=True,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            response_headers.get.assert_called_once_with("content-length")
 
-        requests_mock.assert_called_once_with(
-            "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
-            stream=True,
-            timeout=DEFAULT_TIMEOUT,
-        )
-        response_headers.get.assert_called_once_with("content-length")
+            self.assertEqual(download_progress.length, 9)
 
-        self.assertEqual(download_progress.length, 9)
+            it = iter(download_progress)
+            progress = next(it)
+            self.assertEqual(progress, 1 / 3)
+            progress = next(it)
+            self.assertEqual(progress, 2 / 3)
+            progress = next(it)
+            self.assertEqual(progress, 1)
 
-        it = iter(download_progress)
-        progress = next(it)
-        self.assertEqual(progress, 1 / 3)
-        progress = next(it)
-        self.assertEqual(progress, 2 / 3)
-        progress = next(it)
-        self.assertEqual(progress, 1)
-
-        with self.assertRaises(StopIteration):
-            next(it)
+            with self.assertRaises(StopIteration):
+                next(it)
 
     @patch("pontos.github.api.Path")
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.stream")
     def test_download_release_zip(
         self, requests_mock: MagicMock, path_mock: MagicMock
     ):
         response = MagicMock()
-        response.iter_content.return_value = ["foo", "bar", "baz"]
+        response.iter_bytes.return_value = [b"foo", b"bar", b"baz"]
         response_headers = MagicMock()
         response.headers = response_headers
         response_headers.get.return_value = None
-        requests_mock.return_value = response
+        response_stream = MagicMock()
+        response_stream.__enter__.return_value = response
+        requests_mock.return_value = response_stream
 
         api = GitHubRESTApi("12345")
         download_file = path_mock()
-        download_progress = api.download_release_zip(
+        with api.download_release_zip(
             "greenbone/pontos", "v21.11.0", download_file
-        )
+        ) as download_progress:
+            requests_mock.assert_called_once_with(
+                "GET",
+                "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.zip",  # pylint: disable=line-too-long
+                follow_redirects=True,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            response_headers.get.assert_called_once_with("content-length")
 
-        requests_mock.assert_called_once_with(
-            "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.zip",  # pylint: disable=line-too-long
-            stream=True,
-            timeout=DEFAULT_TIMEOUT,
-        )
-        response_headers.get.assert_called_once_with("content-length")
+            self.assertIsNone(download_progress.length)
 
-        self.assertIsNone(download_progress.length)
+            it = iter(download_progress)
+            progress = next(it)
+            self.assertIsNone(progress)
+            progress = next(it)
+            self.assertIsNone(progress)
+            progress = next(it)
+            self.assertIsNone(progress)
 
-        it = iter(download_progress)
-        progress = next(it)
-        self.assertIsNone(progress)
-        progress = next(it)
-        self.assertIsNone(progress)
-        progress = next(it)
-        self.assertIsNone(progress)
+            with self.assertRaises(StopIteration):
+                next(it)
 
-        with self.assertRaises(StopIteration):
-            next(it)
-
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.get")
     def test_modified_files_in_pr(self, requests_mock: MagicMock):
         response = MagicMock()
         response.links = None
@@ -376,6 +392,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/foo/bar/pulls/1/files",
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -399,7 +416,7 @@ class GitHubApiTestCase(unittest.TestCase):
             },
         )
 
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.get")
     def test_added_files_in_pr(self, requests_mock: MagicMock):
         response = MagicMock()
         response.links = None
@@ -414,6 +431,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         requests_mock.assert_called_once_with(
             "https://api.github.com/repos/foo/bar/pulls/1/files",
+            follow_redirects=True,
             headers={
                 "Authorization": "token 12345",
                 "Accept": "application/vnd.github.v3+json",
@@ -437,89 +455,97 @@ class GitHubApiTestCase(unittest.TestCase):
 
 
 class DownloadTestCase(unittest.TestCase):
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.stream")
     def test_download_without_destination(
         self,
         requests_mock: MagicMock,
     ):
         response = MagicMock()
-        response.iter_content.return_value = [b"foo", b"bar", b"baz"]
+        response.iter_bytes.return_value = [b"foo", b"bar", b"baz"]
         response_headers = MagicMock()
         response.headers = response_headers
         response_headers.get.return_value = None
-        requests_mock.return_value = response
+        response_stream = MagicMock()
+        response_stream.__enter__.return_value = response
+        requests_mock.return_value = response_stream
 
-        download_progress = download(
+        with download(
             "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz"  # pylint: disable=line-too-long
-        )
+        ) as download_progress:
 
-        requests_mock.assert_called_once_with(
-            "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
-            stream=True,
-            timeout=DEFAULT_TIMEOUT,
-        )
-        response_headers.get.assert_called_once_with("content-length")
+            requests_mock.assert_called_once_with(
+                "GET",
+                "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
+                follow_redirects=True,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            response_headers.get.assert_called_once_with("content-length")
 
-        self.assertIsNone(download_progress.length)
-        self.assertEqual(download_progress.destination, Path("v21.11.0.tar.gz"))
+            self.assertIsNone(download_progress.length)
+            self.assertEqual(
+                download_progress.destination, Path("v21.11.0.tar.gz")
+            )
 
-        it = iter(download_progress)
-        progress = next(it)
-        self.assertIsNone(progress)
-        progress = next(it)
-        self.assertIsNone(progress)
-        progress = next(it)
-        self.assertIsNone(progress)
+            it = iter(download_progress)
+            progress = next(it)
+            self.assertIsNone(progress)
+            progress = next(it)
+            self.assertIsNone(progress)
+            progress = next(it)
+            self.assertIsNone(progress)
 
-        with self.assertRaises(StopIteration):
-            next(it)
+            with self.assertRaises(StopIteration):
+                next(it)
 
-        download_progress.destination.unlink()
+            download_progress.destination.unlink()
 
     @patch("pontos.github.api.Path")
-    @patch("pontos.github.api.requests.get")
+    @patch("pontos.github.api.httpx.stream")
     def test_download_with_content_length(
         self, requests_mock: MagicMock, path_mock: MagicMock
     ):
         response = MagicMock()
-        response.iter_content.return_value = ["foo", "bar", "baz"]
+        response.iter_bytes.return_value = [b"foo", b"bar", b"baz"]
         response_headers = MagicMock()
         response.headers = response_headers
         response_headers.get.return_value = "9"
-        requests_mock.return_value = response
+        response_stream = MagicMock()
+        response_stream.__enter__.return_value = response
+        requests_mock.return_value = response_stream
 
         download_file = path_mock()
         file_mock = MagicMock()
         file_mock.__enter__.return_value = file_mock
         download_file.open.return_value = file_mock
 
-        download_progress = download(
+        with download(
             "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
             download_file,
-        )
+        ) as download_progress:
 
-        requests_mock.assert_called_once_with(
-            "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
-            stream=True,
-            timeout=DEFAULT_TIMEOUT,
-        )
-        response_headers.get.assert_called_once_with("content-length")
+            requests_mock.assert_called_once_with(
+                "GET",
+                "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
+                timeout=DEFAULT_TIMEOUT,
+                follow_redirects=True,
+            )
+            response_headers.get.assert_called_once_with("content-length")
 
-        self.assertEqual(download_progress.length, 9)
+            self.assertEqual(download_progress.length, 9)
 
-        it = iter(download_progress)
+            it = iter(download_progress)
 
-        progress = next(it)
-        self.assertEqual(progress, 1 / 3)
-        file_mock.write.assert_called_with("foo")
+            progress = next(it)
+            self.assertEqual(progress, 1 / 3)
+            file_mock.write.assert_called_with(b"foo")
 
-        progress = next(it)
-        self.assertEqual(progress, 2 / 3)
-        file_mock.write.assert_called_with("bar")
+            progress = next(it)
+            self.assertEqual(progress, 2 / 3)
+            file_mock.write.assert_called_with(b"bar")
 
-        progress = next(it)
-        self.assertEqual(progress, 1)
-        file_mock.write.assert_called_with("baz")
+            progress = next(it)
+            self.assertEqual(progress, 1)
+            file_mock.write.assert_called_with(b"baz")
 
-        with self.assertRaises(StopIteration):
-            next(it)
+            with self.assertRaises(StopIteration):
+                next(it)

--- a/tests/release/test_prepare.py
+++ b/tests/release/test_prepare.py
@@ -25,8 +25,6 @@ from pathlib import Path
 from subprocess import CompletedProcess
 from unittest.mock import call, patch
 
-import requests
-
 from pontos import changelog, release
 from pontos.release.helper import version
 
@@ -187,14 +185,12 @@ class PrepareTestCase(unittest.TestCase):
 
     @patch("pontos.release.prepare.shell_cmd_runner")
     @patch("pontos.release.prepare.Path", spec=Path)
-    @patch("pontos.release.release.requests", spec=requests)
     @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.release.prepare.changelog", spec=changelog)
     def test_not_release_when_updating_version_fails(
         self,
         _changelog_mock,
         _version_mock,
-        _requests_mock,
         _path_mock,
         _shell_mock,
     ):
@@ -215,12 +211,10 @@ class PrepareTestCase(unittest.TestCase):
 
     @patch("pontos.release.prepare.shell_cmd_runner")
     @patch("pontos.release.prepare.changelog", spec=changelog)
-    @patch("pontos.release.release.requests", spec=requests)
     @patch("pontos.release.helper.version", spec=version)
     def test_prepare_coventional_commits(
         self,
         _version_mock,
-        _requests_mock,
         _changelog_mock,
         _shell_mock,
     ):

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -24,7 +24,7 @@ from io import StringIO
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-import requests
+import httpx
 
 from pontos import changelog, release
 from pontos.release.helper import version
@@ -33,7 +33,6 @@ from pontos.release.helper import version
 class SignTestCase(unittest.TestCase):
     def setUp(self) -> None:
         os.environ["GITHUB_TOKEN"] = "foo"
-        os.environ["GITHUB_USER"] = "bar"
         self.valid_gh_release_response = (
             '{"zipball_url": "zip", "tarball_url":'
             ' "tar", "upload_url":"upload"}'
@@ -41,24 +40,24 @@ class SignTestCase(unittest.TestCase):
 
     @patch("pontos.release.sign.shell_cmd_runner")
     @patch("pontos.release.helper.Path", spec=Path)
-    @patch("pontos.release.helper.requests", spec=requests)
+    @patch("pontos.github.api.httpx")
     @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.changelog", spec=changelog)
     def test_fail_sign_on_invalid_get_response(
         self,
-        _changelog_mock,
-        _version_mock,
-        _requests_mock,
+        changelog_mock,
+        version_mock,
+        requests_mock,
         _path_mock,
         _shell_mock,
     ):
-        _version_mock.main.return_value = (True, "MyProject.conf")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (True, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
 
-        fake_get = MagicMock(spec=requests.Response).return_value
+        fake_get = MagicMock()
         fake_get.status_code = 404
         fake_get.text = self.valid_gh_release_response
-        _requests_mock.get.return_value = fake_get
+        requests_mock.get.return_value = fake_get
 
         args = [
             "sign",
@@ -68,37 +67,50 @@ class SignTestCase(unittest.TestCase):
             "0.0.1",
         ]
 
-        with redirect_stdout(StringIO()):
-            released = release.main(
+        with redirect_stdout(StringIO()), self.assertRaises(httpx.HTTPError):
+            release.main(
                 leave=False,
                 args=args,
             )
-        self.assertFalse(released)
 
     @patch("pontos.release.sign.shell_cmd_runner")
     @patch("pontos.release.helper.Path", spec=Path)
-    @patch("pontos.release.helper.requests", spec=requests)
+    @patch("pontos.github.api.httpx")
+    @patch("pontos.helper.httpx.stream")
+    @patch("pontos.release.helper.httpx.post")
     @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.changelog", spec=changelog)
     def test_fail_sign_on_upload_fail(
         self,
-        _changelog_mock,
-        _version_mock,
-        _requests_mock,
+        changelog_mock,
+        version_mock,
+        post_mock,
+        request_mock,
+        stream_mock,
         _path_mock,
         _shell_mock,
     ):
-        _version_mock.main.return_value = (True, "MyProject.conf")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (True, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
 
-        fake_get = MagicMock(spec=requests.Response).return_value
+        fake_get = MagicMock()
         fake_get.status_code = 200
         fake_get.text = self.valid_gh_release_response
-        fake_post = MagicMock(spec=requests.Response).return_value
+        fake_post = MagicMock()
         fake_post.status_code = 500
+        fake_post.is_success = False
         fake_post.text = self.valid_gh_release_response
-        _requests_mock.get.return_value = fake_get
-        _requests_mock.post.return_value = fake_post
+        request_mock.get.return_value = fake_get
+        post_mock.return_value = fake_post
+
+        response = MagicMock()
+        response.iter_bytes.side_effect = [
+            [b"foo", b"bar", b"baz"],
+            [b"lorem", b"ipsum"],
+        ]
+        response_stream = MagicMock()
+        response_stream.__enter__.return_value = response
+        stream_mock.return_value = response_stream
 
         args = [
             "sign",
@@ -112,35 +124,46 @@ class SignTestCase(unittest.TestCase):
                 leave=False,
                 args=args,
             )
+
         self.assertFalse(released)
 
     @patch("pontos.release.sign.shell_cmd_runner")
     @patch("pontos.release.helper.Path", spec=Path)
-    @patch("pontos.release.helper.requests", spec=requests)
-    @patch("pontos.release.sign.requests", spec=requests)
+    @patch("pontos.github.api.httpx")
+    @patch("pontos.helper.httpx.stream")
+    @patch("pontos.release.helper.httpx.post")
     @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.changelog", spec=changelog)
     def test_successfully_sign(
         self,
-        _changelog_mock,
-        _version_mock,
-        _sign_requests_mock,
-        _requests_mock,
+        changelog_mock,
+        version_mock,
+        post_mock,
+        request_mock,
+        stream_mock,
         _path_mock,
         _shell_mock,
     ):
-        _version_mock.main.return_value = (True, "MyProject.conf")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (True, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
 
-        fake_get = MagicMock(spec=requests.Response).return_value
+        fake_get = MagicMock()
         fake_get.status_code = 200
         fake_get.text = self.valid_gh_release_response
-        fake_post = MagicMock(spec=requests.Response).return_value
+        fake_post = MagicMock()
         fake_post.status_code = 201
         fake_post.text = self.valid_gh_release_response
-        _sign_requests_mock.get.return_value = fake_get
-        _requests_mock.get.return_value = fake_get
-        _requests_mock.post.return_value = fake_post
+        request_mock.get.return_value = fake_get
+        post_mock.return_value = fake_post
+
+        response = MagicMock()
+        response.iter_bytes.side_effect = [
+            [b"foo", b"bar", b"baz"],
+            [b"lorem", b"ipsum"],
+        ]
+        response_stream = MagicMock()
+        response_stream.__enter__.return_value = response
+        stream_mock.return_value = response_stream
 
         args = [
             "sign",

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -16,9 +16,10 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
-from unittest.mock import MagicMock, call
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
 
-from pontos.helper import DownloadProgressIterable
+from pontos.helper import DEFAULT_TIMEOUT, DownloadProgressIterable, download
 
 
 class DownloadProgressIterableTestCase(unittest.TestCase):
@@ -80,3 +81,100 @@ class DownloadProgressIterableTestCase(unittest.TestCase):
         download_progress.run()
         destination.open.assert_called_once()
         writer.write.assert_has_calls((call("foo"), call("bar"), call("baz")))
+
+
+class DownloadTestCase(unittest.TestCase):
+    @patch("pontos.github.api.httpx.stream")
+    def test_download_without_destination(
+        self,
+        requests_mock: MagicMock,
+    ):
+        response = MagicMock()
+        response.iter_bytes.return_value = [b"foo", b"bar", b"baz"]
+        response_headers = MagicMock()
+        response.headers = response_headers
+        response_headers.get.return_value = None
+        response_stream = MagicMock()
+        response_stream.__enter__.return_value = response
+        requests_mock.return_value = response_stream
+
+        with download(
+            "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz"  # pylint: disable=line-too-long
+        ) as download_progress:
+
+            requests_mock.assert_called_once_with(
+                "GET",
+                "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
+                follow_redirects=True,
+                timeout=DEFAULT_TIMEOUT,
+            )
+            response_headers.get.assert_called_once_with("content-length")
+
+            self.assertIsNone(download_progress.length)
+            self.assertEqual(
+                download_progress.destination, Path("v21.11.0.tar.gz")
+            )
+
+            it = iter(download_progress)
+            progress = next(it)
+            self.assertIsNone(progress)
+            progress = next(it)
+            self.assertIsNone(progress)
+            progress = next(it)
+            self.assertIsNone(progress)
+
+            with self.assertRaises(StopIteration):
+                next(it)
+
+            download_progress.destination.unlink()
+
+    @patch("pontos.github.api.Path")
+    @patch("pontos.github.api.httpx.stream")
+    def test_download_with_content_length(
+        self, requests_mock: MagicMock, path_mock: MagicMock
+    ):
+        response = MagicMock()
+        response.iter_bytes.return_value = [b"foo", b"bar", b"baz"]
+        response_headers = MagicMock()
+        response.headers = response_headers
+        response_headers.get.return_value = "9"
+        response_stream = MagicMock()
+        response_stream.__enter__.return_value = response
+        requests_mock.return_value = response_stream
+
+        download_file = path_mock()
+        file_mock = MagicMock()
+        file_mock.__enter__.return_value = file_mock
+        download_file.open.return_value = file_mock
+
+        with download(
+            "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
+            download_file,
+        ) as download_progress:
+
+            requests_mock.assert_called_once_with(
+                "GET",
+                "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
+                timeout=DEFAULT_TIMEOUT,
+                follow_redirects=True,
+            )
+            response_headers.get.assert_called_once_with("content-length")
+
+            self.assertEqual(download_progress.length, 9)
+
+            it = iter(download_progress)
+
+            progress = next(it)
+            self.assertEqual(progress, 1 / 3)
+            file_mock.write.assert_called_with(b"foo")
+
+            progress = next(it)
+            self.assertEqual(progress, 2 / 3)
+            file_mock.write.assert_called_with(b"bar")
+
+            progress = next(it)
+            self.assertEqual(progress, 1)
+            file_mock.write.assert_called_with(b"baz")
+
+            with self.assertRaises(StopIteration):
+                next(it)


### PR DESCRIPTION
**What**:

* Use httpx instead of requests.
* Refactor: Uniform usage of `downloads`
* Use the pontos git API in pontos release

**Why**:

httpx seems to be more future proof (async, http 2, ...) by supporting a very similar API to requests

DEVOPS-300

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
