### PR TITLE
Fix: Set required dependent args for updating branch protection rules

### DIFF
--- a/pontos/github/api/branch.py
+++ b/pontos/github/api/branch.py
@@ -452,6 +452,8 @@ class GitHubAsyncRESTBranches(GitHubAsyncREST):
 
         if require_branches_to_be_up_to_date is not None:
             status_checks = data.get("required_status_checks") or {}
+            # checks must be set if strict is set
+            status_checks["checks"] = []
             status_checks["strict"] = require_branches_to_be_up_to_date
             data["required_status_checks"] = status_checks
 
@@ -471,10 +473,16 @@ class GitHubAsyncRESTBranches(GitHubAsyncREST):
 
         if restrictions_users is not None:
             restrictions = data.get("restrictions") or {}
+            # teams must be set too if users are set
+            r_teams = restrictions.get("teams", [])
+            restrictions["teams"] = r_teams
             restrictions["users"] = list(restrictions_users)
             data["restrictions"] = restrictions
         if restrictions_teams is not None:
             restrictions = data.get("restrictions") or {}
+            # users must be set too if teams are set
+            r_users = restrictions.get("users", [])
+            restrictions["users"] = r_users
             restrictions["teams"] = list(restrictions_teams)
             data["restrictions"] = restrictions
         if restrictions_apps is not None:

--- a/tests/github/api/test_branch.py
+++ b/tests/github/api/test_branch.py
@@ -311,6 +311,116 @@ class GitHubAsyncRESTBranchesTestCase(GitHubAsyncRESTTestCase):
             "https://api.github.com/repos/octocat/Hello-World/branches/main/protection",
         )
 
+    async def test_update_protection_defaults(self):
+        response = create_response()
+        response.json.return_value = {
+            "url": "https://api.github.com/repos/octocat/Hello-World/branches/main/protection",
+        }
+        self.client.put.return_value = response
+
+        rules = await self.api.update_protection_rules(
+            "foo/bar",
+            "baz",
+        )
+
+        self.client.put.assert_awaited_once_with(
+            "/repos/foo/bar/branches/baz/protection",
+            data={
+                "required_status_checks": None,
+                "enforce_admins": None,
+                "required_pull_request_reviews": None,
+                "restrictions": None,
+            },
+        )
+
+        self.assertEqual(
+            rules.url,
+            "https://api.github.com/repos/octocat/Hello-World/branches/main/protection",
+        )
+
+    async def test_update_protection_rules_up_to_date_branch(self):
+        response = create_response()
+        response.json.return_value = {
+            "url": "https://api.github.com/repos/octocat/Hello-World/branches/main/protection",
+        }
+        self.client.put.return_value = response
+
+        rules = await self.api.update_protection_rules(
+            "foo/bar",
+            "baz",
+            require_branches_to_be_up_to_date=True,
+        )
+
+        self.client.put.assert_awaited_once_with(
+            "/repos/foo/bar/branches/baz/protection",
+            data={
+                "required_status_checks": {
+                    "strict": True,
+                    "checks": [],
+                },
+                "enforce_admins": None,
+                "required_pull_request_reviews": None,
+                "restrictions": None,
+            },
+        )
+
+        self.assertEqual(
+            rules.url,
+            "https://api.github.com/repos/octocat/Hello-World/branches/main/protection",
+        )
+
+    async def test_update_protection_rules_restriction_users(self):
+        response = create_response()
+        response.json.return_value = {
+            "url": "https://api.github.com/repos/octocat/Hello-World/branches/main/protection",
+        }
+        self.client.put.return_value = response
+
+        rules = await self.api.update_protection_rules(
+            "foo/bar", "baz", restrictions_users=["foo", "bar"]
+        )
+
+        self.client.put.assert_awaited_once_with(
+            "/repos/foo/bar/branches/baz/protection",
+            data={
+                "enforce_admins": None,
+                "required_pull_request_reviews": None,
+                "required_status_checks": None,
+                "restrictions": {"users": ["foo", "bar"], "teams": []},
+            },
+        )
+
+        self.assertEqual(
+            rules.url,
+            "https://api.github.com/repos/octocat/Hello-World/branches/main/protection",
+        )
+
+    async def test_update_protection_rules_restriction_teams(self):
+        response = create_response()
+        response.json.return_value = {
+            "url": "https://api.github.com/repos/octocat/Hello-World/branches/main/protection",
+        }
+        self.client.put.return_value = response
+
+        rules = await self.api.update_protection_rules(
+            "foo/bar", "baz", restrictions_teams=["foo", "bar"]
+        )
+
+        self.client.put.assert_awaited_once_with(
+            "/repos/foo/bar/branches/baz/protection",
+            data={
+                "enforce_admins": None,
+                "required_pull_request_reviews": None,
+                "required_status_checks": None,
+                "restrictions": {"teams": ["foo", "bar"], "users": []},
+            },
+        )
+
+        self.assertEqual(
+            rules.url,
+            "https://api.github.com/repos/octocat/Hello-World/branches/main/protection",
+        )
+
     async def test_update_protection_rules_failure(self):
         response = create_response()
         error = HTTPStatusError("404", request=MagicMock(), response=response)


### PR DESCRIPTION
**What**:

Set required dependent args for updating branch protection rules

When calling the GitHub REST API for updating branch protection rules there are some dependent requirements of the provided arguments. For example if a user restriction is set the teams property must be provided too.

**Why**:

Don't fail if specific dependent arguments are not provided to the API method.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
