### PR TITLE
Extend Organization API

### DIFF
--- a/pontos/github/api/errors.py
+++ b/pontos/github/api/errors.py
@@ -1,0 +1,22 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pontos.errors import PontosError
+
+
+class GitHubApiError(PontosError):
+    """Error while using the GitHub API"""

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -161,6 +161,26 @@ class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
         response = await self._client.post(api, data=data)
         response.raise_for_status()
 
+    async def remove_member(
+        self,
+        organization: str,
+        username: str,
+    ) -> None:
+        """
+        Remove a member from a GitHub Organization
+
+        Args:
+            organization: GitHub organization to use
+            username: The handle for the GitHub user account to remove from the
+                organization.
+
+        Raises:
+            `httpx.HTTPStatusError` if there was an error in the request
+        """
+        api = f"/orgs/{organization}/memberships/{username}"
+        response = await self._client.delete(api)
+        response.raise_for_status()
+
 
 class GitHubRESTOrganizationsMixin:
     def organisation_exists(self, orga: str) -> bool:

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -181,6 +181,56 @@ class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
         response = await self._client.delete(api)
         response.raise_for_status()
 
+    async def outside_collaborators(
+        self,
+        organization: str,
+        *,
+        member_filter: MemberFilter = MemberFilter.ALL,
+    ) -> Iterable[JSON_OBJECT]:
+        """
+        Get information about outside collaborators of an organization
+
+        Args:
+            organization: GitHub organization to use
+            member_filter: Filter the list of outside collaborators.
+
+        Raises:
+            `httpx.HTTPStatusError` if there was an error in the request
+        """
+        api = f"/orgs/{organization}/outside_collaborators"
+        params = {
+            "filter": member_filter.value,
+            "per_page": "100",
+        }
+        members = []
+
+        async for response in self._client.get_all(api, params=params):
+            response.raise_for_status()
+
+            members.extend(response.json())
+
+        return members
+
+    async def remove_outside_collaborator(
+        self,
+        organization: str,
+        username: str,
+    ) -> None:
+        """
+        Remove an outside collaborator from a GitHub Organization
+
+        Args:
+            organization: GitHub organization to use
+            username: The handle for the GitHub user account to remove from the
+                organization.
+
+        Raises:
+            `httpx.HTTPStatusError` if there was an error in the request
+        """
+        api = f"/orgs/{organization}/outside_collaborators/{username}"
+        response = await self._client.delete(api)
+        response.raise_for_status()
+
 
 class GitHubRESTOrganizationsMixin:
     def organisation_exists(self, orga: str) -> bool:

--- a/tests/github/api/test_organizations.py
+++ b/tests/github/api/test_organizations.py
@@ -230,6 +230,16 @@ class GitHubAsyncRESTOrganizationsTestCase(GitHubAsyncRESTTestCase):
             },
         )
 
+    async def test_remove_member(self):
+        response = create_response(is_success=False)
+        self.client.delete.return_value = response
+
+        await self.api.remove_member("foo", "bar")
+
+        self.client.delete.assert_awaited_once_with(
+            "/orgs/foo/memberships/bar",
+        )
+
 
 class GitHubOrganizationsTestCase(unittest.TestCase):
     @patch("pontos.github.api.api.httpx.get")


### PR DESCRIPTION
**What**:

Add async GitHub API for additional organization membership handling

**Why**:

We need to be able to add and remove members.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
