### PR TITLE
Change: Use AsyncIterators for async GitHub API returning several values

### DIFF
--- a/pontos/github/api/artifacts.py
+++ b/pontos/github/api/artifacts.py
@@ -18,6 +18,7 @@
 from pathlib import Path
 from typing import (
     AsyncContextManager,
+    AsyncIterator,
     ContextManager,
     Iterable,
     Optional,
@@ -37,12 +38,12 @@ from pontos.helper import (
 
 
 class GitHubAsyncRESTArtifacts(GitHubAsyncREST):
-    async def _get_paged_artifacts(
+    def _get_paged_artifacts(
         self, api, *, params: Optional[Params] = None
-    ) -> Iterable[JSON_OBJECT]:
-        return await self._get_paged_items(api, "artifacts", params=params)
+    ) -> AsyncIterator[JSON_OBJECT]:
+        return self._get_paged_items(api, "artifacts", params=params)
 
-    async def get_all(self, repo: str) -> Iterable[JSON_OBJECT]:
+    def get_all(self, repo: str) -> AsyncIterator[JSON_OBJECT]:
         """
         List all artifacts of a repository
 
@@ -57,7 +58,7 @@ class GitHubAsyncRESTArtifacts(GitHubAsyncREST):
             Information about the artifacts in the repository as a dict
         """
         api = f"/repos/{repo}/actions/artifacts"
-        return await self._get_paged_artifacts(api)
+        return self._get_paged_artifacts(api)
 
     async def get(self, repo: str, artifact: str) -> JSON_OBJECT:
         """
@@ -79,9 +80,9 @@ class GitHubAsyncRESTArtifacts(GitHubAsyncREST):
         response.raise_for_status()
         return response.json()
 
-    async def get_workflow_run_artifacts(
+    def get_workflow_run_artifacts(
         self, repo: str, run: str
-    ) -> Iterable[JSON_OBJECT]:
+    ) -> AsyncIterator[JSON_OBJECT]:
         """
         List all artifacts for a workflow run
 
@@ -97,7 +98,7 @@ class GitHubAsyncRESTArtifacts(GitHubAsyncREST):
             Information about the artifacts in the workflow as a dict
         """
         api = f"/repos/{repo}/actions/runs/{run}/artifacts"
-        return await self._get_paged_artifacts(api)
+        return self._get_paged_artifacts(api)
 
     async def delete(self, repo: str, artifact: str):
         """

--- a/pontos/github/api/client.py
+++ b/pontos/github/api/client.py
@@ -18,15 +18,7 @@
 
 from contextlib import AbstractAsyncContextManager
 from types import TracebackType
-from typing import (
-    Any,
-    AsyncContextManager,
-    AsyncIterator,
-    Dict,
-    Iterable,
-    Optional,
-    Type,
-)
+from typing import Any, AsyncContextManager, AsyncIterator, Dict, Optional, Type
 
 import httpx
 
@@ -275,7 +267,7 @@ class GitHubAsyncREST:
 
     async def _get_paged_items(
         self, api: str, name: str, *, params: Optional[Params] = None
-    ) -> Iterable[JSON_OBJECT]:
+    ) -> AsyncIterator[JSON_OBJECT]:
         """
         Internal method to get the paged items information from different REST
         URLs.
@@ -285,11 +277,8 @@ class GitHubAsyncREST:
 
         params["per_page"] = "100"  # max number
 
-        items = []
-
         async for response in self._client.get_all(api, params=params):
             response.raise_for_status()
             data: JSON_OBJECT = response.json()
-            items.extend(data.get(name, []))
-
-        return items
+            for item in data.get(name, []):
+                yield item

--- a/pontos/github/api/labels.py
+++ b/pontos/github/api/labels.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 
-from typing import Iterable, List
+from typing import AsyncIterator, Iterable, List
 
 import httpx
 
@@ -29,7 +29,7 @@ class GitHubAsyncRESTLabels(GitHubAsyncREST):
         self,
         repo: str,
         issue: int,
-    ) -> Iterable[str]:
+    ) -> AsyncIterator[str]:
         """
         Get all labels that are set in the issue/pr
 
@@ -43,16 +43,12 @@ class GitHubAsyncRESTLabels(GitHubAsyncREST):
         api = f"/repos/{repo}/issues/{issue}/labels"
         params = {"per_page": "100"}
 
-        items = []
-
         async for response in self._client.get_all(api, params=params):
             response.raise_for_status()
             data: JSON = response.json()
 
             for label in data:
-                items.append(label["name"])
-
-        return items
+                yield label["name"]
 
     async def set_all(
         self, repo: str, issue: int, labels: Iterable[str]

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from enum import Enum
-from typing import Iterable, Optional
+from typing import AsyncIterator, Iterable, Optional
 
 import httpx
 
@@ -59,7 +59,7 @@ class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
         organization: str,
         *,
         repository_type: RepositoryType = RepositoryType.ALL,
-    ) -> Iterable[JSON_OBJECT]:
+    ) -> AsyncIterator[JSON_OBJECT]:
         """
         Get information about organization repositories
 
@@ -73,14 +73,11 @@ class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
         """
         api = f"/orgs/{organization}/repos"
         params = {"type": repository_type.value, "per_page": "100"}
