### PR TITLE
Add GitHub Models

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -875,7 +875,7 @@ testing = ["flake8 (<5)", "func-timeout", "jaraco.functools", "jaraco.itertools"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "aed798272c8af49b6b995d7ab347a7788e27e53326c6b6689600742695dd0137"
+content-hash = "7e376d0524d4808c9796807d7c829c734558b02b44505964271f3bbb47898836"
 
 [metadata.files]
 alabaster = [

--- a/pontos/github/models/__init__.py
+++ b/pontos/github/models/__init__.py
@@ -1,0 +1,18 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from pontos.github.models.base import *

--- a/pontos/github/models/__init__.py
+++ b/pontos/github/models/__init__.py
@@ -16,3 +16,4 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pontos.github.models.base import *
+from pontos.github.models.organization import *

--- a/pontos/github/models/__init__.py
+++ b/pontos/github/models/__init__.py
@@ -16,4 +16,5 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from pontos.github.models.base import *
+from pontos.github.models.branch import *
 from pontos.github.models.organization import *

--- a/pontos/github/models/base.py
+++ b/pontos/github/models/base.py
@@ -1,0 +1,194 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from dataclasses import dataclass
+from inspect import isclass
+from typing import Any, Dict, List, Optional, Type, Union, get_type_hints
+
+from pontos.github.api.teams import TeamPrivacy
+
+try:
+    from typing import get_args, get_origin
+except ImportError:
+    from typing_extensions import get_args, get_origin
+
+__all__ = (
+    "App",
+    "GitHubModel",
+    "User",
+    "Team",
+)
+
+
+def dotted_attributes(obj: Any, data: Dict[str, Any]) -> Any:
+    """
+    Set dotted attributes on an object
+
+    Example:
+        .. code-block:: python
+
+            class Foo:
+                '''Some class'''
+
+            foo = Foo()
+            attrs = {"bar": 123, "baz": 456}
+
+            foo = dotted_attributes(foo, attrs)
+            print(foo.bar, foo.baz)
+    """
+    for key, value in data.items():
+        if isinstance(value, dict):
+            default = None if hasattr(obj, key) else GitHubModelAttribute()
+            prop = getattr(obj, key, default)
+            value = dotted_attributes(prop, value)
+
+        setattr(obj, key, value)
+
+    return obj
+
+
+class GitHubModelAttribute:
+    """
+    A utility class to allow setting attributes
+    """
+
+
+@dataclass(init=False)
+class GitHubModel:
+    """
+    Base class for all GitHub models
+    """
+
+    @staticmethod
+    def _get_value_from_model_field_cls(
+        model_field_cls: Type[Any], value: Any
+    ) -> Any:
+        if isclass(model_field_cls) and issubclass(
+            model_field_cls, GitHubModel
+        ):
+            value = model_field_cls.from_dict(value)
+        elif (
+            get_origin(model_field_cls) == Union
+            or get_origin(model_field_cls) == list
+        ):
+            # it should be an Optional field
+            model_field_cls = get_args(model_field_cls)[0]
+            value = GitHubModel._get_value_from_model_field_cls(
+                model_field_cls, value
+            )
+        else:
+            if isinstance(value, dict):
+                value = model_field_cls(**value)
+            else:
+                value = model_field_cls(value)
+        return value
+
+    @staticmethod
+    def _get_value(model_field_cls: Type[Any], value: Any) -> Any:
+        if model_field_cls:
+            value = GitHubModel._get_value_from_model_field_cls(
+                model_field_cls, value
+            )
+        return value
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]):
+        """
+        Create a model from a dict
+
+        Example:
+            .. code-block:: python
+
+            model = GitHubModel.from_dict({
+                "id": 123,
+                "node_id": "abcde",
+                "created_at": "2017-07-08T16:18:44-04:00",
+                "updated_at": "2017-07-08T16:18:44-04:00",
+            })
+        """
+        kwargs = {}
+        additional_attrs = {}
+        type_hints = get_type_hints(cls)
+        for name, value in data.items():
+            if isinstance(value, list):
+                model_field_cls = type_hints.get(name)
+                value = [cls._get_value(model_field_cls, v) for v in value]
+            elif value is not None:
+                model_field_cls = type_hints.get(name)
+                value = cls._get_value(model_field_cls, value)
+
+            if name in type_hints:
+                kwargs[name] = value
+            else:
+                additional_attrs[name] = value
+
+        instance = cls(**kwargs)
+        dotted_attributes(instance, additional_attrs)
+        return instance
+
+
+@dataclass
+class User(GitHubModel):
+    login: str
+    id: int
+    node_id: str
+    avatar_url: str
+    gravatar_id: str
+    url: str
+    html_url: str
+    followers_url: str
+    following_url: str
+    gists_url: str
+    starred_url: str
+    subscriptions_url: str
+    organizations_url: str
+    repos_url: str
+    events_url: str
+    received_events_url: str
+    type: str
+    site_admin: bool
+
+
+@dataclass
+class Team(GitHubModel):
+    id: int
+    node_id: str
+    url: str
+    html_url: str
+    name: str
+    slug: str
+    description: str
+    privacy: TeamPrivacy
+    permission: str
+    members_url: str
+    repositories_url: str
+    parent: Optional["Team"] = None
+
+
+@dataclass
+class App(GitHubModel):
+    id: int
+    slug: str
+    node_id: str
+    owner: User
+    name: str
+    description: str
+    external_url: str
+    html_url: str
+    created_at: str
+    updated_at: str
+    events: List[str]

--- a/pontos/github/models/branch.py
+++ b/pontos/github/models/branch.py
@@ -1,0 +1,108 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from pontos.github.models.base import App, GitHubModel, Team, User
+
+__all__ = (
+    "BranchProtection",
+    "BranchProtectionFeature",
+    "BypassPullRequestAllowances",
+    "DismissalRestrictions",
+    "RequiredPullRequestReviews",
+    "RequiredStatusChecks",
+    "Restrictions",
+    "StatusCheck",
+)
+
+
+@dataclass
+class DismissalRestrictions(GitHubModel):
+    url: str
+    users_url: str
+    teams_url: str
+    users: List[User]
+    teams: List[Team]
+    apps: List[App]
+
+
+@dataclass
+class BypassPullRequestAllowances(GitHubModel):
+    users: List[User]
+    teams: List[Team]
+    apps: List[App]
+
+
+@dataclass
+class RequiredPullRequestReviews(GitHubModel):
+    url: str
+    dismiss_stale_reviews: bool
+    require_code_owner_reviews: bool
+    required_approving_review_count: int
+    require_last_push_approval: bool
+    dismissal_restrictions: Optional[DismissalRestrictions] = None
+    bypass_pull_request_allowances: Optional[BypassPullRequestAllowances] = None
+
+
+@dataclass
+class StatusCheck(GitHubModel):
+    context: str
+    app_id: Optional[int] = None
+
+
+@dataclass
+class RequiredStatusChecks(GitHubModel):
+    url: str
+    strict: bool
+    checks: List[StatusCheck]
+    enforcement_level: Optional[str] = None
+
+
+@dataclass
+class Restrictions(GitHubModel):
+    url: str
+    users_url: str
+    teams_url: str
+    apps_url: str
+    users: List[User]
+    teams: List[Team]
+    apps: List[App]
+
+
+@dataclass
+class BranchProtectionFeature(GitHubModel):
+    enabled: bool
+    url: Optional[str] = None
+
+
+@dataclass
+class BranchProtection(GitHubModel):
+    url: str
+    required_status_checks: Optional[RequiredStatusChecks] = None
+    required_pull_request_reviews: Optional[RequiredPullRequestReviews] = None
+    restrictions: Optional[Restrictions] = None
+    enforce_admins: Optional[BranchProtectionFeature] = None
+    required_linear_history: Optional[BranchProtectionFeature] = None
+    allow_force_pushes: Optional[BranchProtectionFeature] = None
+    allow_deletions: Optional[BranchProtectionFeature] = None
+    block_creations: Optional[BranchProtectionFeature] = None
+    required_conversation_resolution: Optional[BranchProtectionFeature] = None
+    lock_branch: Optional[BranchProtectionFeature] = None
+    allow_fork_syncing: Optional[BranchProtectionFeature] = None
+    required_signatures: Optional[BranchProtectionFeature] = None

