### PR TITLE
GitHub artifacts API

### DIFF
--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -594,3 +594,32 @@ class GitHubRESTApi:
         response = self._request(api, request=httpx.get)
         response.raise_for_status()
         return response.json()
+
+    def download_repository_artifact(
+        self, repo: str, artifact: str, destination: Union[Path, str]
+    ) -> ContextManager[DownloadProgressIterable]:
+        """
+        Download a repository artifact zip file
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            destination: A path where to store the downloaded file
+
+        Raises:
+            HTTPError if the request was invalid
+
+        Example:
+            .. code-block:: python
+
+            api = GitHubRESTApi("...")
+
+            print("Downloading", end="")
+
+            with api.download_repository_artifact(
+                "org/repo", "artifact.zip"
+            ) as progress_iterator:
+                for progress in progress_iterator:
+                    print(".", end="")
+        """
+        api = f"{self.url}/repos/{repo}/actions/artifacts/{artifact}/zip"
+        return download(api, destination, headers=self._request_headers())

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -54,6 +54,9 @@ def _get_next_url(response) -> Optional[str]:
     return None
 
 
+JSON = Dict[str, Union[str, bool, int]]
+
+
 class GitHubRESTApi:
     def __init__(
         self,
@@ -114,7 +117,7 @@ class GitHubRESTApi:
         params: Optional[Dict[str, str]] = None,
         data: Optional[Dict[str, str]] = None,
         request: Optional[Callable] = None,
-    ) -> Iterator[Dict[str, str]]:
+    ) -> Iterator[JSON]:
         response = self._request(api, params=params, data=data, request=request)
 
         yield from response.json()
@@ -158,7 +161,7 @@ class GitHubRESTApi:
 
     def pull_request_commits(
         self, repo: str, pull_request: int
-    ) -> Iterable[Dict[str, str]]:
+    ) -> Iterable[JSON]:
         """
         Get all commit information of a pull request
 
@@ -330,7 +333,7 @@ class GitHubRESTApi:
         response = self._request(api)
         return response.is_success
 
-    def release(self, repo: str, tag: str) -> Dict[str, str]:
+    def release(self, repo: str, tag: str) -> JSON:
         """
         Get data of a GitHub release by tag
 

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -646,3 +646,19 @@ class GitHubRESTApi:
         """
         api = f"/repos/{repo}/actions/runs/{workflow}/artifacts"
         return self._get_artifacts(api)
+
+    def delete_repository_artifact(self, repo: str, artifact: str):
+        """
+        Delete an artifact of a repository
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            artifact: ID of the artifact
+
+        Raises:
+            HTTPStatusError: A httpx.HTTPStatusError is raised if the request
+                failed.
+        """
+        api = f"/repos/{repo}/actions/artifacts/{artifact}"
+        response = self._request(api, request=httpx.delete)
+        response.raise_for_status()

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -66,6 +66,19 @@ class GitHubRESTApi:
         self.token = token
         self.url = url
 
+    def _request_headers(
+        self, *, content_type: Optional[str] = None
+    ) -> Dict[str, str]:
+        headers = {
+            "Accept": "application/vnd.github.v3+json",
+        }
+        if self.token:
+            headers["Authorization"] = f"token {self.token}"
+        if content_type:
+            headers["Content-Type"] = content_type
+
+        return headers
+
     def _request_internal(
         self,
         url: str,
@@ -76,15 +89,8 @@ class GitHubRESTApi:
         request: Optional[Callable] = None,
         content_type: Optional[str] = None,
     ) -> httpx.Response:
-        headers = {
-            "Accept": "application/vnd.github.v3+json",
-        }
-        if self.token:
-            headers["Authorization"] = f"token {self.token}"
-        if content_type:
-            headers["Content-Type"] = content_type
-
         request = request or httpx.get
+        headers = self._request_headers(content_type=content_type)
         kwargs = {}
         if data is not None:
             kwargs["json"] = data

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -542,17 +542,11 @@ class GitHubRESTApi:
         response = self._request(api, data=data, request=httpx.post)
         response.raise_for_status()
 
-    def get_repository_artifacts(self, repo: str) -> Iterable[JSON]:
+    def _get_artifacts(self, api: str) -> Iterable[JSON]:
         """