-        repos = []
 
         async for response in self._client.get_all(api, params=params):
             response.raise_for_status()
-
-            repos.extend(response.json())
-
-        return repos
+            for repo in response.json():
+                yield repo
 
     async def members(
         self,
@@ -88,7 +85,7 @@ class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
         *,
         member_filter: MemberFilter = MemberFilter.ALL,
         role: MemberRole = MemberRole.ALL,
-    ) -> Iterable[JSON_OBJECT]:
+    ) -> AsyncIterator[JSON_OBJECT]:
         """
         Get information about organization members
 
@@ -107,14 +104,11 @@ class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
             "per_page": "100",
             "role": role.value,
         }
-        members = []
-
         async for response in self._client.get_all(api, params=params):
             response.raise_for_status()
 
-            members.extend(response.json())
-
-        return members
+            for member in response.json():
+                yield member
 
     async def invite(
         self,
@@ -194,7 +188,7 @@ class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
         organization: str,
         *,
         member_filter: MemberFilter = MemberFilter.ALL,
-    ) -> Iterable[JSON_OBJECT]:
+    ) -> AsyncIterator[JSON_OBJECT]:
         """
         Get information about outside collaborators of an organization
 
@@ -212,14 +206,11 @@ class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
             "filter": member_filter.value,
             "per_page": "100",
         }
-        members = []
-
         async for response in self._client.get_all(api, params=params):
             response.raise_for_status()
 
-            members.extend(response.json())
-
-        return members
+            for member in response.json():
+                yield member
 
     async def remove_outside_collaborator(
         self,

--- a/pontos/github/api/pull_requests.py
+++ b/pontos/github/api/pull_requests.py
@@ -17,7 +17,7 @@
 
 from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Iterable, Iterator, Optional
+from typing import AsyncIterator, Dict, Iterable, Iterator, Optional
 
 import httpx
 
@@ -40,7 +40,7 @@ class GitHubAsyncRESTPullRequests(GitHubAsyncREST):
 
     async def commits(
         self, repo: str, pull_request: int
-    ) -> Iterable[JSON_OBJECT]:
+    ) -> AsyncIterator[JSON_OBJECT]:
         """
         Get all commit information of a pull request
 
@@ -57,12 +57,10 @@ class GitHubAsyncRESTPullRequests(GitHubAsyncREST):
         # possible to receive 100
         params = {"per_page": "100"}
         api = f"/repos/{repo}/pulls/{pull_request}/commits"
-        commits = []
 
         async for response in self._client.get_all(api, params=params):
-            commits.extend(response.json())
-
-        return commits
+            for commit in response.json():
+                yield commit
 
     async def create(
         self,

--- a/pontos/github/api/teams.py
+++ b/pontos/github/api/teams.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from enum import Enum
-from typing import Iterable, Optional
+from typing import AsyncIterator, Iterable, Optional
 
 from pontos.github.api.client import GitHubAsyncREST
 from pontos.github.api.helper import JSON_OBJECT
@@ -33,7 +33,7 @@ class TeamRole(Enum):
 
 
 class GitHubAsyncRESTTeams(GitHubAsyncREST):
-    async def get_all(self, organization: str) -> Iterable[JSON_OBJECT]:
+    async def get_all(self, organization: str) -> AsyncIterator[JSON_OBJECT]:
         """
         Get information about teams of an organization.
 
