### PR TITLE
Change: Drop support for Python 3.7 and 3.8

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -31,8 +31,6 @@ jobs:
     strategy:
       matrix:
         python-version:
-          - 3.7
-          - 3.8
           - 3.9
           - "3.10"
           - "3.11"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,8 +15,6 @@ classifiers=[
   "License :: OSI Approved :: GNU General Public License v3 or later (GPLv3+)",  # pylint: disable=line-too-long
   "Environment :: Console",
   "Intended Audience :: Developers",
-  "Programming Language :: Python :: 3.7",
-  "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
@@ -58,7 +56,7 @@ furo = "^2022.9.29"
 
 [tool.black]
 line-length = 80
-target-version = ['py37', 'py38', 'py39', 'py310', 'py311']
+target-version = ['py39', 'py310', 'py311']
 exclude = '''
 /(
     \.git

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,10 +19,9 @@
 
 import builtins
 import sys
-import unittest
 from typing import Any, AsyncIterator, Awaitable, Iterable
-from unittest import TestCase
-from unittest.mock import MagicMock
+from unittest import IsolatedAsyncioTestCase
+from unittest.mock import AsyncMock
 
 if sys.version_info.minor < 10:
     # aiter and anext have been added in Python 3.10
@@ -41,46 +40,6 @@ else:
         return builtins.anext(obj)
 
 
-if sys.version_info.minor > 7:
-    from unittest import IsolatedAsyncioTestCase
-    from unittest.mock import AsyncMock
-else:
-
-    @unittest.skip("Async Tests not available for Python 3.7")
-    class IsolatedAsyncioTestCase(TestCase):
-        pass
-
-    class AsyncMock(MagicMock):
-        # implement all necessary methods to keep Pylint happy
-
-        def __init__(self, *args: Any, **kw: Any) -> None:
-            super().__init__(*args, **kw)
-
-            self.__aenter__ = self
-            self.__aexit__ = self
-
-        def assert_awaited(self):
-            pass
-
-        def assert_awaited_once(self):
-            pass
-
-        def assert_awaited_with(self, *args, **kwargs):
-            pass
-
-        def assert_awaited_once_with(self, *args, **kwargs):
-            pass
-
-        def assert_any_await(self, *args, **kwargs):
-            pass
-
-        def assert_has_awaits(self, calls, any_order=False):
-            pass
-
-        def assert_not_awaited(self):
-            pass
-
-
 class AsyncIteratorMock(AsyncIterator):
     def __init__(self, iterable: Iterable[Any]) -> None:
         self.iterator = iter(iterable)
@@ -92,4 +51,10 @@ class AsyncIteratorMock(AsyncIterator):
             raise StopAsyncIteration() from None
 
 
-__all__ = ["IsolatedAsyncioTestCase", "AsyncMock"]
+__all__ = (
+    "IsolatedAsyncioTestCase",
+    "AsyncMock",
+    "AsyncIteratorMock",
+    "aiter",
+    "anext",
+)


### PR DESCRIPTION
**What**:

Drop support for Python 3.7 and 3.8

**Why**:

These Python versions are rather old and we don't use them in production. It's a burden to keep the compatibility to these versions.