### PR TITLE
Refactor: Remove passing of imported Modules, adjust tests

### DIFF
--- a/pontos/release/main.py
+++ b/pontos/release/main.py
@@ -245,12 +245,8 @@ def main(
             if not parsed_args.func(
                 term,
                 parsed_args,
-                path=_path,
                 username=username,
                 token=token,
-                changelog_module=_changelog,
-                requests_module=_requests,
-                version_module=_version,
             ):
                 return sys.exit(1) if leave else False
         except subprocess.CalledProcessError as e:

--- a/pontos/release/sign.py
+++ b/pontos/release/sign.py
@@ -20,7 +20,6 @@
 
 import json
 from argparse import Namespace
-from pathlib import Path
 
 import requests
 
@@ -61,10 +60,8 @@ def sign(
     terminal: Terminal,
     args: Namespace,
     *,
-    path: Path,
     username: str,
     token: str,
-    requests_module: requests,
     **_kwargs,
 ) -> bool:
     project: str = (
@@ -90,7 +87,7 @@ def sign(
         f"/releases/tags/{git_version}"
     )
 
-    response = requests_module.get(
+    response = requests.get(
         base_url,
         headers=headers,
     )
@@ -159,6 +156,4 @@ def sign(
         token,
         file_paths,
         github_json,
-        path=path,
-        requests_module=requests_module,
     )

--- a/tests/release/test_helper.py
+++ b/tests/release/test_helper.py
@@ -26,7 +26,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from pontos import version
 from pontos.release.helper import (
     calculate_calendar_version,
     find_signing_key,
@@ -127,9 +126,7 @@ class TestHelperFunctions(unittest.TestCase):
         terminal = MagicMock()
         proj_path = Path.cwd()
         os.chdir(self.tmpdir)
-        executed, filename = update_version(
-            terminal, to="21.4.4", _version=version, develop=True
-        )
+        executed, filename = update_version(terminal, to="21.4.4", develop=True)
         self.assertFalse(executed)
         self.assertEqual(filename, "")
 
@@ -156,7 +153,7 @@ class TestHelperFunctions(unittest.TestCase):
             encoding="utf-8",
         )
         executed, filename = update_version(
-            terminal, to="21.4.4", _version=version, develop=False
+            terminal, to="21.4.4", develop=False
         )
         toml_text = toml.read_text(encoding="utf-8")
         self.assertEqual(filename, "pyproject.toml")

--- a/tests/release/test_prepare.py
+++ b/tests/release/test_prepare.py
@@ -23,7 +23,7 @@ from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
 from subprocess import CompletedProcess
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import call, patch
 
 import requests
 
@@ -37,12 +37,19 @@ class PrepareTestCase(unittest.TestCase):
         os.environ["GITHUB_USER"] = "bar"
 
     @patch("pontos.release.prepare.shell_cmd_runner")
-    def test_prepare_successfully(self, _shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+    @patch("pontos.release.prepare.Path", spec=Path)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.prepare.changelog", spec=changelog)
+    def test_prepare_successfully(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _path_mock,
+        _shell_mock,
+    ):
+        _changelog_mock.update.return_value = ("updated", "changelog")
+        _version_mock.main.return_value = (True, "MyProject.conf")
+
         args = [
             "prepare",
             "--release-version",
@@ -50,43 +57,48 @@ class PrepareTestCase(unittest.TestCase):
         ]
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
         self.assertTrue(released)
 
     @patch("pontos.release.prepare.shell_cmd_runner")
-    def test_prepare_calendar_successfully(self, _shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
-
+    @patch("pontos.release.prepare.Path", spec=Path)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.prepare.changelog", spec=changelog)
+    def test_prepare_calendar_successfully(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _path_mock,
+        _shell_mock,
+    ):
+        _version_mock.main.return_value = (True, "MyProject.conf")
+        _changelog_mock.update.return_value = ("updated", "changelog")
         args = [
             "prepare",
             "--calendar",
         ]
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
         self.assertTrue(released)
 
     @patch("pontos.release.prepare.shell_cmd_runner")
-    def test_use_git_signing_key_on_prepare(self, shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+    @patch("pontos.release.prepare.Path", spec=Path)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.prepare.changelog", spec=changelog)
+    def test_use_git_signing_key_on_prepare(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _path_mock,
+        shell_mock,
+    ):
+        _version_mock.main.return_value = (True, "MyProject.conf")
+        _changelog_mock.update.return_value = ("updated", "changelog")
 
         args = [
             "prepare",
@@ -95,12 +107,8 @@ class PrepareTestCase(unittest.TestCase):
             "--release-version",
             "0.0.1",
         ]
-
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
@@ -117,10 +125,16 @@ class PrepareTestCase(unittest.TestCase):
         )
 
     @patch("pontos.release.prepare.shell_cmd_runner")
-    def test_fail_if_tag_is_already_taken(self, shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_version = MagicMock(spec=version)
-        fake_changelog = MagicMock(spec=changelog)
+    @patch("pontos.release.prepare.Path", spec=Path)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.prepare.changelog", spec=changelog)
+    def test_fail_if_tag_is_already_taken(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _path_mock,
+        shell_mock,
+    ):
 
         shell_mock.return_value = CompletedProcess(
             args="foo", returncode=1, stdout=b"v0.0.1"
@@ -138,9 +152,6 @@ class PrepareTestCase(unittest.TestCase):
 
         with self.assertRaises(SystemExit), redirect_stdout(StringIO()):
             release.main(
-                _path=fake_path_class,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
@@ -149,12 +160,18 @@ class PrepareTestCase(unittest.TestCase):
             shell_mock.assert_called_with("git tag v0.0.1 is already taken")
 
     @patch("pontos.release.prepare.shell_cmd_runner")
-    def test_not_release_when_no_project_found(self, _shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (False, "")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+    @patch("pontos.release.prepare.Path", spec=Path)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.prepare.changelog", spec=changelog)
+    def test_not_release_when_no_project_found(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _path_mock,
+        _shell_mock,
+    ):
+        _version_mock.main.return_value = (False, "")
+        _changelog_mock.update.return_value = ("updated", "changelog")
 
         args = [
             "prepare",
@@ -163,22 +180,26 @@ class PrepareTestCase(unittest.TestCase):
         ]
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
         self.assertFalse(released)
 
     @patch("pontos.release.prepare.shell_cmd_runner")
-    def test_not_release_when_updating_version_fails(self, _shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_requests = MagicMock(spec=requests)
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (False, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+    @patch("pontos.release.prepare.Path", spec=Path)
+    @patch("pontos.release.release.requests", spec=requests)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.prepare.changelog", spec=changelog)
+    def test_not_release_when_updating_version_fails(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _requests_mock,
+        _path_mock,
+        _shell_mock,
+    ):
+        _version_mock.main.return_value = (False, "MyProject.conf")
+        _changelog_mock.update.return_value = ("updated", "changelog")
 
         args = [
             "prepare",
@@ -187,26 +208,29 @@ class PrepareTestCase(unittest.TestCase):
         ]
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _requests=fake_requests,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
         self.assertFalse(released)
 
     @patch("pontos.release.prepare.shell_cmd_runner")
-    @patch("pontos.changelog.changelog")
-    def test_prepare_coventional_commits(self, changelog_mock, _shell_mock):
-        fake_requests = MagicMock(spec=requests)
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
+    @patch("pontos.release.prepare.changelog", spec=changelog)
+    @patch("pontos.release.release.requests", spec=requests)
+    @patch("pontos.release.helper.version", spec=version)
+    def test_prepare_coventional_commits(
+        self,
+        _version_mock,
+        _requests_mock,
+        _changelog_mock,
+        _shell_mock,
+    ):
+
+        _version_mock.main.return_value = (True, "MyProject.conf")
 
         own_path = Path(__file__).absolute().parent
         release_file = own_path.parent.parent / ".release.md"
 
-        builder = changelog_mock.ChangelogBuilder.return_value
+        builder = _changelog_mock.ChangelogBuilder.return_value
         builder.create_changelog_file.return_value = own_path / "v1.2.3.md"
 
         args = [
@@ -217,10 +241,6 @@ class PrepareTestCase(unittest.TestCase):
         ]
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=Path,
-                _requests=fake_requests,
-                _version=fake_version,
-                _changelog=changelog_mock,
                 leave=False,
                 args=args,
             )

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -40,17 +40,26 @@ class ReleaseTestCase(unittest.TestCase):
         )
 
     @patch("pontos.release.release.shell_cmd_runner")
-    def test_release_successfully(self, _shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_requests = MagicMock(spec=requests)
+    @patch("pontos.release.release.Path", spec=Path)
+    @patch("pontos.release.release.requests", spec=requests)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.release.changelog", spec=changelog)
+    def test_release_successfully(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _requests_mock,
+        _path_mock,
+        _shell_mock,
+    ):
+        _version_mock.main.return_value = (True, "MyProject.conf")
+        _changelog_mock.update.return_value = ("updated", "changelog")
+
         fake_post = MagicMock(spec=requests.Response).return_value
         fake_post.status_code = 201
         fake_post.text = self.valid_gh_release_response
-        fake_requests.post.return_value = fake_post
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+        _requests_mock.post.return_value = fake_post
+
         args = [
             "release",
             "--release-version",
@@ -61,27 +70,32 @@ class ReleaseTestCase(unittest.TestCase):
 
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _requests=fake_requests,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
         self.assertTrue(released)
 
     @patch("pontos.release.release.shell_cmd_runner")
-    def test_release_conventional_commits_successfully(self, _shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_requests = MagicMock(spec=requests)
+    @patch("pontos.release.release.Path", spec=Path)
+    @patch("pontos.release.release.requests", spec=requests)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.release.changelog", spec=changelog)
+    def test_release_conventional_commits_successfully(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _requests_mock,
+        _path_mock,
+        _shell_mock,
+    ):
+        _version_mock.main.return_value = (True, "MyProject.conf")
+        _changelog_mock.update.return_value = ("updated", "changelog")
+
         fake_post = MagicMock(spec=requests.Response).return_value
         fake_post.status_code = 201
         fake_post.text = self.valid_gh_release_response
-        fake_requests.post.return_value = fake_post
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+        _requests_mock.post.return_value = fake_post
+
         args = [
             "release",
             "-CC",
@@ -89,29 +103,33 @@ class ReleaseTestCase(unittest.TestCase):
 
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _requests=fake_requests,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
         self.assertTrue(released)
 
     @patch("pontos.release.release.shell_cmd_runner")
+    @patch("pontos.release.release.Path", spec=Path)
+    @patch("pontos.release.release.requests", spec=requests)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.release.changelog", spec=changelog)
     def test_not_release_successfully_when_github_create_release_fails(
-        self, _shell_mock
+        self,
+        _changelog_mock,
+        _version_mock,
+        _requests_mock,
+        _path_mock,
+        _shell_mock,
     ):
-        fake_path_class = MagicMock(spec=Path)
-        fake_requests = MagicMock(spec=requests)
+
+        _version_mock.main.return_value = (True, "MyProject.conf")
+        _changelog_mock.update.return_value = ("updated", "changelog")
+
         fake_post = MagicMock(spec=requests.Response).return_value
         fake_post.status_code = 401
         fake_post.text = self.valid_gh_release_response
-        fake_requests.post.return_value = fake_post
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+        _requests_mock.post.return_value = fake_post
+
         args = [
             "release",
             "--release-version",
@@ -120,27 +138,32 @@ class ReleaseTestCase(unittest.TestCase):
 
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _requests=fake_requests,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
         self.assertFalse(released)
 
     @patch("pontos.release.release.shell_cmd_runner")
-    def test_release_to_specific_git_remote(self, shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_requests = MagicMock(spec=requests)
+    @patch("pontos.release.release.Path", spec=Path)
+    @patch("pontos.release.release.requests", spec=requests)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.release.changelog", spec=changelog)
+    def test_release_to_specific_git_remote(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _requests_mock,
+        _path_mock,
+        shell_mock,
+    ):
+        _version_mock.main.return_value = (True, "MyProject.conf")
+        _changelog_mock.update.return_value = ("updated", "changelog")
+
         fake_post = MagicMock(spec=requests.Response).return_value
         fake_post.status_code = 201
         fake_post.text = self.valid_gh_release_response
-        fake_requests.post.return_value = fake_post
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+        _requests_mock.post.return_value = fake_post
+
         args = [
             "release",
             "--project",
@@ -157,10 +180,6 @@ class ReleaseTestCase(unittest.TestCase):
 
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _requests=fake_requests,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -40,17 +40,26 @@ class SignTestCase(unittest.TestCase):
         )
 
     @patch("pontos.release.sign.shell_cmd_runner")
-    def test_fail_sign_on_invalid_get_response(self, _shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_requests = MagicMock(spec=requests)
+    @patch("pontos.release.helper.Path", spec=Path)
+    @patch("pontos.release.helper.requests", spec=requests)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.changelog", spec=changelog)
+    def test_fail_sign_on_invalid_get_response(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _requests_mock,
+        _path_mock,
+        _shell_mock,
+    ):
+        _version_mock.main.return_value = (True, "MyProject.conf")
+        _changelog_mock.update.return_value = ("updated", "changelog")
+
         fake_get = MagicMock(spec=requests.Response).return_value
         fake_get.status_code = 404
         fake_get.text = self.valid_gh_release_response
-        fake_requests.get.return_value = fake_get
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+        _requests_mock.get.return_value = fake_get
+
         args = [
             "sign",
             "--project",
@@ -61,31 +70,36 @@ class SignTestCase(unittest.TestCase):
 
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _requests=fake_requests,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
         self.assertFalse(released)
 
     @patch("pontos.release.sign.shell_cmd_runner")
-    def test_fail_sign_on_upload_fail(self, _shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_requests = MagicMock(spec=requests)
+    @patch("pontos.release.helper.Path", spec=Path)
+    @patch("pontos.release.helper.requests", spec=requests)
+    @patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.changelog", spec=changelog)
+    def test_fail_sign_on_upload_fail(
+        self,
+        _changelog_mock,
+        _version_mock,
+        _requests_mock,
+        _path_mock,
+        _shell_mock,
+    ):
+        _version_mock.main.return_value = (True, "MyProject.conf")
+        _changelog_mock.update.return_value = ("updated", "changelog")
+
         fake_get = MagicMock(spec=requests.Response).return_value
         fake_get.status_code = 200
         fake_get.text = self.valid_gh_release_response
         fake_post = MagicMock(spec=requests.Response).return_value
         fake_post.status_code = 500
         fake_post.text = self.valid_gh_release_response
-        fake_requests.post.return_value = fake_post
-        fake_requests.get.return_value = fake_get
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+        _requests_mock.get.return_value = fake_get
+        _requests_mock.post.return_value = fake_post
+
         args = [
             "sign",
             "--project",
@@ -93,34 +107,41 @@ class SignTestCase(unittest.TestCase):
             "--release-version",
             "0.0.1",
         ]
-
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _requests=fake_requests,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )
         self.assertFalse(released)
 
     @patch("pontos.release.sign.shell_cmd_runner")
-    def test_successfully_sign(self, _shell_mock):
-        fake_path_class = MagicMock(spec=Path)
-        fake_requests = MagicMock(spec=requests)
+    @patch("pontos.release.helper.Path", spec=Path)
+    @patch("pontos.release.helper.requests", spec=requests)
+    @patch("pontos.release.sign.requests", spec=requests)
+    #@patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.changelog", spec=changelog)
+    def test_successfully_sign(
+        self,
+        _changelog_mock,
+     #   _version_mock,
+        _sign_requests_mock,
+        _requests_mock,
+        _path_mock,
+        _shell_mock,
+    ):
+      #  _version_mock.main.return_value = (True, "MyProject.conf")
+        _changelog_mock.update.return_value = ("updated", "changelog")
+
         fake_get = MagicMock(spec=requests.Response).return_value
         fake_get.status_code = 200
         fake_get.text = self.valid_gh_release_response
-        fake_requests.get.return_value = fake_get
         fake_post = MagicMock(spec=requests.Response).return_value
         fake_post.status_code = 201
         fake_post.text = self.valid_gh_release_response
-        fake_requests.post.return_value = fake_post
-        fake_version = MagicMock(spec=version)
-        fake_version.main.return_value = (True, "MyProject.conf")
-        fake_changelog = MagicMock(spec=changelog)
-        fake_changelog.update.return_value = ("updated", "changelog")
+        _sign_requests_mock.get.return_value = fake_get
+        _requests_mock.get.return_value = fake_get
+        _requests_mock.post.return_value = fake_post
+
         args = [
             "sign",
             "--project",
@@ -128,13 +149,8 @@ class SignTestCase(unittest.TestCase):
             "--release-version",
             "0.0.1",
         ]
-
         with redirect_stdout(StringIO()):
             released = release.main(
-                _path=fake_path_class,
-                _requests=fake_requests,
-                _version=fake_version,
-                _changelog=fake_changelog,
                 leave=False,
                 args=args,
             )

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -118,18 +118,18 @@ class SignTestCase(unittest.TestCase):
     @patch("pontos.release.helper.Path", spec=Path)
     @patch("pontos.release.helper.requests", spec=requests)
     @patch("pontos.release.sign.requests", spec=requests)
-    #@patch("pontos.release.helper.version", spec=version)
+    @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.changelog", spec=changelog)
     def test_successfully_sign(
         self,
         _changelog_mock,
-     #   _version_mock,
+        _version_mock,
         _sign_requests_mock,
         _requests_mock,
         _path_mock,
         _shell_mock,
     ):
-      #  _version_mock.main.return_value = (True, "MyProject.conf")
+        _version_mock.main.return_value = (True, "MyProject.conf")
         _changelog_mock.update.return_value = ("updated", "changelog")
 
         fake_get = MagicMock(spec=requests.Response).return_value


### PR DESCRIPTION
**What**:

Refactor code so that imported modules are no longer passed as parameters

**Why**:

To remove unnecessary parameters

**How**:

Changed that modules are referred directly when used and not indirectly via parameter.
Adjusted the tests so that mocks will no longer be passed as parameters but rather "patched" when necessary

**Checklist**:

- [ x] Tests
- [ x] Conventional commit message
- [ ] Documentation