@@ -46,7 +46,6 @@ class GitHubAsyncRESTTeams(GitHubAsyncREST):
             `httpx.HTTPStatusError` if there was an error in the request
         """
         api = f"/orgs/{organization}/teams"
-        teams = []
         params = {
             "per_page": "100",
         }
@@ -54,9 +53,8 @@ class GitHubAsyncRESTTeams(GitHubAsyncREST):
         async for response in self._client.get_all(api, params=params):
             response.raise_for_status()
 
-            teams.extend(response.json())
-
-        return teams
+            for team in response.json():
+                yield team
 
     async def create(
         self,
@@ -214,7 +212,7 @@ class GitHubAsyncRESTTeams(GitHubAsyncREST):
         self,
         organization: str,
         team: str,
-    ) -> Iterable[JSON_OBJECT]:
+    ) -> AsyncIterator[JSON_OBJECT]:
         """
         Get all members of a team. Team members will include the members of
         child teams.
@@ -229,7 +227,6 @@ class GitHubAsyncRESTTeams(GitHubAsyncREST):
             `httpx.HTTPStatusError` if there was an error in the request
         """
         api = f"/orgs/{organization}/teams/{team}/members"
-        members = []
         params = {
             "per_page": "100",
         }
@@ -237,9 +234,8 @@ class GitHubAsyncRESTTeams(GitHubAsyncREST):
         async for response in self._client.get_all(api, params=params):
             response.raise_for_status()
 
-            members.extend(response.json())
-
-        return members
+            for member in response.json():
+                yield member
 
     async def update_member(
         self,
@@ -299,7 +295,7 @@ class GitHubAsyncRESTTeams(GitHubAsyncREST):
         self,
         organization: str,
         team: str,
-    ) -> Iterable[JSON_OBJECT]:
+    ) -> AsyncIterator[JSON_OBJECT]:
         """
         Lists a team's repositories visible to the authenticated user.
 
@@ -313,7 +309,6 @@ class GitHubAsyncRESTTeams(GitHubAsyncREST):
             `httpx.HTTPStatusError` if there was an error in the request
         """
         api = f"/orgs/{organization}/teams/{team}/repos"
-        repos = []
         params = {
             "per_page": "100",
         }
@@ -321,6 +316,5 @@ class GitHubAsyncRESTTeams(GitHubAsyncREST):
         async for response in self._client.get_all(api, params=params):
             response.raise_for_status()
 
-            repos.extend(response.json())
-
-        return repos
+            for repo in response.json():
+                yield repo

--- a/pontos/github/api/workflows.py
+++ b/pontos/github/api/workflows.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Dict, Iterable, Optional
+from typing import AsyncIterator, Dict, Iterable, Optional
 
 import httpx
 
@@ -24,7 +24,7 @@ from pontos.github.api.helper import JSON_OBJECT
 
 
 class GitHubAsyncRESTWorkflows(GitHubAsyncREST):
-    async def get_all(self, repo: str) -> Iterable[JSON_OBJECT]:
+    def get_all(self, repo: str) -> AsyncIterator[JSON_OBJECT]:
         """
         List all workflows of a repository
 
@@ -39,7 +39,7 @@ class GitHubAsyncRESTWorkflows(GitHubAsyncREST):
             Information about the workflows as an iterable of dicts
         """
         api = f"/repos/{repo}/actions/workflows"
-        return await self._get_paged_items(api, "workflows")
+        return self._get_paged_items(api, "workflows")
 
     async def get(self, repo: str, workflow: str) -> JSON_OBJECT:
         """
@@ -104,7 +104,7 @@ class GitHubAsyncRESTWorkflows(GitHubAsyncREST):
         response = await self._client.post(api, data=data)
         response.raise_for_status()
 
-    async def get_workflow_runs(
+    def get_workflow_runs(
         self,
         repo: str,
         workflow: Optional[str] = None,
@@ -115,7 +115,7 @@ class GitHubAsyncRESTWorkflows(GitHubAsyncREST):
         status: Optional[str] = None,
         created: Optional[str] = None,
         exclude_pull_requests: Optional[bool] = None,
-    ) -> Iterable[JSON_OBJECT]:
+    ) -> AsyncIterator[JSON_OBJECT]:
         # pylint: disable=line-too-long
         """
         List all workflow runs of a repository or of a specific workflow.
@@ -168,7 +168,7 @@ class GitHubAsyncRESTWorkflows(GitHubAsyncREST):
         if exclude_pull_requests is not None:
             params["exclude_pull_requests"] = exclude_pull_requests
 
-        return await self._get_paged_items(api, "workflow_runs", params=params)
+        return self._get_paged_items(api, "workflow_runs", params=params)
 
     async def get_workflow_run(self, repo: str, run: str) -> JSON_OBJECT:
         """

