### PR TITLE
Change: Rename GitHub workflow API

### DIFF
--- a/pontos/github/api/artifacts.py
+++ b/pontos/github/api/artifacts.py
@@ -91,15 +91,15 @@ class GitHubRESTArtifactsMixin:
         api = f"{self.url}/repos/{repo}/actions/artifacts/{artifact}/zip"
         return download(api, destination, headers=self._request_headers())
 
-    def get_workflow_artifacts(
-        self, repo: str, workflow: str
+    def get_workflow_run_artifacts(
+        self, repo: str, run: str
     ) -> Iterable[JSON_OBJECT]:
         """
         List all artifacts for a workflow run
 
         Args:
             repo: GitHub repository (owner/name) to use
-            workflow: The unique identifier of the workflow run
+            run: The unique identifier of the workflow run
 
         Raises:
             HTTPStatusError: A httpx.HTTPStatusError is raised if the request
@@ -108,7 +108,7 @@ class GitHubRESTArtifactsMixin:
         Returns:
             Information about the artifacts in the workflow as a dict
         """
-        api = f"/repos/{repo}/actions/runs/{workflow}/artifacts"
+        api = f"/repos/{repo}/actions/runs/{run}/artifacts"
         return self._get_paged_items(api, "artifacts")
 
     def delete_repository_artifact(self, repo: str, artifact: str):

--- a/tests/github/test_api.py
+++ b/tests/github/test_api.py
@@ -858,7 +858,7 @@ class GitHubApiTestCase(unittest.TestCase):
                 next(it)
 
     @patch("pontos.github.api.api.httpx.get")
-    def test_get_workflow_artifacts(self, requests_mock: MagicMock):
+    def test_get_workflow_run_artifacts(self, requests_mock: MagicMock):
         response = MagicMock()
         response.links = None
         response.json.return_value = {
@@ -873,7 +873,7 @@ class GitHubApiTestCase(unittest.TestCase):
         }
         requests_mock.return_value = response
         api = GitHubRESTApi("12345")
-        artifacts = api.get_workflow_artifacts("foo/bar", "123")
+        artifacts = api.get_workflow_run_artifacts("foo/bar", "123")
 
         args, kwargs = default_request(
             "https://api.github.com/repos/foo/bar/actions/runs/123/artifacts",
@@ -885,7 +885,7 @@ class GitHubApiTestCase(unittest.TestCase):
         self.assertEqual(artifacts[0]["name"], "Foo")
 
     @patch("pontos.github.api.api.httpx.get")
-    def test_get_workflow_artifacts_with_pagination(
+    def test_get_workflow_run_artifacts_with_pagination(
         self, requests_mock: MagicMock
     ):
         response = MagicMock()
@@ -914,7 +914,7 @@ class GitHubApiTestCase(unittest.TestCase):
         ]
         requests_mock.return_value = response
         api = GitHubRESTApi("12345")
-        artifacts = api.get_workflow_artifacts("foo/bar", "123")
+        artifacts = api.get_workflow_run_artifacts("foo/bar", "123")
 
         args1, kwargs1 = default_request(
             "https://api.github.com/repos/foo/bar/actions/runs/123/artifacts",


### PR DESCRIPTION
**What**:

Rename get_workflow_artifacts to get_workflow_run_artifacts to have a consistent naming.

**Why**:

Consistent API naming.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
