### PR TITLE
Change: Improve get_repositories API call

### DIFF
--- a/pontos/github/api/helper.py
+++ b/pontos/github/api/helper.py
@@ -22,6 +22,8 @@ import httpx
 
 DEFAULT_GITHUB_API_URL = "https://api.github.com"
 DEFAULT_TIMEOUT_CONFIG = httpx.Timeout(180.0)  # three minutes
+JSON_OBJECT = Dict[str, Union[str, bool, int]]  # pylint: disable=invalid-name
+JSON = Union[List[JSON_OBJECT], JSON_OBJECT]
 
 
 class FileStatus(Enum):
@@ -29,6 +31,16 @@ class FileStatus(Enum):
     DELETED = "deleted"
     MODIFIED = "modified"
     RENAMED = "renamed"
+
+
+class RepositoryType(Enum):
+    ALL = "all"
+    PUBLIC = "public"
+    PRIVATE = "private"
+    FORKS = "forks"
+    SOURCES = "sources"
+    MEMBER = "member"
+    INTERNAL = "internal"
 
 
 def _get_next_url(response) -> Optional[str]:
@@ -39,7 +51,3 @@ def _get_next_url(response) -> Optional[str]:
             pass
 
     return None
-
-
-JSON_OBJECT = Dict[str, Union[str, bool, int]]  # pylint: disable=invalid-name
-JSON = Union[List[JSON_OBJECT], JSON_OBJECT]

--- a/pontos/github/api/helper.py
+++ b/pontos/github/api/helper.py
@@ -32,6 +32,7 @@ class FileStatus(Enum):
     MODIFIED = "modified"
     RENAMED = "renamed"
 
+
 class RepositoryType(Enum):
     ALL = "all"
     PUBLIC = "public"
@@ -40,6 +41,7 @@ class RepositoryType(Enum):
     SOURCES = "sources"
     MEMBER = "member"
     INTERNAL = "internal"
+
 
 class WorkflowRunStatus(Enum):
     ACTION_REQUIRED = "action_required"

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from pontos.github.api.helper import JSON
+from pontos.github.api.helper import JSON, RepositoryType
 
 
 class GitHubRESTOrganizationsMixin:
@@ -46,9 +46,9 @@ class GitHubRESTOrganizationsMixin:
         response.raise_for_status()
         response_json = response.json()
 
-        if repository_type == "PUBLIC":
+        if repository_type == RepositoryType.PUBLIC.value:
             return response_json["public_repos"]
