### PR TITLE
Fix creating a GitHub release

### DIFF
--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -296,12 +296,16 @@ class GitHubRESTApi:
         """
         data = {
             "tag_name": tag,
-            "target_commitish": target_commitish,
-            "name": name,
-            "body": body,
             "draft": draft,
             "prerelease": prerelease,
         }
+        if name is not None:
+            data["name"] = name
+        if body is not None:
+            data["body"] = body
+        if target_commitish is not None:
+            data["target_commitish"] = target_commitish
+
         api = f"/repos/{repo}/releases"
         response = self._request(api, data=data, request=httpx.post)
         response.raise_for_status()

--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -197,7 +197,6 @@ class GitHubApiTestCase(unittest.TestCase):
             params=None,
             json={
                 "tag_name": "v1.2.3",
-                "target_commitish": None,
                 "name": "Foo v1.2.3",
                 "body": "This is a release",
                 "draft": False,


### PR DESCRIPTION
**What**:

Optional release arguments must not be added to the json if they are
none.

**Why**:

Calling the GitHub release API failed because the optional target_commitish argument was sent with the value none. This causes an error on GitHub server side.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [ ] Conventional commit message
- [ ] Documentation
