### PR TITLE
Tacire/fix comparison link

### DIFF
--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -235,19 +235,17 @@ def get_current_version(terminal: Terminal) -> str:
     sys.exit(1)
 
 
-def get_last_release_version():
+def get_last_release_version() -> Optional[str]:
     """Get the last released Version from git.
 
     Returns:
         Last released git-tag if tags were found
-        False if none were found
+        or None
     """
 
     git_interface = Git()
     tag_list = git_interface.list_tags()
-    if tag_list:
-        return tag_list[-1]
-    return False
+    return tag_list[-1] if tag_list else None
 
 
 def get_next_patch_version(terminal: Terminal) -> str:

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -19,7 +19,6 @@
 
 import datetime
 import json
-from pickle import FALSE
 import subprocess
 import sys
 import tempfile
@@ -30,11 +29,11 @@ import requests
 from packaging.version import InvalidVersion, Version
 
 from pontos import version
+from pontos.git.git import Git
 from pontos.helper import DownloadProgressIterable
 from pontos.terminal import Terminal
 from pontos.version import CMakeVersionCommand, PythonVersionCommand
 from pontos.version.helper import VersionError
-from pontos.git.git import Git
 
 DEFAULT_TIMEOUT = 1000
 DEFAULT_CHUNK_SIZE = 4096
@@ -235,20 +234,21 @@ def get_current_version(terminal: Terminal) -> str:
     terminal.error("No project settings file found")
     sys.exit(1)
 
+
 def get_last_release_version():
     """Get the last released Version from git.
-    
-    Returns: 
+
+    Returns:
         Last released git-tag if tags were found
-        FALSE if none were found
+        False if none were found
     """
 
     git_interface = Git()
     tag_list = git_interface.list_tags()
     if tag_list:
         return tag_list[-1]
-    else:
-        return FALSE
+    return False
+
 
 def get_next_patch_version(terminal: Terminal) -> str:
     """find the correct next patch version by checking latest version"""

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -23,7 +23,7 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Callable, Dict, Iterator, List, Tuple, Union
+from typing import Callable, Dict, Iterator, List, Tuple, Union, Optional
 
 import requests
 from packaging.version import InvalidVersion, Version

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -19,6 +19,7 @@
 
 import datetime
 import json
+from pickle import FALSE
 import subprocess
 import sys
 import tempfile
@@ -235,10 +236,19 @@ def get_current_version(terminal: Terminal) -> str:
     sys.exit(1)
 
 def get_last_release_version():
-    """Get the last released Version from git"""
+    """Get the last released Version from git.
+    
+    Returns: 
+        Last released git-tag if tags were found
+        FALSE if none were found
+    """
+
     git_interface = Git()
-    last_release_version = git_interface.list_tags()[-1]
-    return last_release_version
+    tag_list = git_interface.list_tags()
+    if tag_list:
+        return tag_list[-1]
+    else:
+        return FALSE
 
 def get_next_patch_version(terminal: Terminal) -> str:
     """find the correct next patch version by checking latest version"""

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -33,6 +33,7 @@ from pontos.helper import DownloadProgressIterable
 from pontos.terminal import Terminal
 from pontos.version import CMakeVersionCommand, PythonVersionCommand
 from pontos.version.helper import VersionError
+from pontos.git.git import Git
 
 DEFAULT_TIMEOUT = 1000
 DEFAULT_CHUNK_SIZE = 4096
@@ -233,6 +234,11 @@ def get_current_version(terminal: Terminal) -> str:
     terminal.error("No project settings file found")
     sys.exit(1)
 
+def get_last_release_version():
+    """Get the last released Version from git"""
+    git_interface = Git()
+    last_release_version = git_interface.list_tags()[-1]
+    return last_release_version
 
 def get_next_patch_version(terminal: Terminal) -> str:
     """find the correct next patch version by checking latest version"""