--- a/tests/github/api/test_artifacts.py
+++ b/tests/github/api/test_artifacts.py
@@ -72,9 +72,16 @@ class GitHubAsyncRESTArtifactsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        workflows = await self.api.get_all("foo/bar")
+        async_it = aiter(self.api.get_all("foo/bar"))
+        artifact = await anext(async_it)
+        self.assertEqual(artifact["id"], 1)
+        artifact = await anext(async_it)
+        self.assertEqual(artifact["id"], 2)
+        artifact = await anext(async_it)
+        self.assertEqual(artifact["id"], 3)
 
-        self.assertEqual(len(workflows), 3)
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/repos/foo/bar/actions/artifacts",
@@ -91,9 +98,16 @@ class GitHubAsyncRESTArtifactsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        workflows = await self.api.get_workflow_run_artifacts("foo/bar", "123")
+        async_it = aiter(self.api.get_workflow_run_artifacts("foo/bar", "123"))
+        artifact = await anext(async_it)
+        self.assertEqual(artifact["id"], 1)
+        artifact = await anext(async_it)
+        self.assertEqual(artifact["id"], 2)
+        artifact = await anext(async_it)
+        self.assertEqual(artifact["id"], 3)
 
-        self.assertEqual(len(workflows), 3)
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/repos/foo/bar/actions/runs/123/artifacts",

--- a/tests/github/api/test_organizations.py
+++ b/tests/github/api/test_organizations.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines, redefined-builtin
 
 import unittest
 from pathlib import Path
@@ -31,7 +31,7 @@ from pontos.github.api.organizations import (
     MemberFilter,
     MemberRole,
 )
-from tests import AsyncIteratorMock
+from tests import AsyncIteratorMock, aiter, anext
 from tests.github.api import (
     GitHubAsyncRESTTestCase,
     create_response,
@@ -70,10 +70,16 @@ class GitHubAsyncRESTOrganizationsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        repos = await self.api.get_repositories("foo")
+        async_it = aiter(self.api.get_repositories("foo"))
+        repo = await anext(async_it)
+        self.assertEqual(repo["id"], 1)
+        repo = await anext(async_it)
+        self.assertEqual(repo["id"], 2)
+        repo = await anext(async_it)
+        self.assertEqual(repo["id"], 3)
 
-        self.assertEqual(len(repos), 3)
-        self.assertEqual(repos, [{"id": 1}, {"id": 2}, {"id": 3}])
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/orgs/foo/repos",
@@ -90,12 +96,20 @@ class GitHubAsyncRESTOrganizationsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        repos = await self.api.get_repositories(
-            "foo", repository_type=RepositoryType.PRIVATE
+        async_it = aiter(
+            self.api.get_repositories(
+                "foo", repository_type=RepositoryType.PRIVATE
+            )
         )
+        repo = await anext(async_it)
+        self.assertEqual(repo["id"], 1)
+        repo = await anext(async_it)
+        self.assertEqual(repo["id"], 2)
+        repo = await anext(async_it)
+        self.assertEqual(repo["id"], 3)
 
-        self.assertEqual(len(repos), 3)
-        self.assertEqual(repos, [{"id": 1}, {"id": 2}, {"id": 3}])
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/orgs/foo/repos",
@@ -112,10 +126,16 @@ class GitHubAsyncRESTOrganizationsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        members = await self.api.members("foo")
+        async_it = aiter(self.api.members("foo"))
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 1)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 2)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 3)
 
-        self.assertEqual(len(members), 3)
-        self.assertEqual(members, [{"id": 1}, {"id": 2}, {"id": 3}])
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/orgs/foo/members",
@@ -132,10 +152,16 @@ class GitHubAsyncRESTOrganizationsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        members = await self.api.members("foo", role=MemberRole.ADMIN)
+        async_it = aiter(self.api.members("foo", role=MemberRole.ADMIN))
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 1)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 2)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 3)
 