--- a/pontos/github/models/organization.py
+++ b/pontos/github/models/organization.py
@@ -1,0 +1,126 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from dataclasses import dataclass
+from typing import List, Optional
+
+from pontos.github.models.base import GitHubModel, User
+
+__all__ = (
+    "License",
+    "Repository",
+)
+
+
+@dataclass
+class License(GitHubModel):
+    key: str
+    name: str
+    url: str
+    spdx_id: str
+    node_id: str
+    html_url: Optional[str] = None
+
+
+@dataclass
+class Repository(GitHubModel):
+    id: int
+    node_id: str
+    name: str
+    full_name: str
+    private: bool
+    owner: User
+    html_url: str
+    description: str
+    fork: bool
+    url: str
+    forks_url: str
+    keys_url: str
+    collaborators_url: str
+    teams_url: str
+    hooks_url: str
+    issue_events_url: str
+    events_url: str
+    assignees_url: str
+    branches_url: str
+    tags_url: str
+    blobs_url: str
+    git_tags_url: str
+    git_refs_url: str
+    trees_url: str
+    statuses_url: str
+    languages_url: str
+    stargazers_url: str
+    contributors_url: str
+    subscribers_url: str
+    subscription_url: str
+    commits_url: str
+    git_commits_url: str
+    comments_url: str
+    issue_comment_url: str
+    contents_url: str
+    compare_url: str
+    merges_url: str
+    archive_url: str
+    downloads_url: str
+    issues_url: str
+    pulls_url: str
+    milestones_url: str
+    notifications_url: str
+    labels_url: str
+    releases_url: str
+    deployments_url: str
+    created_at: str
+    updated_at: str
+    pushed_at: str
+    git_url: str
+    ssh_url: str
+    clone_url: str
+    svn_url: str
+    homepage: str
+    stargazers_count: int
+    watchers_count: int
+    language: str
+    has_issues: bool
+    has_projects: bool
+    has_downloads: bool
+    has_wiki: bool
+    has_pages: bool
+    has_discussions: bool
+    forks_count: int
+    mirror_url: str
+    archived: bool
+    disabled: bool
+    open_issues_count: int
+    license: License
+    is_template: bool
+    topics: List[str]
+    visibility: str
+    forks: int
+    open_issues: int
+    watchers: int
+    default_branch: str
+    allow_forking: Optional[bool] = None
+    allow_rebase_merge: Optional[bool] = None
+    allow_squash_merge: Optional[bool] = None
+    allow_auto_merge: Optional[bool] = None
+    delete_branch_on_merge: Optional[bool] = None
+    allow_merge_commit: Optional[bool] = None
+    web_commit_signoff_required: Optional[bool] = None
+    subscribers_count: Optional[int] = None
+    network_count: Optional[int] = None
+    size: Optional[int] = None

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,7 @@ tomlkit = ">=0.5.11"
 packaging = ">=20.3"
 httpx = {extras = ["http2"], version = "^0.23.0"}
 rich = "^12.4.4"
+typing-extensions = { version = "^4.4.0", python = "<3.8" }
 
 [tool.poetry.dev-dependencies]
 autohooks = ">=22.7.0"

