### PR TITLE
Add: API call `path_exists()` to GitHub API

### DIFF
--- a/pontos/github/api/api.py
+++ b/pontos/github/api/api.py
@@ -21,6 +21,7 @@ import httpx
 
 from pontos.github.api.artifacts import GitHubRESTArtifactsMixin
 from pontos.github.api.branch import GitHubRESTBranchMixin
+from pontos.github.api.contents import GitHubRESTContentMixin
 from pontos.github.api.helper import (
     DEFAULT_GITHUB_API_URL,
     DEFAULT_TIMEOUT_CONFIG,
@@ -40,6 +41,7 @@ class GitHubRESTApi(
     GitHubRESTReleaseMixin,
     GitHubRESTArtifactsMixin,
     GitHubRESTBranchMixin,
+    GitHubRESTContentMixin,
     GitHubRESTLabelsMixin,
     GitHubAPIWorkflowsMixin,
     GitHubRESTOrganizationsMixin,

--- a/pontos/github/api/contents.py
+++ b/pontos/github/api/contents.py
@@ -1,0 +1,39 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+import httpx
+
+
+class GitHubRESTContentMixin:
+    def path_exits(self, repo: str, path: str, branch: str = None) -> bool:
+        """
+        Check if a path exists in a branch of a repository
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            path: to the file/directory in question
+            branch: Branch to check, defaults to default branch (:
+
+        Returns:
+            True if existing, False else
+        """
+        api = f"/repos/{repo}/contents/{path}"
+        params = {}
+        params["ref"] = branch
+        response: httpx.Response = self._request(api, params=params)
+        return response.is_success

--- a/pontos/github/api/contents.py
+++ b/pontos/github/api/contents.py
@@ -34,6 +34,7 @@ class GitHubRESTContentMixin:
         """
         api = f"/repos/{repo}/contents/{path}"
         params = {}
-        params["ref"] = branch
+        if branch:
+            params["ref"] = branch
         response: httpx.Response = self._request(api, params=params)
         return response.is_success

--- a/tests/github/api/test_contents.py
+++ b/tests/github/api/test_contents.py
@@ -1,0 +1,63 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from pontos.github.api import GitHubRESTApi
+from tests.github.api import default_request
+
+here = Path(__file__).parent
+
+
+class GitHubContentTestCase(unittest.TestCase):
+    @patch("pontos.github.api.api.httpx.get")
+    def test_path_exists(self, requests_mock: MagicMock):
+        response = MagicMock()
+        response.ok = True
+        requests_mock.return_value = response
+
+        api = GitHubRESTApi("12345")
+        exists = api.path_exits(repo="foo/bar", path="baz", branch="main")
+
+        args, kwargs = default_request(
+            "https://api.github.com/repos/foo/bar/contents/baz",
+            params={
+                "ref": "main",
+            },
+        )
+        requests_mock.assert_called_once_with(*args, **kwargs)
+        self.assertTrue(exists)
+
+    @patch("pontos.github.api.api.httpx.get")
+    def test_path_not_exists(self, requests_mock: MagicMock):
+        response = MagicMock()
+        response.is_success = False
+        requests_mock.return_value = response
+
+        api = GitHubRESTApi("12345")
+        exists = api.path_exits(repo="foo/bar", path="baz", branch="main")
+
+        args, kwargs = default_request(
+            "https://api.github.com/repos/foo/bar/contents/baz",
+            params={
+                "ref": "main",
+            },
+        )
+        requests_mock.assert_called_once_with(*args, **kwargs)
+        self.assertFalse(exists)


### PR DESCRIPTION
**What**:

* Add an API call `path_exists()`, that verifies the existence of a file/directory in a github repository's branch

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR?
-->

**Why**:

* E.g. check for existence of `.github/dependabot.yml` file or `.github/workflows` directory

<!-- Why are these changes necessary? -->

**How**:

* Using the GitHub API

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