-        List all artifacts of a repository
-
-        Args:
-            repo: GitHub repository (owner/name) to use
-
-        Returns:
-            Information about the artifacts in the repository as a dict
+        Internal method to get the artifacts information from different REST
+        URLs.
         """
-        api = f"/repos/{repo}/actions/artifacts"
         page = 1
         per_page = 100
         params = {"per_page": per_page, "page": page}
@@ -572,6 +566,19 @@ class GitHubRESTApi:
             downloaded = len(artifacts)
 
         return artifacts
+
+    def get_repository_artifacts(self, repo: str) -> Iterable[JSON]:
+        """
+        List all artifacts of a repository
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+
+        Returns:
+            Information about the artifacts in the repository as a dict
+        """
+        api = f"/repos/{repo}/actions/artifacts"
+        return self._get_artifacts(api)
 
     def get_repository_artifact(
         self, repo: str, artifact: str
@@ -623,3 +630,19 @@ class GitHubRESTApi:
         """
         api = f"{self.url}/repos/{repo}/actions/artifacts/{artifact}/zip"
         return download(api, destination, headers=self._request_headers())
+
+    def get_workflow_artifacts(
+        self, repo: str, workflow: str
+    ) -> Iterable[JSON]:
+        """
+        List all artifacts for a workflow run
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            workflow: The unique identifier of the workflow run
+
+        Returns:
+            Information about the artifacts in the workflow as a dict
+        """
+        api = f"/repos/{repo}/actions/runs/{workflow}/artifacts"
+        return self._get_artifacts(api)

--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -566,3 +566,25 @@ class GitHubRESTApi:
             downloaded = len(artifacts)
 
         return artifacts
+
+    def get_repository_artifact(
+        self, repo: str, artifact: str
+    ) -> Iterable[JSON]:
+        """
+        Get a single artifact of a repository
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            artifact: ID of the artifact
+
+        Raises:
+            HTTPStatusError: A httpx.HTTPStatusError is raised if the request
+                failed.
+
+        Returns:
+            Information about the artifact as a dict
+        """
+        api = f"/repos/{repo}/actions/artifacts/{artifact}"
+        response = self._request(api, request=httpx.get)
+        response.raise_for_status()
+        return response.json()

--- a/pontos/helper.py
+++ b/pontos/helper.py
@@ -19,7 +19,7 @@
 import subprocess
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, Iterable, Iterator, Optional
+from typing import Generator, Iterable, Iterator, Optional, Union
 
 import httpx
 
