### PR TITLE
Add: Add a GitHub Permission enum

### DIFF
--- a/pontos/github/models/base.py
+++ b/pontos/github/models/base.py
@@ -172,6 +172,14 @@ class TeamRole(Enum):
     MAINTAINER = "maintainer"
 
 
+class Permission(Enum):
+    PULL = "pull"
+    PUSH = "push"
+    TRIAGE = "triage"
+    MAINTAIN = "maintain"
+    ADMIN = "admin"
+
+
 @dataclass
 class Team(GitHubModel):
     id: int
@@ -182,7 +190,7 @@ class Team(GitHubModel):
     slug: str
     description: str
     privacy: TeamPrivacy
-    permission: str
+    permission: Permission
     members_url: str
     repositories_url: str
     parent: Optional["Team"] = None

--- a/tests/github/models/test_base.py
+++ b/tests/github/models/test_base.py
@@ -25,6 +25,7 @@ from pontos.github.models.base import (
     App,
     GitHubModel,
     GitHubModelAttribute,
+    Permission,
     Team,
     User,
     dotted_attributes,
@@ -186,7 +187,7 @@ class TeamTestCase(unittest.TestCase):
             team.repositories_url,
             "https://api.github.com/organizations/31986857/team/3764115/repos",
         )
-        self.assertEqual(team.permission, "pull")
+        self.assertEqual(team.permission, Permission.PULL)
         self.assertIsNone(team.parent)
 
 

--- a/tests/github/models/test_branch.py
+++ b/tests/github/models/test_branch.py
@@ -20,6 +20,7 @@
 import unittest
 
 from pontos.github.api.teams import TeamPrivacy
+from pontos.github.models.base import Permission
 from pontos.github.models.branch import (
     BranchProtection,
     RequiredPullRequestReviews,
@@ -291,7 +292,7 @@ class RequiredPullRequestReviewsTestCase(unittest.TestCase):
         self.assertEqual(team.node_id, "T_kwDOAegUqc4AUtL1")
         self.assertEqual(team.slug, "devops")
         self.assertEqual(team.description, "Team responsible for DevOps")
-        self.assertEqual(team.permission, "pull")
+        self.assertEqual(team.permission, Permission.PULL)
         self.assertEqual(team.privacy, TeamPrivacy.CLOSED)
         self.assertEqual(
             team.url, "https://api.github.com/organizations/321/team/123"
@@ -584,7 +585,7 @@ class BranchProtectionTestCase(unittest.TestCase):
         self.assertEqual(team.node_id, "T_kwDOAegUqc4AUtL1")
         self.assertEqual(team.slug, "devops")
         self.assertEqual(team.description, "Team responsible for DevOps")
-        self.assertEqual(team.permission, "pull")
+        self.assertEqual(team.permission, Permission.PULL)
         self.assertEqual(team.privacy, TeamPrivacy.CLOSED)
         self.assertEqual(
             team.url, "https://api.github.com/organizations/321/team/123"

--- a/tests/github/models/test_pull_request.py
+++ b/tests/github/models/test_pull_request.py
@@ -19,7 +19,7 @@
 
 import unittest
 
-from pontos.github.models.base import TeamPrivacy
+from pontos.github.models.base import Permission, TeamPrivacy
 from pontos.github.models.pull_request import PullRequest
 
 
@@ -959,7 +959,7 @@ class PullRequestTestCase(unittest.TestCase):
         self.assertEqual(team.slug, "justice-league")
         self.assertEqual(team.description, "A great team.")
         self.assertEqual(team.privacy, TeamPrivacy.CLOSED)
-        self.assertEqual(team.permission, "admin")
+        self.assertEqual(team.permission, Permission.ADMIN)
         self.assertEqual(
             team.members_url, "https://api.github.com/teams/1/members{/member}"
         )


### PR DESCRIPTION
**What**:

Add a GitHub Permission enum

**Why**:

Permissions have distinct values. Therefore it is best to use an enum instead of a string.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [x] Documentation
