### PR TITLE
Change: Run all workflows on Python 3.10 now

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -35,6 +35,7 @@ jobs:
           - 3.8
           - 3.9
           - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - name: Install python, poetry and dependencies
@@ -53,4 +54,4 @@ jobs:
       - name: Install and calculate and upload coverage to codecov.io
         uses: greenbone/actions/coverage-python@v2
         with:
-          version: 3.9
+          version: "3.10"

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install poetry and dependencies
         uses: greenbone/actions/poetry@v2
         with:
-          version: "3.9"
+          version: "3.10"
       - name: Build Documentation
         run: |
           cd docs && poetry run make html

--- a/.github/workflows/release-pontos-manually.yml
+++ b/.github/workflows/release-pontos-manually.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Release with release action
         uses: greenbone/actions/release-python@v2
         with:
-          version: 3.9
+          version: "3.10"
           conventional-commits: true
           ref: ${{ github.event.inputs.branch }}
           github-user: ${{ secrets.GREENBONE_BOT }}

--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Release with release action
         uses: greenbone/actions/release-python@v2
         with:
-          version: 3.9
+          version: "3.10"
           conventional-commits: true
           github-user: ${{ secrets.GREENBONE_BOT }}
           github-user-mail: ${{ secrets.GREENBONE_BOT_MAIL }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ classifiers=[
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Operating System :: OS Independent",
   "Topic :: Software Development :: Libraries :: Python Modules",
 ]
@@ -56,7 +57,7 @@ furo = "^2022.9.29"
 
 [tool.black]
 line-length = 80
-target-version = ['py37', 'py38', 'py39', 'py310']
+target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
 exclude = '''
 /(
     \.git


### PR DESCRIPTION
**What**:

Run all workflows on Python 3.10 now.

Also run unittests on Python 3.11. Linting with Python 3.11 is postponed becaue we had some issues in other repos.

**Why**:

Support Python 3.11

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
