### PR TITLE
Fix GitHub API for getting the release assets

### DIFF
--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -393,8 +393,7 @@ class GitHubRESTApi:
 
         response = self._request_internal(assets_url)
         response.raise_for_status()
-        response_json = response.json()
-        assets_json = response_json.get("assets", [])
+        assets_json = response.json()
         for asset_json in assets_json:
             asset_url: str = asset_json.get("browser_download_url", "")
             name: str = asset_json.get("name", "")

--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -469,18 +469,16 @@ class GitHubApiTestCase(unittest.TestCase):
             {
                 "assets_url": "https://api.github.com/repos/greenbone/pontos/releases/52499047/assets",  # pylint: disable=line-too-long
             },
-            {
-                "assets": [
-                    {
-                        "name": "foo-21.11.0.tar.gz",
-                        "browser_download_url": "https://github.com/greenbone/pontos/releases/download/v21.11.0/foo-21.11.0.tar.gz",  # pylint: disable=line-too-long
-                    },
-                    {
-                        "name": "bar-21.11.0.zip",
-                        "browser_download_url": "https://github.com/greenbone/pontos/releases/download/v21.11.0/bar-21.11.0.zip",  # pylint: disable=line-too-long
-                    },
-                ],
-            },
+            [
+                {
+                    "name": "foo-21.11.0.tar.gz",
+                    "browser_download_url": "https://github.com/greenbone/pontos/releases/download/v21.11.0/foo-21.11.0.tar.gz",  # pylint: disable=line-too-long
+                },
+                {
+                    "name": "bar-21.11.0.zip",
+                    "browser_download_url": "https://github.com/greenbone/pontos/releases/download/v21.11.0/bar-21.11.0.zip",  # pylint: disable=line-too-long
+                },
+            ],
         ]
 
         request_mock.return_value = response
@@ -574,18 +572,16 @@ class GitHubApiTestCase(unittest.TestCase):
             {
                 "assets_url": "https://api.github.com/repos/greenbone/pontos/releases/52499047/assets",  # pylint: disable=line-too-long
             },
-            {
-                "assets": [
-                    {
-                        "name": "foo.txt",
-                        "browser_download_url": "https://github.com/greenbone/pontos/releases/download/v21.11.0/foo.txt",  # pylint: disable=line-too-long
-                    },
-                    {
-                        "name": "foo.txt.asc",
-                        "browser_download_url": "https://github.com/greenbone/pontos/releases/download/v21.11.0/foo.txt.asc",  # pylint: disable=line-too-long
-                    },
-                ],
-            },
+            [
+                {
+                    "name": "foo.txt",
+                    "browser_download_url": "https://github.com/greenbone/pontos/releases/download/v21.11.0/foo.txt",  # pylint: disable=line-too-long
+                },
+                {
+                    "name": "foo.txt.asc",
+                    "browser_download_url": "https://github.com/greenbone/pontos/releases/download/v21.11.0/foo.txt.asc",  # pylint: disable=line-too-long
+                },
+            ],
         ]
         request_mock.return_value = response
 


### PR DESCRIPTION
**What**:

Return the correct json object of the get release assets response.

**Why**:

The [REST API](https://docs.github.com/en/rest/releases/assets#list-release-assets) returns a list and not an object with an assets key.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
