### PR TITLE
Fix: Ensure release CLI fails if no sub-command is passed

### DIFF
--- a/pontos/release/main.py
+++ b/pontos/release/main.py
@@ -57,6 +57,7 @@ def parse_args(args) -> Tuple[str, str, Namespace]:
         description="valid subcommands",
         help="additional help",
         dest="command",
+        required=True,
     )
 
     prepare_parser = subparsers.add_parser("prepare")


### PR DESCRIPTION
**What**:

Require passing a sub-command argument for the pontos-release CLI.

**Why**:

Don't fail with a traceback

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [x] Conventional commit message
- [ ] Documentation
