### PR TITLE
Add: Add allow_update_branch argument to repositories.create API

### DIFF
--- a/pontos/github/api/repositories.py
+++ b/pontos/github/api/repositories.py
@@ -156,6 +156,7 @@ class GitHubAsyncRESTRepositories(GitHubAsyncREST):
         allow_merge_commit: Optional[bool] = True,
         allow_rebase_merge: Optional[bool] = True,
         allow_auto_merge: Optional[bool] = False,
+        allow_update_branch: Optional[bool] = False,
         delete_branch_on_merge: Optional[bool] = False,
         squash_merge_commit_title: Optional[SquashMergeCommitTitle] = None,
         squash_merge_commit_message: Optional[SquashMergeCommitMessage] = None,
@@ -206,6 +207,10 @@ class GitHubAsyncRESTRepositories(GitHubAsyncREST):
                 requests, or False to prevent rebase-merging. Default: True.
             allow_auto_merge: Either True to allow auto-merge on pull requests,
                 or False to disallow auto-merge. Default: False.
+            allow_update_branch: Either True to always allow a pull request head
+                branch that is behind its base branch to be updated even if it
+                is not required to be up to date before merging, or False
+                otherwise. Default: False.
             delete_branch_on_merge: Either True to allow automatically deleting
                 head branches when pull requests are merged, or False to prevent
                 automatic deletion. Default: False.
@@ -284,6 +289,8 @@ class GitHubAsyncRESTRepositories(GitHubAsyncREST):
             data["allow_rebase_merge"] = allow_rebase_merge
         if allow_auto_merge is not None:
             data["allow_auto_merge"] = allow_auto_merge
+        if allow_update_branch is not None:
+            data["allow_update_branch"] = allow_update_branch
         if delete_branch_on_merge is not None:
             data["delete_branch_on_merge"] = delete_branch_on_merge
         if squash_merge_commit_title:

--- a/tests/github/api/test_repositories.py
+++ b/tests/github/api/test_repositories.py
@@ -572,6 +572,7 @@ class GitHubAsyncRESTRepositoriesTestCase(GitHubAsyncRESTTestCase):
                 "allow_merge_commit": True,
                 "allow_rebase_merge": True,
                 "allow_auto_merge": False,
+                "allow_update_branch": False,
                 "delete_branch_on_merge": False,
             },
         )
@@ -600,6 +601,7 @@ class GitHubAsyncRESTRepositoriesTestCase(GitHubAsyncRESTTestCase):
             allow_merge_commit=False,
             allow_rebase_merge=False,
             allow_auto_merge=True,
+            allow_update_branch=True,
             delete_branch_on_merge=True,
             squash_merge_commit_title=SquashMergeCommitTitle.COMMIT_OR_PR_TITLE,
             squash_merge_commit_message=SquashMergeCommitMessage.PR_BODY,
@@ -625,6 +627,7 @@ class GitHubAsyncRESTRepositoriesTestCase(GitHubAsyncRESTTestCase):
                 "allow_merge_commit": False,
                 "allow_rebase_merge": False,
                 "allow_auto_merge": True,
+                "allow_update_branch": True,
                 "delete_branch_on_merge": True,
                 "squash_merge_commit_title": "COMMIT_OR_PR_TITLE",
                 "squash_merge_commit_message": "PR_BODY",


### PR DESCRIPTION
**What**:

Add allow_update_branch argument to repositories.create API

This argument is not listed in the REST API for the create repo command. Only for the update command. Nevertheless I've tested the argument and it works for create too.

**Why**:

Add missing argument for repo settings.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
