### PR TITLE
Change: Set default timeout for GitHub API to three minutes

### DIFF
--- a/pontos/github/api.py
+++ b/pontos/github/api.py
@@ -35,6 +35,7 @@ import httpx
 from pontos.helper import DownloadProgressIterable, download
 
 DEFAULT_GITHUB_API_URL = "https://api.github.com"
+DEFAULT_TIMEOUT_CONFIG = httpx.Timeout(180.0)  # three minutes
 
 
 class FileStatus(Enum):
@@ -62,9 +63,12 @@ class GitHubRESTApi:
         self,
         token: Optional[str] = None,
         url: Optional[str] = DEFAULT_GITHUB_API_URL,
+        *,
+        timeout: httpx.Timeout = DEFAULT_TIMEOUT_CONFIG,
     ) -> None:
         self.token = token
         self.url = url
+        self.timeout = timeout
 
     def _request_headers(
         self, *, content_type: Optional[str] = None
@@ -101,6 +105,7 @@ class GitHubRESTApi:
             headers=headers,
             params=params,
             follow_redirects=True,
+            timeout=self.timeout,
             **kwargs,
         )
 


### PR DESCRIPTION
**What**:

Increase the timeout for the GitHub API

**Why**:

The httpx default timeout of 5 seconds is very very short for GitHub API requests. Therefore increase the timeout to some feasible default.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
