### PR TITLE
Fix: prepare terminal command runner confusion

### DIFF
--- a/pontos/release/prepare.py
+++ b/pontos/release/prepare.py
@@ -93,7 +93,7 @@ def prepare(
             config=args.cc_config,
         )
         changelog_builder = changelog.ChangelogBuilder(
-            terminal=shell_cmd_runner,
+            terminal=terminal,
             args=cargs,
         )
 


### PR DESCRIPTION
Fixes a confusion while preparing a release which raised an exception
while executing:

```
pontos-release prepare --release-version 22.4.0 --conventional-commits
```

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