--- a/tests/github/models/__init__.py
+++ b/tests/github/models/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/github/models/test_base.py
+++ b/tests/github/models/test_base.py
@@ -1,0 +1,281 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=no-member, disallowed-name, line-too-long
+
+
+import unittest
+
+from pontos.github.api.teams import TeamPrivacy
+from pontos.github.models.base import (
+    App,
+    GitHubModel,
+    GitHubModelAttribute,
+    Team,
+    User,
+    dotted_attributes,
+)
+
+
+class DottedAttributesTestCase(unittest.TestCase):
+    def test_with_new_class(self):
+        class Foo:
+            pass
+
+        foo = Foo()
+        attrs = {"bar": 123, "hello": "World", "baz": [1, 2, 3]}
+
+        foo = dotted_attributes(foo, attrs)
+
+        self.assertEqual(foo.bar, 123)
+        self.assertEqual(foo.baz, [1, 2, 3])
+        self.assertEqual(foo.hello, "World")
+
+    def test_with_github_model_attribute(self):
+        foo = GitHubModelAttribute()
+        attrs = {"bar": 123, "hello": "World", "baz": [1, 2, 3]}
+
+        foo = dotted_attributes(foo, attrs)
+
+        self.assertEqual(foo.bar, 123)
+        self.assertEqual(foo.baz, [1, 2, 3])
+        self.assertEqual(foo.hello, "World")
+
+
+class GitHubModelTestCase(unittest.TestCase):
+    def test_from_dict(self):
+        model = GitHubModel.from_dict(
+            {
+                "x": 1,
+                "y": 2,
+                "hello": "World",
+                "baz": [1, 2, 3],
+                "bar": {"a": "b"},
+            }
+        )
+
+        self.assertEqual(model.x, 1)
+        self.assertEqual(model.y, 2)
+        self.assertEqual(model.hello, "World")
+        self.assertEqual(model.baz, [1, 2, 3])
+        self.assertEqual(model.bar.a, "b")
+
+
+class UserTestCase(unittest.TestCase):
+    def test_from_dict(self):
+        data = {
+            "login": "greenbone",
+            "id": 31986857,
+            "node_id": "MDEyOk9yZ2FuaXphdGlvbjMxOTg2ODU3",
+            "avatar_url": "https://avatars.githubusercontent.com/u/31986857?v=4",
+            "gravatar_id": "",
+            "url": "https://api.github.com/users/greenbone",
+            "html_url": "https://github.com/greenbone",
+            "followers_url": "https://api.github.com/users/greenbone/followers",
+            "following_url": "https://api.github.com/users/greenbone/following{/other_user}",
+            "gists_url": "https://api.github.com/users/greenbone/gists{/gist_id}",
+            "starred_url": "https://api.github.com/users/greenbone/starred{/owner}{/repo}",
+            "subscriptions_url": "https://api.github.com/users/greenbone/subscriptions",
+            "organizations_url": "https://api.github.com/users/greenbone/orgs",
+            "repos_url": "https://api.github.com/users/greenbone/repos",
+            "events_url": "https://api.github.com/users/greenbone/events{/privacy}",
+            "received_events_url": "https://api.github.com/users/greenbone/received_events",
+            "type": "Organization",
+            "site_admin": False,
+        }
+
+        user = User.from_dict(data)
+
+        self.assertEqual(user.login, "greenbone")
+        self.assertEqual(user.id, 31986857)
+        self.assertEqual(user.node_id, "MDEyOk9yZ2FuaXphdGlvbjMxOTg2ODU3")
+        self.assertEqual(user.gravatar_id, "")
+        self.assertEqual(user.url, "https://api.github.com/users/greenbone")
+        self.assertEqual(user.html_url, "https://github.com/greenbone")
+        self.assertEqual(
+            user.followers_url,
+            "https://api.github.com/users/greenbone/followers",
+        )
+        self.assertEqual(
+            user.following_url,
+            "https://api.github.com/users/greenbone/following{/other_user}",
+        )
+        self.assertEqual(
+            user.gists_url,
+            "https://api.github.com/users/greenbone/gists{/gist_id}",
+        )
+        self.assertEqual(
+            user.starred_url,
+            "https://api.github.com/users/greenbone/starred{/owner}{/repo}",
+        )
+        self.assertEqual(
+            user.subscriptions_url,
+            "https://api.github.com/users/greenbone/subscriptions",
+        )
+        self.assertEqual(
+            user.organizations_url,
+            "https://api.github.com/users/greenbone/orgs",
+        )
+        self.assertEqual(
+            user.repos_url, "https://api.github.com/users/greenbone/repos"
+        )
+        self.assertEqual(
+            user.events_url,
+            "https://api.github.com/users/greenbone/events{/privacy}",
+        )
+        self.assertEqual(
+            user.received_events_url,
+            "https://api.github.com/users/greenbone/received_events",
+        )
+        self.assertEqual(user.type, "Organization")
+        self.assertFalse(user.site_admin)
+
+
+class TeamTestCase(unittest.TestCase):
+    def test_from_dict(self):
+        data = {
+            "name": "python-gvm-maintainers",
+            "id": 3764115,
+            "node_id": "MDQ6VGVhbTM3NjQxMTU=",
+            "slug": "python-gvm-maintainers",
+            "description": "Maintainers of python code at GVM",
+            "privacy": "closed",
+            "url": "https://api.github.com/organizations/31986857/team/3764115",
+            "html_url": "https://github.com/orgs/greenbone/teams/python-gvm-maintainers",
+            "members_url": "https://api.github.com/organizations/31986857/team/3764115/members{/member}",
+            "repositories_url": "https://api.github.com/organizations/31986857/team/3764115/repos",
+            "permission": "pull",
+            "parent": None,
+        }
+
+        team = Team.from_dict(data)
+
+        self.assertEqual(team.name, "python-gvm-maintainers")
+        self.assertEqual(team.id, 3764115)
+        self.assertEqual(team.node_id, "MDQ6VGVhbTM3NjQxMTU=")
+        self.assertEqual(team.slug, "python-gvm-maintainers")
+        self.assertEqual(team.description, "Maintainers of python code at GVM")
+        self.assertEqual(team.privacy, TeamPrivacy.CLOSED)
+        self.assertEqual(
+            team.url,
+            "https://api.github.com/organizations/31986857/team/3764115",
+        )
+        self.assertEqual(
+            team.html_url,
+            "https://github.com/orgs/greenbone/teams/python-gvm-maintainers",
+        )
+        self.assertEqual(
+            team.members_url,
+            "https://api.github.com/organizations/31986857/team/3764115/members{/member}",
+        )
+        self.assertEqual(
+            team.repositories_url,
+            "https://api.github.com/organizations/31986857/team/3764115/repos",
+        )
+        self.assertEqual(team.permission, "pull")
+        self.assertIsNone(team.parent)
+
+
+class AppTestCase(unittest.TestCase):
+    def test_from_dict(self):
+        data = {
+            "id": 1,
+            "slug": "octoapp",
+            "node_id": "MDExOkludGVncmF0aW9uMQ==",
+            "owner": {
+                "login": "github",
+                "id": 1,
+                "node_id": "MDEyOk9yZ2FuaXphdGlvbjE=",
+                "avatar_url": "https://github.com/images/error/octocat_happy.gif",
+                "gravatar_id": "",
+                "url": "https://api.github.com/orgs/github",
+                "html_url": "https://github.com/github",
+                "followers_url": "https://api.github.com/users/github/followers",
+                "following_url": "https://api.github.com/users/github/following{/other_user}",
+                "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/github/subscriptions",
+                "organizations_url": "https://api.github.com/users/github/orgs",
+                "repos_url": "https://api.github.com/orgs/github/repos",
+                "events_url": "https://api.github.com/orgs/github/events",
+                "received_events_url": "https://api.github.com/users/github/received_events",
+                "type": "Organization",
+                "site_admin": False,
+            },
+            "name": "Octocat App",
+            "description": "",
+            "external_url": "https://example.com",
+            "html_url": "https://github.com/apps/octoapp",
+            "created_at": "2017-07-08T16:18:44-04:00",
+            "updated_at": "2017-07-08T16:18:44-04:00",
+            "events": ["push", "pull_request"],
+        }
+
+        app = App.from_dict(data)
+
+        self.assertEqual(app.id, 1)
+        self.assertEqual(app.slug, "octoapp")
+        self.assertEqual(app.node_id, "MDExOkludGVncmF0aW9uMQ==")
+        self.assertEqual(app.owner.login, "github")
+        self.assertEqual(app.owner.id, 1)
+        self.assertEqual(app.owner.node_id, "MDEyOk9yZ2FuaXphdGlvbjE=")
+        self.assertEqual(
+            app.owner.avatar_url,
+            "https://github.com/images/error/octocat_happy.gif",
+        )
+        self.assertEqual(app.owner.gravatar_id, "")
+        self.assertEqual(app.owner.url, "https://api.github.com/orgs/github")
+        self.assertEqual(app.owner.html_url, "https://github.com/github")
+        self.assertEqual(
+            app.owner.followers_url,
+            "https://api.github.com/users/github/followers",
+        )
+        self.assertEqual(
+            app.owner.following_url,
+            "https://api.github.com/users/github/following{/other_user}",
+        )
+        self.assertEqual(
+            app.owner.gists_url,
+            "https://api.github.com/users/github/gists{/gist_id}",
+        )
+        self.assertEqual(
+            app.owner.starred_url,
+            "https://api.github.com/users/github/starred{/owner}{/repo}",
+        )
+        self.assertEqual(
+            app.owner.subscriptions_url,
+            "https://api.github.com/users/github/subscriptions",
+        )
+        self.assertEqual(
+            app.owner.organizations_url,
+            "https://api.github.com/users/github/orgs",
+        )
+        self.assertEqual(
+            app.owner.repos_url, "https://api.github.com/orgs/github/repos"
+        )
+        self.assertEqual(
+            app.owner.events_url, "https://api.github.com/orgs/github/events"
+        )
+        self.assertEqual(app.owner.type, "Organization")
+        self.assertFalse(app.owner.site_admin)
+        self.assertEqual(app.name, "Octocat App")
+        self.assertEqual(app.description, "")
+        self.assertEqual(app.external_url, "https://example.com")
+        self.assertEqual(app.html_url, "https://github.com/apps/octoapp")
+        self.assertEqual(app.created_at, "2017-07-08T16:18:44-04:00")
+        self.assertEqual(app.updated_at, "2017-07-08T16:18:44-04:00")
+        self.assertEqual(app.events, ["push", "pull_request"])