-        if repository_type == "PRIVATE":
+        if repository_type == RepositoryType.PRIVATE.value:
             return response_json["total_private_repos"]
             # Use ALL for currently unsupported "types" (INTERNAL, FORKS ...)
         return (

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -16,6 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+from pontos.github.api.helper import JSON
+
+
 class GitHubRESTOrganizationsMixin:
     def organisation_exists(self, orga: str) -> bool:
         """
@@ -57,7 +60,7 @@ class GitHubRESTOrganizationsMixin:
         self,
         orga: str,
         repository_type: str,
-    ):
+    ) -> JSON:
         """
         Get information about organization repositories
 

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -46,15 +46,14 @@ class GitHubRESTOrganizationsMixin:
         response.raise_for_status()
         response_json = response.json()
 
-        if repository_type == "ALL":
-            return (
-                response_json["public_repos"]
-                + response_json["total_private_repos"]
-            )
         if repository_type == "PUBLIC":
             return response_json["public_repos"]
         if repository_type == "PRIVATE":
             return response_json["total_private_repos"]
+            # Use ALL for currently unsupported "types" (INTERNAL, FORKS ...)
+        return (
+            response_json["public_repos"] + response_json["total_private_repos"]
+        )
 
     def get_repositories(
         self,

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -28,7 +28,36 @@ class GitHubRESTOrganizationsMixin:
         response = self._request(api)
         return response.is_success
 
-    def get_repositories(self, orga: str):
+    def get_organization_repository_number(
+        self, orga: str, repository_type: str
+    ) -> int:
+        """
+        Get total number of repositories of organization
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            pull_request: Pull request number to check
+        """
+        api = f"/orgs/{orga}"
+        response = self._request(api)
+        response.raise_for_status()
+        response_json = response.json()
+
+        if repository_type == "ALL":
+            return (
+                response_json["public_repos"]
+                + response_json["total_private_repos"]
+            )
+        if repository_type == "PUBLIC":
+            return response_json["public_repos"]
+        if repository_type == "PRIVATE":
+            return response_json["total_private_repos"]
+
+    def get_repositories(
+        self,
+        orga: str,
+        repository_type: str,
+    ):
         """
         Get information about organization repositories
 
@@ -36,6 +65,21 @@ class GitHubRESTOrganizationsMixin:
             orga: GitHub organization to use
         """
         api = f"/orgs/{orga}/repos"
-        response = self._request(api)
+
+        count = self.get_organization_repository_number(
+            orga=orga, repository_type=repository_type
+        )
+        downloaded = 0
+
+        repos = []
+        params = {}
+        params["type"] = repository_type
+        params["per_page"] = 100  # max
+        while count - downloaded > 0:
+            params["page"] = downloaded / params["per_page"] + 1
+            response = self._request(api, params=params)
+            downloaded += params["per_page"]
+            repos.extend(response.json())
         response.raise_for_status()
+
         return response.json()

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -74,14 +74,15 @@ class GitHubRESTOrganizationsMixin:
         downloaded = 0
 
         repos = []
-        params = {}
-        params["type"] = repository_type.value
-        params["per_page"] = 100  # max
+        params = {"type": repository_type.value, "per_page": 100}
+        page = 0
         while count - downloaded > 0:
-            params["page"] = downloaded / params["per_page"] + 1
+            page += 1
+            params["page"] = page
             response = self._request(api, params=params)
-            downloaded += params["per_page"]
-            repos.extend(response.json())
-        response.raise_for_status()
+            response.raise_for_status()
 
-        return response.json()
+            repos.extend(response.json())
+            downloaded = len(repos)
+            
+        return repos

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -16,6 +16,8 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
+import httpx
+
 from pontos.github.api.helper import JSON, RepositoryType
 
 
@@ -42,7 +44,7 @@ class GitHubRESTOrganizationsMixin:
             pull_request: Pull request number to check
         """
         api = f"/orgs/{orga}"
-        response = self._request(api)
+        response: httpx.Response = self._request(api)
         response.raise_for_status()
         response_json = response.json()
 
@@ -79,7 +81,7 @@ class GitHubRESTOrganizationsMixin:
         while count - downloaded > 0:
             page += 1
             params["page"] = page
-            response = self._request(api, params=params)
+            response: httpx.Response = self._request(api, params=params)
             response.raise_for_status()
 
             repos.extend(response.json())

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -58,7 +58,7 @@ class GitHubRESTOrganizationsMixin:
     def get_repositories(
         self,
         orga: str,
-        repository_type: RepositoryType,
+        repository_type: RepositoryType = RepositoryType.ALL,
     ) -> JSON:
         """
         Get information about organization repositories

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -32,7 +32,7 @@ class GitHubRESTOrganizationsMixin:
         return response.is_success
 
     def get_organization_repository_number(
-        self, orga: str, repository_type: str
+        self, orga: str, repository_type: RepositoryType
     ) -> int:
         """
         Get total number of repositories of organization
@@ -46,9 +46,9 @@ class GitHubRESTOrganizationsMixin:
         response.raise_for_status()
         response_json = response.json()
 
-        if repository_type == RepositoryType.PUBLIC.value:
+        if repository_type == RepositoryType.PUBLIC:
             return response_json["public_repos"]
-        if repository_type == RepositoryType.PRIVATE.value:
+        if repository_type == RepositoryType.PRIVATE:
             return response_json["total_private_repos"]
             # Use ALL for currently unsupported "types" (INTERNAL, FORKS ...)
         return (
@@ -58,7 +58,7 @@ class GitHubRESTOrganizationsMixin:
     def get_repositories(
         self,
         orga: str,
-        repository_type: str,
+        repository_type: RepositoryType,
     ) -> JSON:
         """
         Get information about organization repositories
@@ -75,7 +75,7 @@ class GitHubRESTOrganizationsMixin:
 
         repos = []
         params = {}
-        params["type"] = repository_type
+        params["type"] = repository_type.value
         params["per_page"] = 100  # max
         while count - downloaded > 0:
             params["page"] = downloaded / params["per_page"] + 1

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -84,5 +84,5 @@ class GitHubRESTOrganizationsMixin:
 
             repos.extend(response.json())
             downloaded = len(repos)
-            
+
         return repos

--- a/pontos/github/argparser.py
+++ b/pontos/github/argparser.py
@@ -23,6 +23,7 @@ from pathlib import Path
 from typing import List
 
 from pontos.github.api import FileStatus
+from pontos.github.api.helper import RepositoryType
 from pontos.github.cmds import (
     create_pull_request,
     file_status,
@@ -188,7 +189,7 @@ def parse_args(
         choices=FileStatus,
         default=[FileStatus.ADDED, FileStatus.MODIFIED],
         nargs="+",
-        help=("What file status should be returned" "Default: %(default)s"),
+        help="What file status should be returned. Default: %(default)s",
     )
 
     file_status_parser.add_argument(
@@ -245,12 +246,12 @@ def parse_args(
         ),
     )
 
-    # orga
+    # orga-repos
     repos_parser = subparsers.add_parser("repos", aliases=["R"])
 
     repos_parser.set_defaults(func=repos)
 
-    repos_parser.add_argument("orga", help=("GitHub organization to use"))
+    repos_parser.add_argument("orga", help="GitHub organization to use")
 
     repos_parser.add_argument(
         "-t",
@@ -260,6 +261,16 @@ def parse_args(
         help=(
             "GitHub Token to access the repository. "
             "Default looks for environment variable 'GITHUB_TOKEN'"
+        ),
+    )
+
+    repos_parser.add_argument(
+        "--type",
+        choices=RepositoryType.__members__,
+        default=RepositoryType.PUBLIC,
+        help=(
+            "Define the type of repositories that should be covered. "
+            "Default: %(default)s"
         ),
     )
 

--- a/pontos/github/argparser.py
+++ b/pontos/github/argparser.py
@@ -40,6 +40,10 @@ def from_env(name: str) -> str:
     return os.environ.get(name, name)
 
 
+def get_repository_type(rtype: str) -> RepositoryType:
+    return RepositoryType[rtype]
+
+
 def parse_args(
     args: List[str] = None,
 ) -> Namespace:
@@ -266,7 +270,8 @@ def parse_args(
 
     repos_parser.add_argument(
         "--type",
-        choices=RepositoryType.__members__,
+        choices=RepositoryType,
+        type=get_repository_type,
         default=RepositoryType.PUBLIC,
         help=(
             "Define the type of repositories that should be covered. "
@@ -280,4 +285,6 @@ def parse_args(
         help="Define the Path to save the Repository Information JSON",
     )
 
-    return parser.parse_args(args)
+    parsed_args = parser.parse_args(args)
+
+    return parsed_args

--- a/pontos/github/cmds.py
+++ b/pontos/github/cmds.py
@@ -168,7 +168,9 @@ def repos(terminal: Terminal, args: Namespace):
             )
             sys.exit(1)
         terminal.ok(f"Organization {args.orga} exists.")
-        orga_json = git.get_repositories(orga=args.orga)
+        orga_json = git.get_repositories(
+            orga=args.orga, repository_type=args.type
+        )
         if args.path:
             repo_info = Path(args.path)
             with open(repo_info, encoding="utf-8", mode="w") as fp:

--- a/tests/github/api/test_branch.py
+++ b/tests/github/api/test_branch.py
@@ -31,9 +31,9 @@ class GitHubBranchTestCase(unittest.TestCase):
     @patch("pontos.github.api.api.httpx.get")
     def test_branch_protection_rules(self, requests_mock: MagicMock):
         api = GitHubRESTApi("12345")
-        api.get_repositories(orga="foo")
+        api.branch_protection_rules(repo="foo/bar", branch="baz")
 
         args, kwargs = default_request(
-            "https://api.github.com/orgs/foo/repos",
+            "https://api.github.com/repos/foo/bar/branches/baz/protection",
         )
         requests_mock.assert_called_once_with(*args, **kwargs)

--- a/tests/github/api/test_organizations.py
+++ b/tests/github/api/test_organizations.py
@@ -84,3 +84,72 @@ class GitHubOrganizationsTestCase(unittest.TestCase):
         )
         requests_mock.assert_any_call(*args2, **kwargs2)
         self.assertEqual(ret, [{"foo": "bar"}])
+
+    @patch("pontos.github.api.api.httpx.get")
+    def test_get_organization_repository_number_all(
+        self, requests_mock: MagicMock
+    ):
+        api = GitHubRESTApi("12345")
+        response = httpx.Response(
+            status_code=200,
+            json={"public_repos": 10, "total_private_repos": 10},
+            request=MagicMock(),
+        )
+
+        requests_mock.return_value = response
+        ret = api.get_organization_repository_number(
+            orga="foo", repository_type="ALL"
+        )
+
+        args, kwargs = default_request(
+            "https://api.github.com/orgs/foo",
+        )
+        requests_mock.assert_any_call(*args, **kwargs)
+
+        self.assertEqual(ret, 20)
+
+    @patch("pontos.github.api.api.httpx.get")
+    def test_get_organization_repository_number_private(
+        self, requests_mock: MagicMock
+    ):
+        api = GitHubRESTApi("12345")
+        response = httpx.Response(
+            status_code=200,
+            json={"public_repos": 10, "total_private_repos": 10},
+            request=MagicMock(),
+        )
+
+        requests_mock.return_value = response
+        ret = api.get_organization_repository_number(
+            orga="foo", repository_type="PRIVATE"
+        )
+
+        args, kwargs = default_request(
+            "https://api.github.com/orgs/foo",
+        )
+        requests_mock.assert_any_call(*args, **kwargs)
+
+        self.assertEqual(ret, 10)
+
+    @patch("pontos.github.api.api.httpx.get")
+    def test_get_organization_repository_number_public(
+        self, requests_mock: MagicMock
+    ):
+        api = GitHubRESTApi("12345")
+        response = httpx.Response(
+            status_code=200,
+            json={"public_repos": 10, "total_private_repos": 10},
+            request=MagicMock(),
+        )
+
+        requests_mock.return_value = response
+        ret = api.get_organization_repository_number(
+            orga="foo", repository_type="PUBLIC"
+        )
+
+        args, kwargs = default_request(
+            "https://api.github.com/orgs/foo",
+        )
+        requests_mock.assert_any_call(*args, **kwargs)
+
+        self.assertEqual(ret, 10)

--- a/tests/github/api/test_organizations.py
+++ b/tests/github/api/test_organizations.py
@@ -66,11 +66,13 @@ class GitHubOrganizationsTestCase(unittest.TestCase):
         api = GitHubRESTApi("12345")
         response1 = httpx.Response(
             status_code=200,
-            json={"public_repos": 10, "total_private_repos": 10},
+            json={"public_repos": 1, "total_private_repos": 1},
             request=MagicMock(),
         )
         response2 = httpx.Response(
-            status_code=200, json=[{"foo": "bar"}], request=MagicMock()
+            status_code=200,
+            json=[{"foo": "bar"}, {"foo": "baz"}],
+            request=MagicMock(),
         )
         requests_mock.side_effect = [response1, response2]
         ret = api.get_repositories(
@@ -86,7 +88,7 @@ class GitHubOrganizationsTestCase(unittest.TestCase):
             params={"per_page": 100, "page": 1, "type": "all"},
         )
         requests_mock.assert_any_call(*args2, **kwargs2)
-        self.assertEqual(ret, [{"foo": "bar"}])
+        self.assertEqual(ret, [{"foo": "bar"}, {"foo": "baz"}])
 
     @patch("pontos.github.api.api.httpx.get")
     def test_get_organization_repository_number_all(

--- a/tests/github/api/test_organizations.py
+++ b/tests/github/api/test_organizations.py
@@ -24,6 +24,7 @@ from unittest.mock import MagicMock, patch
 import httpx
 
 from pontos.github.api import GitHubRESTApi
+from pontos.github.api.helper import RepositoryType
 from tests.github.api import default_request
 
 here = Path(__file__).parent
@@ -72,7 +73,9 @@ class GitHubOrganizationsTestCase(unittest.TestCase):
             status_code=200, json=[{"foo": "bar"}], request=MagicMock()
         )
         requests_mock.side_effect = [response1, response2]
-        ret = api.get_repositories(orga="foo", repository_type="ALL")
+        ret = api.get_repositories(
+            orga="foo", repository_type=RepositoryType.ALL
+        )
 
         args, kwargs = default_request(
             "https://api.github.com/orgs/foo",
@@ -80,7 +83,7 @@ class GitHubOrganizationsTestCase(unittest.TestCase):
         requests_mock.assert_any_call(*args, **kwargs)
         args2, kwargs2 = default_request(
             "https://api.github.com/orgs/foo/repos",
-            params={"per_page": 100, "page": 1, "type": "ALL"},
+            params={"per_page": 100, "page": 1, "type": "all"},
         )
         requests_mock.assert_any_call(*args2, **kwargs2)
         self.assertEqual(ret, [{"foo": "bar"}])
@@ -98,7 +101,7 @@ class GitHubOrganizationsTestCase(unittest.TestCase):
 
         requests_mock.return_value = response
         ret = api.get_organization_repository_number(
-            orga="foo", repository_type="ALL"
+            orga="foo", repository_type=RepositoryType.ALL
         )
 
         args, kwargs = default_request(
@@ -121,7 +124,7 @@ class GitHubOrganizationsTestCase(unittest.TestCase):
 
         requests_mock.return_value = response
         ret = api.get_organization_repository_number(
-            orga="foo", repository_type="PRIVATE"
+            orga="foo", repository_type=RepositoryType.PRIVATE
         )
 
         args, kwargs = default_request(
@@ -144,7 +147,7 @@ class GitHubOrganizationsTestCase(unittest.TestCase):
 
         requests_mock.return_value = response
         ret = api.get_organization_repository_number(
-            orga="foo", repository_type="PUBLIC"
+            orga="foo", repository_type=RepositoryType.PUBLIC
         )
 
         args, kwargs = default_request(


### PR DESCRIPTION
**What**:

* Improve the `get_repositories`API call, so it can
  * Print different types of repositories (`ALL`, `PRIVATE`, `PUBLIC`)
  * Always prints all selected repos (enabling pagination)

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* Need this for the repo tables ...

<!-- Why are these changes necessary? -->

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
