### PR TITLE
Add: Add a deprecated decorator to raise deprecation warnings

### DIFF
--- a/pontos/helper.py
+++ b/pontos/helper.py
@@ -17,12 +17,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import subprocess
+import warnings
 from contextlib import asynccontextmanager, contextmanager
+from functools import wraps
 from pathlib import Path
 from typing import (
     Any,
     AsyncContextManager,
     AsyncIterator,
+    Callable,
     Dict,
     Generator,
     Generic,
@@ -30,6 +33,7 @@ from typing import (
     Iterator,
     Optional,
     Tuple,
+    Type,
     TypeVar,
     Union,
 )
@@ -284,3 +288,74 @@ def shell_cmd_runner(args: Iterable[str]) -> subprocess.CompletedProcess:
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
     )
+
+
+def deprecated(
+    _func_or_cls: Union[str, Callable, Type] = None,
+    *,
+    since: str = None,
+    reason: str = None,
+):
+    """
+    A decorator to mark functions, classes and methods as deprecated
+
+    Args:
+        since: An optional version since the referenced item is deprecated.
+        reason: An optional reason why the references item is deprecated.
+
+    Examples:
+        .. code-block:: python
+
+        @deprecated
+        def my_function(*args, **kwargs):
+            ...
+
+        @deprecated("The function is obsolete. Please use my_func instead.")
+        def my_function(*args, **kwargs):
+            ...
+
+        @deprecated(
+            since="1.2.3",
+            reason="The function is obsolete. Please use my_func instead."
+        )
+        def my_function(*args, **kwargs):
+            ...
+
+        @deprecated(reason="The class will be removed in version 3.4.5")
+        class Foo:
+            ...
+
+        class Foo:
+            @deprecated(since="2.3.4")
+            def bar(self, *args, **kwargs):
+                ...
+    """
+    if isinstance(_func_or_cls, str):
+        reason = _func_or_cls
+        _func_or_cls = None
+
+    def decorator_repeat(func_or_cls):
+        module = func_or_cls.__module__
+        name = func_or_cls.__name__
+
+        if module == "__main__":
+            msg = f"{name} is deprecated."
+        else:
+            msg = f"{module}.{name} is deprecated."
+
+        if since:
+            msg += f" It is deprecated since version {since}."
+        if reason:
+            msg += f" {reason}"
+
+        @wraps(func_or_cls)
+        def wrapper(*args, **kwargs):
+            warnings.warn(msg, category=DeprecationWarning, stacklevel=3)
+            return func_or_cls(*args, **kwargs)
+
+        return wrapper
+
+    if _func_or_cls is None:
+        return decorator_repeat
+    else:
+        return decorator_repeat(_func_or_cls)

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=redefined-builtin
+# pylint: disable=redefined-builtin,disallowed-name
 
 import unittest
 from pathlib import Path
@@ -27,6 +27,7 @@ from pontos.helper import (
     DEFAULT_TIMEOUT,
     AsyncDownloadProgressIterable,
     DownloadProgressIterable,
+    deprecated,
     download,
     download_async,
 )
@@ -332,3 +333,142 @@ class DownloadTestCase(unittest.TestCase):
 
             with self.assertRaises(StopIteration):
                 next(it)
+
+
+class DeprecatedTestCase(unittest.TestCase):
+    def test_function(self):
+        @deprecated
+        def foo():
+            pass
+
+        with self.assertWarnsRegex(DeprecationWarning, "foo is deprecated"):
+            foo()
+
+        @deprecated()
+        def foo2():
+            pass
+
+        with self.assertWarnsRegex(DeprecationWarning, "foo2 is deprecated"):
+            foo2()
+
+    def test_function_with_since(self):
+        @deprecated(since="1.2.3")
+        def foo():
+            pass
+
+        with self.assertWarnsRegex(
+            DeprecationWarning, "deprecated since version 1.2.3"
+        ):
+            foo()
+
+    def test_function_with_reason(self):
+        @deprecated("Because it is obsolete.")
+        def foo():
+            pass
+
+        with self.assertWarnsRegex(
+            DeprecationWarning, "Because it is obsolete"
+        ):
+            foo()
+
+        @deprecated(reason="Because it is obsolete.")
+        def foo2():
+            pass
+
+        with self.assertWarnsRegex(
+            DeprecationWarning, "Because it is obsolete"
+        ):
+            foo2()
+
+    def test_class(self):
+        @deprecated
+        class Foo:
+            pass
+
+        with self.assertWarnsRegex(DeprecationWarning, "Foo is deprecated"):
+            Foo()
+
+        @deprecated()
+        class Foo2:
+            pass
+
+        with self.assertWarnsRegex(DeprecationWarning, "Foo2 is deprecated"):
+            Foo2()
+
+    def test_class_with_since(self):
+        @deprecated(since="1.2.3")
+        class Foo:
+            pass
+
+        with self.assertWarnsRegex(
+            DeprecationWarning, "deprecated since version 1.2.3"
+        ):
+            Foo()
+
+    def test_class_with_reason(self):
+        @deprecated("Because it is obsolete.")
+        class Foo:
+            pass
+
+        with self.assertWarnsRegex(
+            DeprecationWarning, "Because it is obsolete"
+        ):
+            Foo()
+
+        @deprecated(reason="Because it is obsolete.")
+        class Foo2:
+            pass
+
+        with self.assertWarnsRegex(
+            DeprecationWarning, "Because it is obsolete"
+        ):
+            Foo2()
+
+    def test_method(self):
+        class Foo:
+            @deprecated
+            def bar(self):
+                pass
+
+        with self.assertWarnsRegex(DeprecationWarning, "bar is deprecated"):
+            Foo().bar()
+
+        class Foo2:
+            @deprecated
+            def bar(self):
+                pass
+
+        with self.assertWarnsRegex(DeprecationWarning, "bar is deprecated"):
+            Foo2().bar()
+
+    def test_method_with_since(self):
+        class Foo:
+            @deprecated(since="1.2.3")
+            def bar(self):
+                pass
+
+        with self.assertWarnsRegex(
+            DeprecationWarning, "deprecated since version 1.2.3"
+        ):
+            Foo().bar()
+
+    def test_method_with_reason(self):
+        class Foo:
+            @deprecated("Because it is obsolete.")
+            def bar(self):
+                pass
+
+        with self.assertWarnsRegex(
+            DeprecationWarning, "Because it is obsolete"
+        ):
+            Foo().bar()
+
+        class Foo2:
+            @deprecated(reason="Because it is obsolete.")
+            def bar(self):
+                pass
+
+        with self.assertWarnsRegex(
+            DeprecationWarning, "Because it is obsolete"
+        ):
+            Foo2().bar()


### PR DESCRIPTION
**What**:

Add a deprecated decorator to raise deprecation warnings

This decorator can be used to mark functions, classes and methods as deprecated. It will raise a deprecation warning if a marked item is used.

**Why**:

Allow for deprecating code before breaking the API.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