--- a/tests/github/models/test_branch.py
+++ b/tests/github/models/test_branch.py
@@ -1,0 +1,670 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=line-too-long
+
+import unittest
+
+from pontos.github.api.teams import TeamPrivacy
+from pontos.github.models.branch import (
+    BranchProtection,
+    RequiredPullRequestReviews,
+    RequiredStatusChecks,
+    Restrictions,
+)
+
+
+class RestrictionsTestCase(unittest.TestCase):
+    def test_from_dict(self):
+        data = {
+            "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions",
+            "users_url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/users",
+            "teams_url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/teams",
+            "apps_url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/apps",
+            "users": [
+                {
+                    "login": "greenbonebot",
+                    "id": 123,
+                    "node_id": "MDQ6VXNlcjg1MjU0NjY2",
+                    "avatar_url": "https://avatars.githubusercontent.com/u/85254666?v=4",
+                    "gravatar_id": "",
+                    "url": "https://api.github.com/users/greenbonebot",
+                    "html_url": "https://github.com/greenbonebot",
+                    "followers_url": "https://api.github.com/users/greenbonebot/followers",
+                    "following_url": "https://api.github.com/users/greenbonebot/following{/other_user}",
+                    "gists_url": "https://api.github.com/users/greenbonebot/gists{/gist_id}",
+                    "starred_url": "https://api.github.com/users/greenbonebot/starred{/owner}{/repo}",
+                    "subscriptions_url": "https://api.github.com/users/greenbonebot/subscriptions",
+                    "organizations_url": "https://api.github.com/users/greenbonebot/orgs",
+                    "repos_url": "https://api.github.com/users/greenbonebot/repos",
+                    "events_url": "https://api.github.com/users/greenbonebot/events{/privacy}",
+                    "received_events_url": "https://api.github.com/users/greenbonebot/received_events",
+                    "type": "User",
+                    "site_admin": False,
+                }
+            ],
+            "teams": [],
+            "apps": [],
+        }
+
+        restrictions = Restrictions.from_dict(data)
+        self.assertEqual(
+            restrictions.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions",
+        )
+        self.assertEqual(
+            restrictions.users_url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/users",
+        )
+        self.assertEqual(
+            restrictions.teams_url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/teams",
+        )
+        self.assertEqual(
+            restrictions.apps_url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/apps",
+        )
+        user = restrictions.users[0]
+        self.assertEqual(len(restrictions.users), 1)
+        self.assertEqual(user.login, "greenbonebot")
+        self.assertEqual(user.node_id, "MDQ6VXNlcjg1MjU0NjY2")
+        self.assertEqual(
+            user.avatar_url,
+            "https://avatars.githubusercontent.com/u/85254666?v=4",
+        )
+        self.assertEqual(user.gravatar_id, "")
+        self.assertEqual(user.url, "https://api.github.com/users/greenbonebot")
+        self.assertEqual(user.html_url, "https://github.com/greenbonebot")
+        self.assertEqual(
+            user.followers_url,
+            "https://api.github.com/users/greenbonebot/followers",
+        )
+        self.assertEqual(
+            user.following_url,
+            "https://api.github.com/users/greenbonebot/following{/other_user}",
+        )
+        self.assertEqual(
+            user.gists_url,
+            "https://api.github.com/users/greenbonebot/gists{/gist_id}",
+        )
+        self.assertEqual(
+            user.starred_url,
+            "https://api.github.com/users/greenbonebot/starred{/owner}{/repo}",
+        )
+        self.assertEqual(
+            user.subscriptions_url,
+            "https://api.github.com/users/greenbonebot/subscriptions",
+        )
+        self.assertEqual(
+            user.organizations_url,
+            "https://api.github.com/users/greenbonebot/orgs",
+        )
+        self.assertEqual(
+            user.repos_url, "https://api.github.com/users/greenbonebot/repos"
+        )
+        self.assertEqual(
+            user.events_url,
+            "https://api.github.com/users/greenbonebot/events{/privacy}",
+        )
+        self.assertEqual(
+            user.received_events_url,
+            "https://api.github.com/users/greenbonebot/received_events",
+        )
+        self.assertEqual(user.type, "User")
+        self.assertEqual(user.site_admin, False)
+        self.assertEqual(restrictions.teams, [])
+        self.assertEqual(restrictions.apps, [])
+
+
+class RequiredStatusChecksTestCase(unittest.TestCase):
+    def test_from_dict(self):
+        data = {
+            "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_status_checks",
+            "strict": True,
+            "checks": [
+                {"context": "unittests", "app_id": 123},
+                {"context": "linting"},
+            ],
+        }
+
+        checks = RequiredStatusChecks.from_dict(data)
+
+        self.assertEqual(
+            checks.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_status_checks",
+        )
+        self.assertTrue(checks.strict)
+        self.assertEqual(len(checks.checks), 2)
+        self.assertEqual(checks.checks[0].context, "unittests")
+        self.assertEqual(checks.checks[0].app_id, 123)
+        self.assertEqual(checks.checks[1].context, "linting")
+        self.assertIsNone(checks.checks[1].app_id)
+
+
+class RequiredPullRequestReviewsTestCase(unittest.TestCase):
+    def test_from_dict(self):
+        data = {
+            "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_pull_request_reviews",
+            "dismiss_stale_reviews": True,
+            "require_code_owner_reviews": True,
+            "require_last_push_approval": True,
+            "required_approving_review_count": 1,
+            "dismissal_restrictions": {
+                "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions",
+                "users_url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions/users",
+                "teams_url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions/teams",
+                "users": [
+                    {
+                        "login": "greenbonebot",
+                        "id": 123,
+                        "node_id": "MDQ6VXNlcjg1MjU0NjY2",
+                        "avatar_url": "https://avatars.githubusercontent.com/u/85254666?v=4",
+                        "gravatar_id": "",
+                        "url": "https://api.github.com/users/greenbonebot",
+                        "html_url": "https://github.com/greenbonebot",
+                        "followers_url": "https://api.github.com/users/greenbonebot/followers",
+                        "following_url": "https://api.github.com/users/greenbonebot/following{/other_user}",
+                        "gists_url": "https://api.github.com/users/greenbonebot/gists{/gist_id}",
+                        "starred_url": "https://api.github.com/users/greenbonebot/starred{/owner}{/repo}",
+                        "subscriptions_url": "https://api.github.com/users/greenbonebot/subscriptions",
+                        "organizations_url": "https://api.github.com/users/greenbonebot/orgs",
+                        "repos_url": "https://api.github.com/users/greenbonebot/repos",
+                        "events_url": "https://api.github.com/users/greenbonebot/events{/privacy}",
+                        "received_events_url": "https://api.github.com/users/greenbonebot/received_events",
+                        "type": "User",
+                        "site_admin": False,
+                    }
+                ],
+                "teams": [
+                    {
+                        "name": "devops",
+                        "id": 123,
+                        "node_id": "T_kwDOAegUqc4AUtL1",
+                        "slug": "devops",
+                        "description": "Team responsible for DevOps",
+                        "privacy": "closed",
+                        "url": "https://api.github.com/organizations/321/team/123",
+                        "html_url": "https://github.com/orgs/foo/teams/devops",
+                        "members_url": "https://api.github.com/organizations/321/team/123/members{/member}",
+                        "repositories_url": "https://api.github.com/organizations/321/team/123/repos",
+                        "permission": "pull",
+                        "parent": None,
+                    }
+                ],
+                "apps": [],
+            },
+        }
+
+        reviews = RequiredPullRequestReviews.from_dict(data)
+
+        self.assertEqual(
+            reviews.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_pull_request_reviews",
+        )
+        self.assertTrue(reviews.dismiss_stale_reviews)
+        self.assertTrue(reviews.require_code_owner_reviews)
+        self.assertTrue(reviews.require_last_push_approval)
+        self.assertEqual(
+            reviews.required_approving_review_count,
+            1,
+        )
+        dismissal_restrictions = reviews.dismissal_restrictions
+        self.assertEqual(
+            dismissal_restrictions.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions",
+        )
+        self.assertEqual(
+            dismissal_restrictions.users_url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions/users",
+        )
+        self.assertEqual(
+            dismissal_restrictions.teams_url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions/teams",
+        )
+        self.assertEqual(dismissal_restrictions.apps, [])
+        user = dismissal_restrictions.users[0]
+        self.assertEqual(len(dismissal_restrictions.users), 1)
+        self.assertEqual(user.login, "greenbonebot")
+        self.assertEqual(user.node_id, "MDQ6VXNlcjg1MjU0NjY2")
+        self.assertEqual(
+            user.avatar_url,
+            "https://avatars.githubusercontent.com/u/85254666?v=4",
+        )
+        self.assertEqual(user.gravatar_id, "")
+        self.assertEqual(user.url, "https://api.github.com/users/greenbonebot")
+        self.assertEqual(user.html_url, "https://github.com/greenbonebot")
+        self.assertEqual(
+            user.followers_url,
+            "https://api.github.com/users/greenbonebot/followers",
+        )
+        self.assertEqual(
+            user.following_url,
+            "https://api.github.com/users/greenbonebot/following{/other_user}",
+        )
+        self.assertEqual(
+            user.gists_url,
+            "https://api.github.com/users/greenbonebot/gists{/gist_id}",
+        )
+        self.assertEqual(
+            user.starred_url,
+            "https://api.github.com/users/greenbonebot/starred{/owner}{/repo}",
+        )
+        self.assertEqual(
+            user.subscriptions_url,
+            "https://api.github.com/users/greenbonebot/subscriptions",
+        )
+        self.assertEqual(
+            user.organizations_url,
+            "https://api.github.com/users/greenbonebot/orgs",
+        )
+        self.assertEqual(
+            user.repos_url, "https://api.github.com/users/greenbonebot/repos"
+        )
+        self.assertEqual(
+            user.events_url,
+            "https://api.github.com/users/greenbonebot/events{/privacy}",
+        )
+        self.assertEqual(
+            user.received_events_url,
+            "https://api.github.com/users/greenbonebot/received_events",
+        )
+        self.assertEqual(user.type, "User")
+        self.assertEqual(user.site_admin, False)
+        self.assertEqual(len(dismissal_restrictions.teams), 1)
+        team = dismissal_restrictions.teams[0]
+        self.assertEqual(team.name, "devops")
+        self.assertEqual(team.id, 123)
+        self.assertEqual(team.node_id, "T_kwDOAegUqc4AUtL1")
+        self.assertEqual(team.slug, "devops")
+        self.assertEqual(team.description, "Team responsible for DevOps")
+        self.assertEqual(team.permission, "pull")
+        self.assertEqual(team.privacy, TeamPrivacy.CLOSED)
+        self.assertEqual(
+            team.url, "https://api.github.com/organizations/321/team/123"
+        )
+        self.assertEqual(
+            team.html_url, "https://github.com/orgs/foo/teams/devops"
+        )
+        self.assertEqual(
+            team.members_url,
+            "https://api.github.com/organizations/321/team/123/members{/member}",
+        )
+        self.assertEqual(
+            team.repositories_url,
+            "https://api.github.com/organizations/321/team/123/repos",
+        )
+        self.assertIsNone(team.parent)
+
+
+class BranchProtectionTestCase(unittest.TestCase):
+    def test_from_dict_minimal(self):
+        data = {
+            "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection",
+            "required_signatures": {
+                "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_signatures",
+                "enabled": False,
+            },
+            "enforce_admins": {
+                "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/enforce_admins",
+                "enabled": False,
+            },
+            "required_linear_history": {"enabled": False},
+            "allow_force_pushes": {"enabled": False},
+            "allow_deletions": {"enabled": False},
+            "block_creations": {"enabled": False},
+            "required_conversation_resolution": {"enabled": False},
+            "lock_branch": {"enabled": True},
+            "allow_fork_syncing": {"enabled": False},
+        }
+
+        protection = BranchProtection.from_dict(data)
+
+        self.assertEqual(
+            protection.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection",
+        )
+        self.assertEqual(
+            protection.required_signatures.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_signatures",
+        )
+        self.assertFalse(protection.required_signatures.enabled)
+        self.assertEqual(
+            protection.enforce_admins.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/enforce_admins",
+        )
+        self.assertFalse(protection.enforce_admins.enabled)
+        self.assertFalse(protection.required_linear_history.enabled)
+        self.assertFalse(protection.allow_force_pushes.enabled)
+        self.assertFalse(protection.allow_deletions.enabled)
+        self.assertFalse(protection.block_creations.enabled)
+        self.assertFalse(protection.required_conversation_resolution.enabled)
+        self.assertTrue(protection.lock_branch.enabled)
+        self.assertFalse(protection.allow_fork_syncing.enabled)
+
+        self.assertIsNone(protection.required_status_checks)
+        self.assertIsNone(protection.required_pull_request_reviews)
+        self.assertIsNone(protection.restrictions)
+
+    def test_from_dict(self):
+        data = {
+            "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection",
+            "required_status_checks": {
+                "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_status_checks",
+                "strict": True,
+                "checks": [],
+            },
+            "restrictions": {
+                "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions",
+                "users_url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/users",
+                "teams_url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/teams",
+                "apps_url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/apps",
+                "users": [
+                    {
+                        "login": "greenbonebot",
+                        "id": 123,
+                        "node_id": "MDQ6VXNlcjg1MjU0NjY2",
+                        "avatar_url": "https://avatars.githubusercontent.com/u/85254666?v=4",
+                        "gravatar_id": "",
+                        "url": "https://api.github.com/users/greenbonebot",
+                        "html_url": "https://github.com/greenbonebot",
+                        "followers_url": "https://api.github.com/users/greenbonebot/followers",
+                        "following_url": "https://api.github.com/users/greenbonebot/following{/other_user}",
+                        "gists_url": "https://api.github.com/users/greenbonebot/gists{/gist_id}",
+                        "starred_url": "https://api.github.com/users/greenbonebot/starred{/owner}{/repo}",
+                        "subscriptions_url": "https://api.github.com/users/greenbonebot/subscriptions",
+                        "organizations_url": "https://api.github.com/users/greenbonebot/orgs",
+                        "repos_url": "https://api.github.com/users/greenbonebot/repos",
+                        "events_url": "https://api.github.com/users/greenbonebot/events{/privacy}",
+                        "received_events_url": "https://api.github.com/users/greenbonebot/received_events",
+                        "type": "User",
+                        "site_admin": False,
+                    }
+                ],
+                "teams": [],
+                "apps": [],
+            },
+            "required_pull_request_reviews": {
+                "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_pull_request_reviews",
+                "dismiss_stale_reviews": True,
+                "require_code_owner_reviews": True,
+                "require_last_push_approval": True,
+                "required_approving_review_count": 1,
+                "dismissal_restrictions": {
+                    "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions",
+                    "users_url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions/users",
+                    "teams_url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions/teams",
+                    "users": [
+                        {
+                            "login": "greenbonebot",
+                            "id": 123,
+                            "node_id": "MDQ6VXNlcjg1MjU0NjY2",
+                            "avatar_url": "https://avatars.githubusercontent.com/u/85254666?v=4",
+                            "gravatar_id": "",
+                            "url": "https://api.github.com/users/greenbonebot",
+                            "html_url": "https://github.com/greenbonebot",
+                            "followers_url": "https://api.github.com/users/greenbonebot/followers",
+                            "following_url": "https://api.github.com/users/greenbonebot/following{/other_user}",
+                            "gists_url": "https://api.github.com/users/greenbonebot/gists{/gist_id}",
+                            "starred_url": "https://api.github.com/users/greenbonebot/starred{/owner}{/repo}",
+                            "subscriptions_url": "https://api.github.com/users/greenbonebot/subscriptions",
+                            "organizations_url": "https://api.github.com/users/greenbonebot/orgs",
+                            "repos_url": "https://api.github.com/users/greenbonebot/repos",
+                            "events_url": "https://api.github.com/users/greenbonebot/events{/privacy}",
+                            "received_events_url": "https://api.github.com/users/greenbonebot/received_events",
+                            "type": "User",
+                            "site_admin": False,
+                        }
+                    ],
+                    "teams": [
+                        {
+                            "name": "devops",
+                            "id": 123,
+                            "node_id": "T_kwDOAegUqc4AUtL1",
+                            "slug": "devops",
+                            "description": "Team responsible for DevOps",
+                            "privacy": "closed",
+                            "url": "https://api.github.com/organizations/321/team/123",
+                            "html_url": "https://github.com/orgs/foo/teams/devops",
+                            "members_url": "https://api.github.com/organizations/321/team/123/members{/member}",
+                            "repositories_url": "https://api.github.com/organizations/321/team/123/repos",
+                            "permission": "pull",
+                            "parent": None,
+                        }
+                    ],
+                    "apps": [],
+                },
+            },
+            "required_signatures": {
+                "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_signatures",
+                "enabled": True,
+            },
+            "enforce_admins": {
+                "url": "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/enforce_admins",
+                "enabled": True,
+            },
+            "required_linear_history": {"enabled": True},
+            "allow_force_pushes": {"enabled": False},
+            "allow_deletions": {"enabled": False},
+            "block_creations": {"enabled": True},
+            "required_conversation_resolution": {"enabled": True},
+            "lock_branch": {"enabled": True},
+            "allow_fork_syncing": {"enabled": False},
+        }
+
+        protection = BranchProtection.from_dict(data)
+
+        self.assertEqual(
+            protection.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection",
+        )
+        self.assertEqual(
+            protection.required_signatures.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_signatures",
+        )
+        self.assertTrue(protection.required_signatures.enabled)
+        self.assertEqual(
+            protection.enforce_admins.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/enforce_admins",
+        )
+        self.assertTrue(protection.enforce_admins.enabled)
+        self.assertTrue(protection.required_linear_history.enabled)
+        self.assertFalse(protection.allow_force_pushes.enabled)
+        self.assertFalse(protection.allow_deletions.enabled)
+        self.assertTrue(protection.block_creations.enabled)
+        self.assertTrue(protection.required_conversation_resolution.enabled)
+        self.assertTrue(protection.lock_branch.enabled)
+        self.assertFalse(protection.allow_fork_syncing.enabled)
+
+        self.assertEqual(
+            protection.required_status_checks.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_status_checks",
+        )
+        self.assertTrue(protection.required_status_checks.strict)
+        self.assertEqual(protection.required_status_checks.checks, [])
+
+        self.assertEqual(
+            protection.required_pull_request_reviews.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/required_pull_request_reviews",
+        )
+        self.assertTrue(
+            protection.required_pull_request_reviews.dismiss_stale_reviews
+        )
+        self.assertTrue(
+            protection.required_pull_request_reviews.require_code_owner_reviews
+        )
+        self.assertTrue(
+            protection.required_pull_request_reviews.require_last_push_approval
+        )
+        self.assertEqual(
+            protection.required_pull_request_reviews.required_approving_review_count,
+            1,
+        )
+        dismissal_restrictions = (
+            protection.required_pull_request_reviews.dismissal_restrictions
+        )
+        self.assertEqual(
+            dismissal_restrictions.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions",
+        )
+        self.assertEqual(
+            dismissal_restrictions.users_url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions/users",
+        )
+        self.assertEqual(
+            dismissal_restrictions.teams_url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/dismissal_restrictions/teams",
+        )
+        self.assertEqual(dismissal_restrictions.apps, [])
+        user = dismissal_restrictions.users[0]
+        self.assertEqual(len(dismissal_restrictions.users), 1)
+        self.assertEqual(user.login, "greenbonebot")
+        self.assertEqual(user.node_id, "MDQ6VXNlcjg1MjU0NjY2")
+        self.assertEqual(
+            user.avatar_url,
+            "https://avatars.githubusercontent.com/u/85254666?v=4",
+        )
+        self.assertEqual(user.gravatar_id, "")
+        self.assertEqual(user.url, "https://api.github.com/users/greenbonebot")
+        self.assertEqual(user.html_url, "https://github.com/greenbonebot")
+        self.assertEqual(
+            user.followers_url,
+            "https://api.github.com/users/greenbonebot/followers",
+        )
+        self.assertEqual(
+            user.following_url,
+            "https://api.github.com/users/greenbonebot/following{/other_user}",
+        )
+        self.assertEqual(
+            user.gists_url,
+            "https://api.github.com/users/greenbonebot/gists{/gist_id}",
+        )
+        self.assertEqual(
+            user.starred_url,
+            "https://api.github.com/users/greenbonebot/starred{/owner}{/repo}",
+        )
+        self.assertEqual(
+            user.subscriptions_url,
+            "https://api.github.com/users/greenbonebot/subscriptions",
+        )
+        self.assertEqual(
+            user.organizations_url,
+            "https://api.github.com/users/greenbonebot/orgs",
+        )
+        self.assertEqual(
+            user.repos_url, "https://api.github.com/users/greenbonebot/repos"
+        )
+        self.assertEqual(
+            user.events_url,
+            "https://api.github.com/users/greenbonebot/events{/privacy}",
+        )
+        self.assertEqual(
+            user.received_events_url,
+            "https://api.github.com/users/greenbonebot/received_events",
+        )
+        self.assertEqual(user.type, "User")
+        self.assertEqual(user.site_admin, False)
+        self.assertEqual(len(dismissal_restrictions.teams), 1)
+        team = dismissal_restrictions.teams[0]
+        self.assertEqual(team.name, "devops")
+        self.assertEqual(team.id, 123)
+        self.assertEqual(team.node_id, "T_kwDOAegUqc4AUtL1")
+        self.assertEqual(team.slug, "devops")
+        self.assertEqual(team.description, "Team responsible for DevOps")
+        self.assertEqual(team.permission, "pull")
+        self.assertEqual(team.privacy, TeamPrivacy.CLOSED)
+        self.assertEqual(
+            team.url, "https://api.github.com/organizations/321/team/123"
+        )
+        self.assertEqual(
+            team.html_url, "https://github.com/orgs/foo/teams/devops"
+        )
+        self.assertEqual(
+            team.members_url,
+            "https://api.github.com/organizations/321/team/123/members{/member}",
+        )
+        self.assertEqual(
+            team.repositories_url,
+            "https://api.github.com/organizations/321/team/123/repos",
+        )
+        self.assertIsNone(team.parent)
+
+        self.assertEqual(
+            protection.restrictions.url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions",
+        )
+        self.assertEqual(
+            protection.restrictions.users_url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/users",
+        )
+        self.assertEqual(
+            protection.restrictions.teams_url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/teams",
+        )
+        self.assertEqual(
+            protection.restrictions.apps_url,
+            "https://api.github.com/repos/foo/bar/branches/branch_protection/protection/restrictions/apps",
+        )
+        user = protection.restrictions.users[0]
+        self.assertEqual(len(protection.restrictions.users), 1)
+        self.assertEqual(user.login, "greenbonebot")
+        self.assertEqual(user.node_id, "MDQ6VXNlcjg1MjU0NjY2")
+        self.assertEqual(
+            user.avatar_url,
+            "https://avatars.githubusercontent.com/u/85254666?v=4",
+        )
+        self.assertEqual(user.gravatar_id, "")
+        self.assertEqual(user.url, "https://api.github.com/users/greenbonebot")
+        self.assertEqual(user.html_url, "https://github.com/greenbonebot")
+        self.assertEqual(
+            user.followers_url,
+            "https://api.github.com/users/greenbonebot/followers",
+        )
+        self.assertEqual(
+            user.following_url,
+            "https://api.github.com/users/greenbonebot/following{/other_user}",
+        )
+        self.assertEqual(
+            user.gists_url,
+            "https://api.github.com/users/greenbonebot/gists{/gist_id}",
+        )
+        self.assertEqual(
+            user.starred_url,
+            "https://api.github.com/users/greenbonebot/starred{/owner}{/repo}",
+        )
+        self.assertEqual(
+            user.subscriptions_url,
+            "https://api.github.com/users/greenbonebot/subscriptions",
+        )
+        self.assertEqual(
+            user.organizations_url,
+            "https://api.github.com/users/greenbonebot/orgs",
+        )
+        self.assertEqual(
+            user.repos_url, "https://api.github.com/users/greenbonebot/repos"
+        )
+        self.assertEqual(
+            user.events_url,
+            "https://api.github.com/users/greenbonebot/events{/privacy}",
+        )
+        self.assertEqual(
+            user.received_events_url,
+            "https://api.github.com/users/greenbonebot/received_events",
+        )
+        self.assertEqual(user.type, "User")
+        self.assertEqual(user.site_admin, False)
+        self.assertEqual(protection.restrictions.teams, [])
+        self.assertEqual(protection.restrictions.apps, [])