@@ -86,7 +86,7 @@ class DownloadProgressIterable:
 @contextmanager
 def download(
     url: str,
-    destination: Optional[Path] = None,
+    destination: Optional[Union[Path, str]] = None,
     *,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     timeout: int = DEFAULT_TIMEOUT,
@@ -113,7 +113,9 @@ def download(
             for progress in progress_it:
                 print(progress)
     """
-    destination = Path(url.split("/")[-1]) if not destination else destination
+    destination = (
+        Path(url.split("/")[-1]) if not destination else Path(destination)
+    )
 
     with httpx.stream(
         "GET", url, timeout=timeout, follow_redirects=True

--- a/pontos/helper.py
+++ b/pontos/helper.py
@@ -113,6 +113,8 @@ def download(
         is unknown.
 
     Example:
+        .. code-block:: python
+
         with download("https://example.com/some/file")) as progress_it:
             for progress in progress_it:
                 print(progress)

--- a/pontos/helper.py
+++ b/pontos/helper.py
@@ -19,7 +19,7 @@
 import subprocess
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, Iterable, Iterator, Optional, Union
+from typing import Any, Dict, Generator, Iterable, Iterator, Optional, Union
 
 import httpx
 
@@ -88,6 +88,8 @@ def download(
     url: str,
     destination: Optional[Union[Path, str]] = None,
     *,
+    headers: Dict[str, Any] = None,
+    params: Dict[str, Any] = None,
     chunk_size: int = DEFAULT_CHUNK_SIZE,
     timeout: int = DEFAULT_TIMEOUT,
 ) -> Generator[DownloadProgressIterable, None, None]:
@@ -97,6 +99,8 @@ def download(
         url: The url of the file we want to download
         destination: Path of the file to store the download in. If set it will
                      be derived from the passed URL.
+        headers: HTTP headers to use for the download
+        params: HTTP request parameters to use for the download
         chunk_size: Download file in chunks of this size
         timeout: Connection timeout
 
@@ -118,7 +122,12 @@ def download(
     )
 
     with httpx.stream(
-        "GET", url, timeout=timeout, follow_redirects=True
+        "GET",
+        url,
+        timeout=timeout,
+        follow_redirects=True,
+        headers=headers,
+        params=params,
     ) as response:
         response.raise_for_status()
 

--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -248,7 +248,7 @@ class GitHubApiTestCase(unittest.TestCase):
 
         self.assertEqual(data["id"], 52499047)
 
-    @patch("pontos.github.api.Path")
+    @patch("pontos.helper.Path")
     @patch("pontos.github.api.httpx.stream")
     def test_download_release_tarball(
         self, requests_mock: MagicMock, path_mock: MagicMock
@@ -288,7 +288,7 @@ class GitHubApiTestCase(unittest.TestCase):
             with self.assertRaises(StopIteration):
                 next(it)
 
-    @patch("pontos.github.api.Path")
+    @patch("pontos.helper.Path")
     @patch("pontos.github.api.httpx.stream")
     def test_download_release_tarball_with_content_length(
         self, requests_mock: MagicMock, path_mock: MagicMock
@@ -328,7 +328,7 @@ class GitHubApiTestCase(unittest.TestCase):
             with self.assertRaises(StopIteration):
                 next(it)
 
-    @patch("pontos.github.api.Path")
+    @patch("pontos.helper.Path")
     @patch("pontos.github.api.httpx.stream")
     def test_download_release_zip(
         self, requests_mock: MagicMock, path_mock: MagicMock
@@ -442,7 +442,7 @@ class GitHubApiTestCase(unittest.TestCase):
             },
         )
 
-    @patch("pontos.github.api.Path")
+    @patch("pontos.helper.Path")
     @patch("pontos.github.api.httpx.get")
     @patch("pontos.github.api.httpx.stream")
     def test_download_release_assets(

--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -270,6 +270,8 @@ class GitHubApiTestCase(unittest.TestCase):
             requests_mock.assert_called_once_with(
                 "GET",
                 "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
+                headers=None,
+                params=None,
                 follow_redirects=True,
                 timeout=DEFAULT_TIMEOUT,
             )
@@ -310,6 +312,8 @@ class GitHubApiTestCase(unittest.TestCase):
             requests_mock.assert_called_once_with(
                 "GET",
                 "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
+                params=None,
+                headers=None,
                 follow_redirects=True,
                 timeout=DEFAULT_TIMEOUT,
             )
@@ -351,6 +355,8 @@ class GitHubApiTestCase(unittest.TestCase):
                 "GET",
                 "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.zip",  # pylint: disable=line-too-long
                 follow_redirects=True,
+                headers=None,
+                params=None,
                 timeout=DEFAULT_TIMEOUT,
             )
             response_headers.get.assert_called_once_with("content-length")

--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -857,3 +857,52 @@ class GitHubApiTestCase(unittest.TestCase):
         self.assertEqual(len(artifacts), 120)
         self.assertEqual(artifacts[0]["name"], "Foo-0")
         self.assertEqual(artifacts[119]["name"], "Foo-119")
+
+    @patch("pontos.github.api.httpx.get")
+    def test_get_repository_artifact(self, requests_mock: MagicMock):
+        response = MagicMock(autospec=httpx.Response)
+        response.json.return_value = {
+            "id": 123,
+            "name": "Foo",
+        }
+
+        requests_mock.return_value = response
+        api = GitHubRESTApi("12345")
+        artifacts = api.get_repository_artifact("foo/bar", "123")
+
+        requests_mock.assert_called_once_with(
+            "https://api.github.com/repos/foo/bar/actions/artifacts/123",
+            headers={
+                "Accept": "application/vnd.github.v3+json",
+                "Authorization": "token 12345",
+            },
+            params=None,
+            follow_redirects=True,
+        )
+
+        self.assertEqual(artifacts["id"], 123)
+        self.assertEqual(artifacts["name"], "Foo")
+
+    @patch("pontos.github.api.httpx.get")
+    def test_get_repository_artifact_invalid(self, requests_mock: MagicMock):
+        response = MagicMock(autospec=httpx.Response)
+        response.is_success = False
+        response.raise_for_status.side_effect = httpx.HTTPStatusError(
+            "Testing Status Message", request=None, response=response
+        )
+
+        requests_mock.return_value = response
+        api = GitHubRESTApi("12345")
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            api.get_repository_artifact("foo/bar", "123")
+
+        requests_mock.assert_called_once_with(
+            "https://api.github.com/repos/foo/bar/actions/artifacts/123",
+            headers={
+                "Accept": "application/vnd.github.v3+json",
+                "Authorization": "token 12345",
+            },
+            params=None,
+            follow_redirects=True,
+        )

--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -763,3 +763,97 @@ class GitHubApiTestCase(unittest.TestCase):
             },
             params=None,
         )
+
+    @patch("pontos.github.api.httpx.get")
+    def test_get_repository_artifacts(self, requests_mock: MagicMock):
+        response = MagicMock()
+        response.links = None
+        response.json.return_value = {
+            "total_count": 1,
+            "artifacts": [
+                {
+                    "id": 11,
+                    "node_id": "MDg6QXJ0aWZhY3QxMQ==",
+                    "name": "Foo",
+                }
+            ],
+        }
+        requests_mock.return_value = response
+        api = GitHubRESTApi("12345")
+        artifacts = api.get_repository_artifacts("foo/bar")
+
+        requests_mock.assert_called_once_with(
+            "https://api.github.com/repos/foo/bar/actions/artifacts",
+            headers={
+                "Authorization": "token 12345",
+                "Accept": "application/vnd.github.v3+json",
+            },
+            params={"per_page": 100, "page": 1},
+            follow_redirects=True,
+        )
+
+        self.assertEqual(len(artifacts), 1)
+        self.assertEqual(artifacts[0]["name"], "Foo")
+
+    @patch("pontos.github.api.httpx.get")
+    def test_get_repository_artifacts_with_pagination(
+        self, requests_mock: MagicMock
+    ):
+        response = MagicMock()
+        response.links = None
+        response.json.side_effect = [
+            {
+                "total_count": 120,
+                "artifacts": [
+                    {
+                        "id": id,
+                        "name": f"Foo-{id}",
+                    }
+                    for id in range(0, 100)
+                ],
+            },
+            {
+                "total_count": 120,
+                "artifacts": [
+                    {
+                        "id": id,
+                        "name": f"Foo-{id}",
+                    }
+                    for id in range(100, 120)
+                ],
+            },
+        ]
+        requests_mock.return_value = response
+        api = GitHubRESTApi("12345")
+        artifacts = api.get_repository_artifacts("foo/bar")
+
+        requests_mock.assert_has_calls(
+            [
+                call.__bool__(),
+                call(
+                    "https://api.github.com/repos/foo/bar/actions/artifacts",
+                    headers={
+                        "Accept": "application/vnd.github.v3+json",
+                        "Authorization": "token 12345",
+                    },
+                    params={"per_page": 100, "page": 1},
+                    follow_redirects=True,
+                ),
+                call().json(),
+                call.__bool__(),
+                call(
+                    "https://api.github.com/repos/foo/bar/actions/artifacts",
+                    headers={
+                        "Accept": "application/vnd.github.v3+json",
+                        "Authorization": "token 12345",
+                    },
+                    params={"per_page": 100, "page": 2},
+                    follow_redirects=True,
+                ),
+                call().json(),
+            ]
+        )
+
+        self.assertEqual(len(artifacts), 120)
+        self.assertEqual(artifacts[0]["name"], "Foo-0")
+        self.assertEqual(artifacts[119]["name"], "Foo-119")

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -75,6 +75,7 @@ class SignTestCase(unittest.TestCase):
 
     @patch("pontos.release.sign.shell_cmd_runner")
     @patch("pontos.release.sign.Path", spec=Path)
+    @patch("pontos.helper.Path", spec=Path)
     @patch("pontos.github.api.httpx")
     @patch("pontos.helper.httpx.stream")
     @patch("pontos.release.helper.version", spec=version)
@@ -86,6 +87,7 @@ class SignTestCase(unittest.TestCase):
         stream_mock,
         request_mock,
         _path_mock,
+        _path2_mock,
         _shell_mock,
     ):
         version_mock.main.return_value = (True, "MyProject.conf")
@@ -130,6 +132,7 @@ class SignTestCase(unittest.TestCase):
 
     @patch("pontos.release.sign.shell_cmd_runner")
     @patch("pontos.release.sign.Path", spec=Path)
+    @patch("pontos.helper.Path", spec=Path)
     @patch("pontos.github.api.httpx")
     @patch("pontos.helper.httpx.stream")
     @patch("pontos.release.helper.version", spec=version)
@@ -141,6 +144,7 @@ class SignTestCase(unittest.TestCase):
         stream_mock,
         request_mock,
         _path_mock,
+        _path2_mock,
         _shell_mock,
     ):
         version_mock.main.return_value = (True, "MyProject.conf")

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -140,6 +140,8 @@ class DownloadTestCase(unittest.TestCase):
                 "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
                 follow_redirects=True,
                 timeout=DEFAULT_TIMEOUT,
+                headers=None,
+                params=None,
             )
             response_headers.get.assert_called_once_with("content-length")
 
@@ -161,7 +163,7 @@ class DownloadTestCase(unittest.TestCase):
 
             download_progress.destination.unlink()
 
-    @patch("pontos.github.api.Path")
+    @patch("pontos.helper.Path")
     @patch("pontos.github.api.httpx.stream")
     def test_download_with_content_length(
         self, requests_mock: MagicMock, path_mock: MagicMock
@@ -190,6 +192,8 @@ class DownloadTestCase(unittest.TestCase):
                 "https://github.com/greenbone/pontos/archive/refs/tags/v21.11.0.tar.gz",  # pylint: disable=line-too-long
                 timeout=DEFAULT_TIMEOUT,
                 follow_redirects=True,
+                headers=None,
+                params=None,
             )
             response_headers.get.assert_called_once_with("content-length")
 


### PR DESCRIPTION
**What**:

Implement https://docs.github.com/en/rest/actions/artifacts in pontos

DEVOPS-403

**Why**:

We want to use pontos for downloading artifacts in GitHub Actions

**How**:

Unittests and manual tests against the GitHub REST interface

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
