### PR TITLE
Change: Check if token is available for pontos-release release and sign

### DIFF
--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -45,6 +45,13 @@ def release(
     token: str,
     **_kwargs,
 ) -> bool:
+    if not token:
+        terminal.error(
+            "Token is missing. The GitHub token is required to create a "
+            "release."
+        )
+        return False
+
     project: str = (
         args.project
         if args.project is not None

--- a/pontos/release/sign.py
+++ b/pontos/release/sign.py
@@ -35,6 +35,15 @@ def sign(
     token: str,
     **_kwargs,
 ) -> bool:
+    if not token and not args.dry_run:
+        # dry run doesn't upload assets. therefore a token MAY NOT be required
+        # for public repositories.
+        terminal.error(
+            "Token is missing. The GitHub token is required to upload "
+            "signature files."
+        )
+        return False
+
     project: str = (
         args.project
         if args.project is not None


### PR DESCRIPTION
**What**:

When creating a release and uploading the signatures as release assets a
GitHub token is required. Ensure the user has set a token for both
commands now.

**Why**:

The commands should fail if a required argument is not available.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [n/a] Documentation