--- a/tests/github/models/test_organization.py
+++ b/tests/github/models/test_organization.py
@@ -1,0 +1,445 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=line-too-long, redefined-builtin
+
+import unittest
+
+from pontos.github.models.organization import License, Repository
+
+
+class LicenseTestCase(unittest.TestCase):
+    def test_from_dict(self):
+        data = {
+            "key": "gpl-3.0",
+            "name": "GNU General Public License v3.0",
+            "spdx_id": "GPL-3.0",
+            "url": "https://api.github.com/licenses/gpl-3.0",
+            "node_id": "MDc6TGljZW5zZTk=",
+        }
+
+        license = License.from_dict(data)
+
+        self.assertEqual(license.key, "gpl-3.0")
+        self.assertEqual(license.name, "GNU General Public License v3.0")
+        self.assertEqual(license.spdx_id, "GPL-3.0")
+        self.assertEqual(license.url, "https://api.github.com/licenses/gpl-3.0")
+        self.assertEqual(license.node_id, "MDc6TGljZW5zZTk=")
+
+
+class RepositoryTestCase(unittest.TestCase):
+    def test_from_dict(self):
+        data = {
+            "id": 103647077,
+            "node_id": "MDEwOlJlcG9zaXRvcnkxMDM2NDcwNzc=",
+            "name": "gvm-tools",
+            "full_name": "greenbone/gvm-tools",
+            "private": False,
+            "owner": {
+                "login": "greenbone",
+                "id": 31986857,
+                "node_id": "MDEyOk9yZ2FuaXphdGlvbjMxOTg2ODU3",
+                "avatar_url": "https://avatars.githubusercontent.com/u/31986857?v=4",
+                "gravatar_id": "",
+                "url": "https://api.github.com/users/greenbone",
+                "html_url": "https://github.com/greenbone",
+                "followers_url": "https://api.github.com/users/greenbone/followers",
+                "following_url": "https://api.github.com/users/greenbone/following{/other_user}",
+                "gists_url": "https://api.github.com/users/greenbone/gists{/gist_id}",
+                "starred_url": "https://api.github.com/users/greenbone/starred{/owner}{/repo}",
+                "subscriptions_url": "https://api.github.com/users/greenbone/subscriptions",
+                "organizations_url": "https://api.github.com/users/greenbone/orgs",
+                "repos_url": "https://api.github.com/users/greenbone/repos",
+                "events_url": "https://api.github.com/users/greenbone/events{/privacy}",
+                "received_events_url": "https://api.github.com/users/greenbone/received_events",
+                "type": "Organization",
+                "site_admin": False,
+            },
+            "html_url": "https://github.com/greenbone/gvm-tools",
+            "description": "Remote control your Greenbone Community Edition or Greenbone Enterprise Appliance",
+            "fork": False,
+            "url": "https://api.github.com/repos/greenbone/gvm-tools",
+            "forks_url": "https://api.github.com/repos/greenbone/gvm-tools/forks",
+            "keys_url": "https://api.github.com/repos/greenbone/gvm-tools/keys{/key_id}",
+            "collaborators_url": "https://api.github.com/repos/greenbone/gvm-tools/collaborators{/collaborator}",
+            "teams_url": "https://api.github.com/repos/greenbone/gvm-tools/teams",
+            "hooks_url": "https://api.github.com/repos/greenbone/gvm-tools/hooks",
+            "issue_events_url": "https://api.github.com/repos/greenbone/gvm-tools/issues/events{/number}",
+            "events_url": "https://api.github.com/repos/greenbone/gvm-tools/events",
+            "assignees_url": "https://api.github.com/repos/greenbone/gvm-tools/assignees{/user}",
+            "branches_url": "https://api.github.com/repos/greenbone/gvm-tools/branches{/branch}",
+            "tags_url": "https://api.github.com/repos/greenbone/gvm-tools/tags",
+            "blobs_url": "https://api.github.com/repos/greenbone/gvm-tools/git/blobs{/sha}",
+            "git_tags_url": "https://api.github.com/repos/greenbone/gvm-tools/git/tags{/sha}",
+            "git_refs_url": "https://api.github.com/repos/greenbone/gvm-tools/git/refs{/sha}",
+            "trees_url": "https://api.github.com/repos/greenbone/gvm-tools/git/trees{/sha}",
+            "statuses_url": "https://api.github.com/repos/greenbone/gvm-tools/statuses/{sha}",
+            "languages_url": "https://api.github.com/repos/greenbone/gvm-tools/languages",
+            "stargazers_url": "https://api.github.com/repos/greenbone/gvm-tools/stargazers",
+            "contributors_url": "https://api.github.com/repos/greenbone/gvm-tools/contributors",
+            "subscribers_url": "https://api.github.com/repos/greenbone/gvm-tools/subscribers",
+            "subscription_url": "https://api.github.com/repos/greenbone/gvm-tools/subscription",
+            "commits_url": "https://api.github.com/repos/greenbone/gvm-tools/commits{/sha}",
+            "git_commits_url": "https://api.github.com/repos/greenbone/gvm-tools/git/commits{/sha}",
+            "comments_url": "https://api.github.com/repos/greenbone/gvm-tools/comments{/number}",
+            "issue_comment_url": "https://api.github.com/repos/greenbone/gvm-tools/issues/comments{/number}",
+            "contents_url": "https://api.github.com/repos/greenbone/gvm-tools/contents/{+path}",
+            "compare_url": "https://api.github.com/repos/greenbone/gvm-tools/compare/{base}...{head}",
+            "merges_url": "https://api.github.com/repos/greenbone/gvm-tools/merges",
+            "archive_url": "https://api.github.com/repos/greenbone/gvm-tools/{archive_format}{/ref}",
+            "downloads_url": "https://api.github.com/repos/greenbone/gvm-tools/downloads",
+            "issues_url": "https://api.github.com/repos/greenbone/gvm-tools/issues{/number}",
+            "pulls_url": "https://api.github.com/repos/greenbone/gvm-tools/pulls{/number}",
+            "milestones_url": "https://api.github.com/repos/greenbone/gvm-tools/milestones{/number}",
+            "notifications_url": "https://api.github.com/repos/greenbone/gvm-tools/notifications{?since,all,participating}",
+            "labels_url": "https://api.github.com/repos/greenbone/gvm-tools/labels{/name}",
+            "releases_url": "https://api.github.com/repos/greenbone/gvm-tools/releases{/id}",
+            "deployments_url": "https://api.github.com/repos/greenbone/gvm-tools/deployments",
+            "created_at": "2017-09-15T10:54:42Z",
+            "updated_at": "2022-11-01T07:45:33Z",
+            "pushed_at": "2022-11-07T09:21:30Z",
+            "git_url": "git://github.com/greenbone/gvm-tools.git",
+            "ssh_url": "git@github.com:greenbone/gvm-tools.git",
+            "clone_url": "https://github.com/greenbone/gvm-tools.git",
+            "svn_url": "https://github.com/greenbone/gvm-tools",
+            "homepage": "https://greenbone.github.io/gvm-tools/",
+            "size": 3461,
+            "stargazers_count": 128,
+            "watchers_count": 128,
+            "language": "Python",
+            "has_issues": True,
+            "has_projects": False,
+            "has_downloads": True,
+            "has_wiki": True,
+            "has_pages": True,
+            "has_discussions": False,
+            "forks_count": 74,
+            "mirror_url": None,
+            "archived": False,
+            "disabled": False,
+            "open_issues_count": 3,
+            "license": {
+                "key": "gpl-3.0",
+                "name": "GNU General Public License v3.0",
+                "spdx_id": "GPL-3.0",
+                "url": "https://api.github.com/licenses/gpl-3.0",
+                "node_id": "MDc6TGljZW5zZTk=",
+            },
+            "allow_forking": True,
+            "is_template": False,
+            "web_commit_signoff_required": False,
+            "topics": [
+                "gmp",
+                "gmp-scripts",
+                "greenbone",
+                "greenbone-vulnerability-manager",
+                "gvm",
+                "gvm-cli",
+                "gvm-pyshell",
+                "gvm-script",
+                "omp",
+                "openvas",
+                "openvas-cli",
+                "osp",
+                "python",
+                "vulnerability",
+                "vulnerability-assessment",
+                "vulnerability-management",
+            ],
+            "visibility": "public",
+            "forks": 74,
+            "open_issues": 3,
+            "watchers": 128,
+            "default_branch": "main",
+        }
+
+        repo = Repository.from_dict(data)
+
+        self.assertEqual(repo.id, 103647077)
+        self.assertEqual(repo.node_id, "MDEwOlJlcG9zaXRvcnkxMDM2NDcwNzc=")
+        self.assertEqual(repo.name, "gvm-tools")
+        self.assertEqual(repo.full_name, "greenbone/gvm-tools")
+        self.assertEqual(repo.private, False)
+        self.assertEqual(repo.owner.login, "greenbone")
+        self.assertEqual(repo.owner.id, 31986857)
+        self.assertEqual(repo.owner.node_id, "MDEyOk9yZ2FuaXphdGlvbjMxOTg2ODU3")
+        self.assertEqual(
+            repo.owner.avatar_url,
+            "https://avatars.githubusercontent.com/u/31986857?v=4",
+        )
+        self.assertEqual(repo.owner.gravatar_id, "")
+        self.assertEqual(
+            repo.owner.url, "https://api.github.com/users/greenbone"
+        )
+        self.assertEqual(repo.owner.html_url, "https://github.com/greenbone")
+        self.assertEqual(
+            repo.owner.followers_url,
+            "https://api.github.com/users/greenbone/followers",
+        )
+        self.assertEqual(
+            repo.owner.following_url,
+            "https://api.github.com/users/greenbone/following{/other_user}",
+        )
+        self.assertEqual(
+            repo.owner.gists_url,
+            "https://api.github.com/users/greenbone/gists{/gist_id}",
+        )
+        self.assertEqual(
+            repo.owner.starred_url,
+            "https://api.github.com/users/greenbone/starred{/owner}{/repo}",
+        )
+        self.assertEqual(
+            repo.owner.subscriptions_url,
+            "https://api.github.com/users/greenbone/subscriptions",
+        )
+        self.assertEqual(
+            repo.owner.organizations_url,
+            "https://api.github.com/users/greenbone/orgs",
+        )
+        self.assertEqual(
+            repo.owner.repos_url, "https://api.github.com/users/greenbone/repos"
+        )
+        self.assertEqual(
+            repo.owner.events_url,
+            "https://api.github.com/users/greenbone/events{/privacy}",
+        )
+        self.assertEqual(
+            repo.owner.received_events_url,
+            "https://api.github.com/users/greenbone/received_events",
+        )
+        self.assertEqual(repo.owner.type, "Organization")
+        self.assertFalse(repo.owner.site_admin)
+        self.assertEqual(
+            repo.html_url, "https://github.com/greenbone/gvm-tools"
+        )
+        self.assertEqual(
+            repo.description,
+            "Remote control your Greenbone Community Edition or Greenbone Enterprise Appliance",
+        )
+        self.assertEqual(repo.fork, False)
+        self.assertEqual(
+            repo.url, "https://api.github.com/repos/greenbone/gvm-tools"
+        )
+        self.assertEqual(
+            repo.forks_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/forks",
+        )
+        self.assertEqual(
+            repo.keys_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/keys{/key_id}",
+        )
+        self.assertEqual(
+            repo.collaborators_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/collaborators{/collaborator}",
+        )
+        self.assertEqual(
+            repo.teams_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/teams",
+        )
+        self.assertEqual(
+            repo.hooks_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/hooks",
+        )
+        self.assertEqual(
+            repo.issue_events_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/issues/events{/number}",
+        )
+        self.assertEqual(
+            repo.events_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/events",
+        )
+        self.assertEqual(
+            repo.assignees_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/assignees{/user}",
+        )
+        self.assertEqual(
+            repo.branches_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/branches{/branch}",
+        )
+        self.assertEqual(
+            repo.tags_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/tags",
+        )
+        self.assertEqual(
+            repo.blobs_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/git/blobs{/sha}",
+        )
+        self.assertEqual(
+            repo.git_tags_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/git/tags{/sha}",
+        )
+        self.assertEqual(
+            repo.git_refs_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/git/refs{/sha}",
+        )
+        self.assertEqual(
+            repo.trees_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/git/trees{/sha}",
+        )
+        self.assertEqual(
+            repo.statuses_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/statuses/{sha}",
+        )
+        self.assertEqual(
+            repo.languages_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/languages",
+        )
+        self.assertEqual(
+            repo.stargazers_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/stargazers",
+        )
+        self.assertEqual(
+            repo.contributors_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/contributors",
+        )
+        self.assertEqual(
+            repo.subscribers_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/subscribers",
+        )
+        self.assertEqual(
+            repo.subscription_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/subscription",
+        )
+        self.assertEqual(
+            repo.commits_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/commits{/sha}",
+        )
+        self.assertEqual(
+            repo.git_commits_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/git/commits{/sha}",
+        )
+        self.assertEqual(
+            repo.comments_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/comments{/number}",
+        )
+        self.assertEqual(
+            repo.issue_comment_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/issues/comments{/number}",
+        )
+        self.assertEqual(
+            repo.contents_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/contents/{+path}",
+        )
+        self.assertEqual(
+            repo.compare_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/compare/{base}...{head}",
+        )
+        self.assertEqual(
+            repo.merges_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/merges",
+        )
+        self.assertEqual(
+            repo.archive_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/{archive_format}{/ref}",
+        )
+        self.assertEqual(
+            repo.downloads_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/downloads",
+        )
+        self.assertEqual(
+            repo.issues_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/issues{/number}",
+        )
+        self.assertEqual(
+            repo.pulls_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/pulls{/number}",
+        )
+        self.assertEqual(
+            repo.milestones_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/milestones{/number}",
+        )
+        self.assertEqual(
+            repo.notifications_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/notifications{?since,all,participating}",
+        )
+        self.assertEqual(
+            repo.labels_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/labels{/name}",
+        )
+        self.assertEqual(
+            repo.releases_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/releases{/id}",
+        )
+        self.assertEqual(
+            repo.deployments_url,
+            "https://api.github.com/repos/greenbone/gvm-tools/deployments",
+        )
+        self.assertEqual(repo.created_at, "2017-09-15T10:54:42Z")
+        self.assertEqual(repo.updated_at, "2022-11-01T07:45:33Z")
+        self.assertEqual(repo.pushed_at, "2022-11-07T09:21:30Z")
+        self.assertEqual(
+            repo.git_url, "git://github.com/greenbone/gvm-tools.git"
+        )
+        self.assertEqual(repo.ssh_url, "git@github.com:greenbone/gvm-tools.git")
+        self.assertEqual(
+            repo.clone_url, "https://github.com/greenbone/gvm-tools.git"
+        )
+        self.assertEqual(repo.svn_url, "https://github.com/greenbone/gvm-tools")
+        self.assertEqual(
+            repo.homepage, "https://greenbone.github.io/gvm-tools/"
+        )
+        self.assertEqual(repo.size, 3461)
+        self.assertEqual(repo.stargazers_count, 128)
+        self.assertEqual(repo.watchers_count, 128)
+        self.assertEqual(repo.language, "Python")
+        self.assertEqual(repo.has_issues, True)
+        self.assertEqual(repo.has_projects, False)
+        self.assertEqual(repo.has_downloads, True)
+        self.assertEqual(repo.has_wiki, True)
+        self.assertEqual(repo.has_pages, True)
+        self.assertEqual(repo.has_discussions, False)
+        self.assertEqual(repo.forks_count, 74)
+        self.assertEqual(repo.mirror_url, None)
+        self.assertEqual(repo.archived, False)
+        self.assertEqual(repo.disabled, False)
+        self.assertEqual(repo.open_issues_count, 3)
+        self.assertEqual(repo.license.key, "gpl-3.0")
+        self.assertEqual(repo.license.name, "GNU General Public License v3.0")
+        self.assertEqual(repo.license.spdx_id, "GPL-3.0")
+        self.assertEqual(
+            repo.license.url, "https://api.github.com/licenses/gpl-3.0"
+        )
+        self.assertEqual(repo.license.node_id, "MDc6TGljZW5zZTk=")
+        self.assertTrue(repo.allow_forking)
+        self.assertFalse(repo.is_template)
+        self.assertFalse(repo.web_commit_signoff_required)
+        self.assertEqual(
+            repo.topics,
+            [
+                "gmp",
+                "gmp-scripts",
+                "greenbone",
+                "greenbone-vulnerability-manager",
+                "gvm",
+                "gvm-cli",
+                "gvm-pyshell",
+                "gvm-script",
+                "omp",
+                "openvas",
+                "openvas-cli",
+                "osp",
+                "python",
+                "vulnerability",
+                "vulnerability-assessment",
+                "vulnerability-management",
+            ],
+        )
+        self.assertEqual(repo.visibility, "public")
+        self.assertEqual(repo.forks, 74)
+        self.assertEqual(repo.open_issues, 3)
+        self.assertEqual(repo.watchers, 128)
+        self.assertEqual(repo.default_branch, "main")


### PR DESCRIPTION
**What**:

GitHub Models are classes to represent data returned by GitHub REST API responses for example a Repository, Organization, User, ...

**Why**:

It's not often obvious what's returned from GitHub responses and also the docs about these responses are outdated and missing information. Therefore add model classes that contain (and hopefully also document) the data of the responses.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