-        self.assertEqual(len(members), 3)
-        self.assertEqual(members, [{"id": 1}, {"id": 2}, {"id": 3}])
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/orgs/foo/members",
@@ -152,12 +178,18 @@ class GitHubAsyncRESTOrganizationsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        members = await self.api.members(
-            "foo", member_filter=MemberFilter.TWO_FA_DISABLED
+        async_it = aiter(
+            self.api.members("foo", member_filter=MemberFilter.TWO_FA_DISABLED)
         )
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 1)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 2)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 3)
 
-        self.assertEqual(len(members), 3)
-        self.assertEqual(members, [{"id": 1}, {"id": 2}, {"id": 3}])
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/orgs/foo/members",
@@ -263,10 +295,16 @@ class GitHubAsyncRESTOrganizationsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        members = await self.api.outside_collaborators("foo")
+        async_it = aiter(self.api.outside_collaborators("foo"))
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 1)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 2)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 3)
 
-        self.assertEqual(len(members), 3)
-        self.assertEqual(members, [{"id": 1}, {"id": 2}, {"id": 3}])
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/orgs/foo/outside_collaborators",
@@ -283,19 +321,27 @@ class GitHubAsyncRESTOrganizationsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        members = await self.api.outside_collaborators(
-            "foo", member_filter=MemberFilter.TWO_FA_DISABLED
+        async_it = aiter(
+            self.api.outside_collaborators(
+                "foo", member_filter=MemberFilter.TWO_FA_DISABLED
+            )
         )
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 1)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 2)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 3)
 
-        self.assertEqual(len(members), 3)
-        self.assertEqual(members, [{"id": 1}, {"id": 2}, {"id": 3}])
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/orgs/foo/outside_collaborators",
             params={"per_page": "100", "filter": "2fa_disabled"},
         )
 
-    async def test_outside_collaborator(self):
+    async def test_remove_outside_collaborator(self):
         response = create_response(is_success=False)
         self.client.delete.return_value = response
 

--- a/tests/github/api/test_teams.py
+++ b/tests/github/api/test_teams.py
@@ -14,12 +14,15 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=redefined-builtin
+
 from unittest.mock import MagicMock
 
 import httpx
 
 from pontos.github.api.teams import GitHubAsyncRESTTeams, TeamPrivacy, TeamRole
-from tests import AsyncIteratorMock
+from tests import AsyncIteratorMock, aiter, anext
 from tests.github.api import GitHubAsyncRESTTestCase, create_response
 
 
@@ -36,10 +39,16 @@ class GitHubAsyncRESTTeamsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        repos = await self.api.get_all("foo")
+        async_it = aiter(self.api.get_all("foo"))
+        team = await anext(async_it)
+        self.assertEqual(team["id"], 1)
+        team = await anext(async_it)
+        self.assertEqual(team["id"], 2)
+        team = await anext(async_it)
+        self.assertEqual(team["id"], 3)
 
-        self.assertEqual(len(repos), 3)
-        self.assertEqual(repos, [{"id": 1}, {"id": 2}, {"id": 3}])
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/orgs/foo/teams",
@@ -206,10 +215,16 @@ class GitHubAsyncRESTTeamsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        repos = await self.api.members("foo", "bar")
+        async_it = aiter(self.api.members("foo", "bar"))
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 1)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 2)
+        member = await anext(async_it)
+        self.assertEqual(member["id"], 3)
 
-        self.assertEqual(len(repos), 3)
-        self.assertEqual(repos, [{"id": 1}, {"id": 2}, {"id": 3}])
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/orgs/foo/teams/bar/members",
@@ -284,10 +299,16 @@ class GitHubAsyncRESTTeamsTestCase(GitHubAsyncRESTTestCase):
             [response1, response2]
         )
 
-        repos = await self.api.repositories("foo", "bar")
+        async_it = aiter(self.api.repositories("foo", "bar"))
+        repo = await anext(async_it)
+        self.assertEqual(repo["id"], 1)
+        repo = await anext(async_it)
+        self.assertEqual(repo["id"], 2)
+        repo = await anext(async_it)
+        self.assertEqual(repo["id"], 3)
 
-        self.assertEqual(len(repos), 3)
-        self.assertEqual(repos, [{"id": 1}, {"id": 2}, {"id": 3}])
+        with self.assertRaises(StopAsyncIteration):
+            await anext(async_it)
 
         self.client.get_all.assert_called_once_with(
             "/orgs/foo/teams/bar/repos",


### PR DESCRIPTION
**What**:

Update our async GitHub API to return an AsyncIterator for methods requested a list of items.

**Why**:

`yield` items instead of accumulating a list in memory.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