--- a/pontos/release/prepare.py
+++ b/pontos/release/prepare.py
@@ -29,7 +29,7 @@ from .helper import (
     calculate_calendar_version,
     commit_files,
     find_signing_key,
-    get_current_version,
+    get_last_release_version,
     get_next_patch_version,
     get_project_name,
     update_version,
@@ -82,10 +82,10 @@ def prepare(
 
     changelog_bool = True
     if args.conventional_commits:
-        current_version = get_current_version(terminal)
+        last_release_version = get_last_release_version()
         output = f"v{release_version}.md"
         cargs = Namespace(
-            current_version=current_version,
+            current_version=last_release_version,
             next_version=release_version,
             output=output,
             space=space,

--- a/tests/release/test_helper.py
+++ b/tests/release/test_helper.py
@@ -26,7 +26,6 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-
 from pontos.git.git import Git
 from pontos.release.helper import (
     calculate_calendar_version,
@@ -37,7 +36,6 @@ from pontos.release.helper import (
     get_project_name,
     update_version,
 )
-
 
 
 class TestHelperFunctions(unittest.TestCase):
@@ -184,17 +182,18 @@ class TestHelperFunctions(unittest.TestCase):
         sys.path.remove(self.tmpdir)
         os.chdir(proj_path)
 
-    @patch("pontos.release.helper.Git",spec=Git)
-    def test_get_last_release_version_git(self,_git_interface_mock):
+    @patch("pontos.release.helper.Git", spec=Git)
+    def test_get_last_release_version_git(self, _git_interface_mock):
         git_interface = _git_interface_mock.return_value
-        git_interface.list_tags.return_value = [1,2,3.55]
+        git_interface.list_tags.return_value = [1, 2, 3.55]
         self.assertTrue(get_last_release_version())
 
-    @patch("pontos.release.helper.Git",spec=Git)
-    def test_get_no_release_version_git(self,_git_interface_mock):
+    @patch("pontos.release.helper.Git", spec=Git)
+    def test_get_no_release_version_git(self, _git_interface_mock):
         git_interface = _git_interface_mock.return_value
         git_interface.list_tags.return_value = []
         self.assertFalse(get_last_release_version())
+
 
 class CalculateHelperVersionTestCase(unittest.TestCase):
     def test_calculate_calendar_versions(self):

--- a/tests/release/test_helper.py
+++ b/tests/release/test_helper.py
@@ -185,14 +185,14 @@ class TestHelperFunctions(unittest.TestCase):
     @patch("pontos.release.helper.Git", spec=Git)
     def test_get_last_release_version_git(self, _git_interface_mock):
         git_interface = _git_interface_mock.return_value
-        git_interface.list_tags.return_value = [1, 2, 3.55]
-        self.assertTrue(get_last_release_version())
+        git_interface.list_tags.return_value = ["1", "2", "3.55"]
+        self.assertEqual(get_last_release_version(), "3.55")
 
     @patch("pontos.release.helper.Git", spec=Git)
     def test_get_no_release_version_git(self, _git_interface_mock):
         git_interface = _git_interface_mock.return_value
         git_interface.list_tags.return_value = []
-        self.assertFalse(get_last_release_version())
+        self.assertIsNone(get_last_release_version())
 
 
 class CalculateHelperVersionTestCase(unittest.TestCase):

--- a/tests/release/test_helper.py
+++ b/tests/release/test_helper.py
@@ -26,14 +26,18 @@ import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
+
+from pontos.git.git import Git
 from pontos.release.helper import (
     calculate_calendar_version,
     find_signing_key,
+    get_last_release_version,
     get_next_dev_version,
     get_next_patch_version,
     get_project_name,
     update_version,
 )
+
 
 
 class TestHelperFunctions(unittest.TestCase):
@@ -180,6 +184,17 @@ class TestHelperFunctions(unittest.TestCase):
         sys.path.remove(self.tmpdir)
         os.chdir(proj_path)
 
+    @patch("pontos.release.helper.Git",spec=Git)
+    def test_get_last_release_version_git(self,_git_interface_mock):
+        git_interface = _git_interface_mock.return_value
+        git_interface.list_tags.return_value = [1,2,3.55]
+        self.assertTrue(get_last_release_version())
+
+    @patch("pontos.release.helper.Git",spec=Git)
+    def test_get_no_release_version_git(self,_git_interface_mock):
+        git_interface = _git_interface_mock.return_value
+        git_interface.list_tags.return_value = []
+        self.assertFalse(get_last_release_version())
 
 class CalculateHelperVersionTestCase(unittest.TestCase):
     def test_calculate_calendar_versions(self):


### PR DESCRIPTION
**What**:

  Pontos checks for last released version via git rather than reading the current version out of config files. 

**Why**:

 Automatically generated comparison links will no longer try to compare between dev-versions and released versions but rather compare between this release and last release

**How**:

Used the git API to get a list of last tags and use the last of them for the comparison

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
