### PR TITLE
Improve release CLI

### DIFF
--- a/pontos/changelog/__init__.py
+++ b/pontos/changelog/__init__.py
@@ -17,12 +17,13 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from .changelog import ChangelogError, add_skeleton, update
-from .conventional_commits import ChangelogBuilder, main
+from .conventional_commits import ChangelogBuilder, ChangelogBuilderError, main
 
 __all__ = [
     "add_skeleton",
     "update",
-    "ChangelogBuilder",
     "ChangelogError",
+    "ChangelogBuilder",
+    "ChangelogBuilderError",
     "main",
 ]

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -106,7 +106,7 @@ def calculate_calendar_version(terminal: Terminal) -> str:
         sys.exit(1)
 
 
-def get_current_version(terminal: Terminal) -> str:
+def get_current_version(terminal: Terminal) -> Optional[str]:
     """Get the current Version from a pyproject.toml or
     a CMakeLists.txt file"""
 
@@ -122,7 +122,7 @@ def get_current_version(terminal: Terminal) -> str:
             return current_version
 
     terminal.error("No project settings file found")
-    sys.exit(1)
+    return None
 
 
 def get_last_release_version() -> Optional[str]:

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -16,10 +16,9 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import datetime
-import subprocess
 import sys
 from pathlib import Path
-from typing import Callable, Optional, Tuple
+from typing import Optional, Tuple
 
 from packaging.version import InvalidVersion, Version
 
@@ -191,29 +190,25 @@ def get_git_repository_name(
     return ret.rsplit("/", maxsplit=1)[-1].replace(".git", "").strip()
 
 
-def find_signing_key(terminal: Terminal, shell_cmd_runner: Callable) -> str:
+def find_signing_key(terminal: Terminal) -> str:
     """Find the signing key in the config
 
     Arguments:
-        shell_cmd_runner: The runner for shell commands
+        terminal: The terminal for console output
 
     Returns:
         git signing key or empty string
     """
 
     try:
-        proc = shell_cmd_runner("git config user.signingkey")
-    except subprocess.CalledProcessError as e:
+        return Git().config("user.signingkey").strip()
+    except GitError as e:
         # The command `git config user.signingkey` returns
         # return code 1 if no key is set.
         # So we will return empty string ...
         if e.returncode == 1:
             terminal.warning("No signing key found.")
         return ""
-    # stdout should return "\n" if no key is available
-    # and so git_signing_key should
-    # return '' if no key is available ...
-    return proc.stdout.strip()
 
 
 def update_version(

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -175,22 +175,20 @@ def get_next_dev_version(release_version: str) -> str:
         raise (VersionError(e)) from None
 
 
-def get_project_name(
-    shell_cmd_runner: Callable,
-    *,
+def get_git_repository_name(
     remote: str = "origin",
 ) -> str:
     """Get the git repository name
 
     Arguments:
-        shell_cmd_runner: The runner for shell commands
         remote: the remote to look up the name (str) default: origin
 
     Returns:
         project name
     """
-    ret = shell_cmd_runner(f"git remote get-url {remote}")
-    return ret.stdout.split("/")[-1].replace(".git", "").strip()
+
+    ret = Git().remote_url(remote)
+    return ret.rsplit("/", maxsplit=1)[-1].replace(".git", "").strip()
 
 
 def find_signing_key(terminal: Terminal, shell_cmd_runner: Callable) -> str:

--- a/pontos/release/sign.py
+++ b/pontos/release/sign.py
@@ -25,7 +25,7 @@ from pontos.github.api import GitHubRESTApi
 from pontos.helper import shell_cmd_runner
 from pontos.terminal import Terminal
 
-from .helper import get_current_version, get_project_name
+from .helper import get_current_version, get_git_repository_name
 
 
 def sign(
@@ -45,9 +45,7 @@ def sign(
         return False
 
     project: str = (
-        args.project
-        if args.project is not None
-        else get_project_name(shell_cmd_runner)
+        args.project if args.project is not None else get_git_repository_name()
     )
     space: str = args.space
     git_tag_prefix: str = args.git_tag_prefix
@@ -56,6 +54,9 @@ def sign(
         if args.release_version is not None
         else get_current_version(terminal)
     )
+    if not release_version:
+        return False
+
     signing_key: str = args.signing_key
 
     git_version: str = f"{git_tag_prefix}{release_version}"

--- a/tests/release/test_prepare.py
+++ b/tests/release/test_prepare.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2020-2022 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
@@ -22,10 +21,12 @@ import unittest
 from contextlib import redirect_stdout
 from io import StringIO
 from pathlib import Path
-from unittest.mock import call, patch
+from unittest.mock import patch
 
 from pontos import changelog, release
-from pontos.release.helper import version
+from pontos.git import Git
+from pontos.release.helper import get_current_version, version
+from pontos.testing import temp_git_repository
 
 
 class PrepareTestCase(unittest.TestCase):
@@ -33,109 +34,114 @@ class PrepareTestCase(unittest.TestCase):
         os.environ["GITHUB_TOKEN"] = "foo"
         os.environ["GITHUB_USER"] = "bar"
 
-    @patch("pontos.release.prepare.shell_cmd_runner")
+    @patch("pontos.release.prepare.Git", spec=Git)
     @patch("pontos.release.prepare.Path", spec=Path)
     @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.release.prepare.changelog", spec=changelog)
     def test_prepare_successfully(
         self,
-        _changelog_mock,
-        _version_mock,
+        changelog_mock,
+        version_mock,
         _path_mock,
-        _shell_mock,
+        _git_mock,
     ):
-        _changelog_mock.update.return_value = ("updated", "changelog")
-        _version_mock.main.return_value = (True, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (True, "MyProject.conf")
 
         args = [
             "prepare",
+            "--project",
+            "foo",
             "--release-version",
             "0.0.1",
         ]
-        with redirect_stdout(StringIO()):
+        with temp_git_repository(), redirect_stdout(StringIO()):
             released = release.main(
                 leave=False,
                 args=args,
             )
         self.assertTrue(released)
 
-    @patch("pontos.release.prepare.shell_cmd_runner")
+    @patch(
+        "pontos.release.helper.get_current_version", spec=get_current_version
+    )
+    @patch("pontos.release.prepare.Git", spec=Git)
     @patch("pontos.release.prepare.Path", spec=Path)
     @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.release.prepare.changelog", spec=changelog)
     def test_prepare_calendar_successfully(
         self,
-        _changelog_mock,
-        _version_mock,
+        changelog_mock,
+        version_mock,
         _path_mock,
-        _shell_mock,
+        _git_mock,
+        get_current_version_mock,
     ):
-        _version_mock.main.return_value = (True, "MyProject.conf")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        get_current_version_mock.return_value = "21.6.0"
+        version_mock.main.return_value = (True, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
         args = [
             "prepare",
+            "--project",
+            "foo",
             "--calendar",
         ]
-        with redirect_stdout(StringIO()):
+        with temp_git_repository(), redirect_stdout(StringIO()):
             released = release.main(
                 leave=False,
                 args=args,
             )
         self.assertTrue(released)
 
-    @patch("pontos.release.prepare.shell_cmd_runner")
+    @patch("pontos.release.prepare.Git", spec=Git)
     @patch("pontos.release.prepare.Path", spec=Path)
     @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.release.prepare.changelog", spec=changelog)
     def test_use_git_signing_key_on_prepare(
         self,
-        _changelog_mock,
-        _version_mock,
+        changelog_mock,
+        version_mock,
         _path_mock,
-        shell_mock,
+        git_mock,
     ):
-        _version_mock.main.return_value = (True, "MyProject.conf")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (True, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
 
         args = [
             "prepare",
+            "--project",
+            "foo",
             "--git-signing-key",
             "0815",
             "--release-version",
             "0.0.1",
         ]
-        with redirect_stdout(StringIO()):
+        with temp_git_repository(), redirect_stdout(StringIO()):
             released = release.main(
                 leave=False,
                 args=args,
             )
 
         self.assertTrue(released)
-        shell_mock.assert_has_calls(
-            [
-                call(
-                    "git commit -S0815 --no-verify -m "
-                    "'Automatic release to 0.0.1'"
-                ),
-                call("git tag -u 0815 v0.0.1 -m 'Automatic release to 0.0.1'"),
-            ]
+        git_mock.return_value.tag.assert_called_with(
+            "v0.0.1", gpg_key_id="0815", message="Automatic release to 0.0.1"
+        )
+        git_mock.return_value.commit.assert_called_with(
+            "Automatic release to 0.0.1", verify=False, gpg_signing_key="0815"
         )
 
-    @patch("pontos.release.prepare.shell_cmd_runner")
+    @patch("pontos.release.prepare.Git", spec=Git)
     @patch("pontos.release.prepare.Path", spec=Path)
     @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.release.prepare.changelog", spec=changelog)
-    @patch("pontos.release.prepare.Git")
     def test_fail_if_tag_is_already_taken(
         self,
-        git_mock,
         _changelog_mock,
         version_mock,
         _path_mock,
-        _shell_mock,
+        git_mock,
     ):
-        git_instance = git_mock.return_value
-        git_instance.list_tags.return_value = ["v0.0.1"]
+        git_mock.return_value.list_tags.return_value = ["v0.0.1"]
 
         version_mock.main.return_value = (True, "MyProject.conf")
 
@@ -149,98 +155,106 @@ class PrepareTestCase(unittest.TestCase):
             "1337",
         ]
 
-        with self.assertRaises(SystemExit), redirect_stdout(StringIO()):
+        with temp_git_repository(), self.assertRaises(
+            SystemExit
+        ), redirect_stdout(StringIO()):
             release.main(
                 leave=False,
                 args=args,
             )
 
-        git_instance.list_tags.assert_called_once()
+        git_mock.return_value.list_tags.assert_called_once()
 
-    @patch("pontos.release.prepare.shell_cmd_runner")
+    @patch("pontos.release.prepare.Git", spec=Git)
     @patch("pontos.release.prepare.Path", spec=Path)
     @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.release.prepare.changelog", spec=changelog)
     def test_not_release_when_no_project_found(
         self,
-        _changelog_mock,
-        _version_mock,
+        changelog_mock,
+        version_mock,
         _path_mock,
-        _shell_mock,
+        _git_mock,
     ):
-        _version_mock.main.return_value = (False, "")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (False, "")
+        changelog_mock.update.return_value = ("updated", "changelog")
 
         args = [
             "prepare",
+            "--project",
+            "foo",
             "--release-version",
             "0.0.1",
         ]
-        with redirect_stdout(StringIO()):
+        with temp_git_repository(), redirect_stdout(StringIO()):
             released = release.main(
                 leave=False,
                 args=args,
             )
         self.assertFalse(released)
 
-    @patch("pontos.release.prepare.shell_cmd_runner")
+    @patch("pontos.release.prepare.Git", spec=Git)
     @patch("pontos.release.prepare.Path", spec=Path)
     @patch("pontos.release.helper.version", spec=version)
     @patch("pontos.release.prepare.changelog", spec=changelog)
     def test_not_release_when_updating_version_fails(
         self,
-        _changelog_mock,
-        _version_mock,
+        changelog_mock,
+        version_mock,
         _path_mock,
-        _shell_mock,
+        _git_mock,
     ):
-        _version_mock.main.return_value = (False, "MyProject.conf")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (False, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
 
         args = [
             "prepare",
+            "--project",
+            "foo",
             "--release-version",
             "0.0.1",
         ]
-        with redirect_stdout(StringIO()):
+        with temp_git_repository(), redirect_stdout(StringIO()):
             released = release.main(
                 leave=False,
                 args=args,
             )
         self.assertFalse(released)
 
-    @patch("pontos.release.prepare.shell_cmd_runner")
+    @patch("pontos.release.prepare.Git", spec=Git)
     @patch("pontos.release.prepare.changelog", spec=changelog)
     @patch("pontos.release.helper.version", spec=version)
-    def test_prepare_coventional_commits(
+    def test_prepare_conventional_commits(
         self,
-        _version_mock,
-        _changelog_mock,
-        _shell_mock,
+        version_mock,
+        changelog_mock,
+        _git_mock,
     ):
-
-        _version_mock.main.return_value = (True, "MyProject.conf")
+        version_mock.main.return_value = (True, "MyProject.conf")
 
         own_path = Path(__file__).absolute().parent
-        release_file = own_path.parent.parent / ".release.md"
+        with temp_git_repository() as temp_dir, redirect_stdout(StringIO()):
+            release_file = temp_dir / ".release.md"
 
-        builder = _changelog_mock.ChangelogBuilder.return_value
-        builder.create_changelog_file.return_value = own_path / "v1.2.3.md"
+            builder = changelog_mock.ChangelogBuilder.return_value
+            builder.create_changelog_file.return_value = own_path / "v1.2.3.md"
 
-        args = [
-            "prepare",
-            "--release-version",
-            "1.2.3",
-            "-CC",
-        ]
-        with redirect_stdout(StringIO()):
+            args = [
+                "prepare",
+                "--project",
+                "foo",
+                "--release-version",
+                "1.2.3",
+                "-CC",
+            ]
             released = release.main(
                 leave=False,
                 args=args,
             )
-        self.assertTrue(released)
 
-        expected_release_content = """## [21.8.1] - 2021-08-23
+            self.assertTrue(released)
+
+            expected_release_content = """## [21.8.1] - 2021-08-23
 
 ## Added
 
@@ -252,8 +266,7 @@ class PrepareTestCase(unittest.TestCase):
 
 [21.8.1]: https://github.com/y0urself/test_workflows/compare/21.8.0...21.8.1"""
 
-        self.assertEqual(
-            release_file.read_text(encoding="utf-8"), expected_release_content
-        )
-
-        release_file.unlink()
+            self.assertEqual(
+                release_file.read_text(encoding="utf-8"),
+                expected_release_content,
+            )

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2020-2022 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
@@ -27,7 +26,9 @@ from unittest.mock import MagicMock, call, patch
 import httpx
 
 from pontos import changelog, release
+from pontos.git import Git
 from pontos.release.helper import version
+from pontos.testing import temp_git_repository
 
 
 class ReleaseTestCase(unittest.TestCase):
@@ -39,7 +40,7 @@ class ReleaseTestCase(unittest.TestCase):
             ' "tar", "upload_url":"upload"}'
         )
 
-    @patch("pontos.release.release.shell_cmd_runner")
+    @patch("pontos.release.release.Git", spec=Git)
     @patch("pontos.release.release.Path", spec=Path)
     @patch("pontos.github.api.api.httpx", spec=httpx)
     @patch("pontos.github.api.release.httpx", spec=httpx)
@@ -47,38 +48,42 @@ class ReleaseTestCase(unittest.TestCase):
     @patch("pontos.release.release.changelog", spec=changelog)
     def test_release_successfully(
         self,
-        _changelog_mock,
-        _version_mock,
-        _requests_mock,
-        _requests2_mock,
+        changelog_mock,
+        version_mock,
+        requests_mock,
+        requests2_mock,
         _path_mock,
-        _shell_mock,
+        _git_mock,
     ):
-        _version_mock.main.return_value = (True, "MyProject.conf")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (True, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
 
         fake_post = MagicMock(spec=httpx.Response).return_value
         fake_post.status_code = 201
         fake_post.text = self.valid_gh_release_response
-        _requests_mock.post.return_value = fake_post
-        _requests2_mock.post.return_value = fake_post
+        requests_mock.post.return_value = fake_post
+        requests2_mock.post.return_value = fake_post
 
         args = [
             "release",
+            "--project",
+            "foo",
+            "--git-signing-key",
+            "123",
             "--release-version",
             "0.0.1",
             "--next-version",
             "0.0.2dev",
         ]
 
-        with redirect_stdout(StringIO()):
+        with temp_git_repository(), redirect_stdout(StringIO()):
             released = release.main(
                 leave=False,
                 args=args,
             )
         self.assertTrue(released)
 
-    @patch("pontos.release.release.shell_cmd_runner")
+    @patch("pontos.release.release.Git", spec=Git)
     @patch("pontos.release.release.Path", spec=Path)
     @patch("pontos.github.api.api.httpx", spec=httpx)
     @patch("pontos.github.api.release.httpx", spec=httpx)
@@ -86,35 +91,45 @@ class ReleaseTestCase(unittest.TestCase):
     @patch("pontos.release.release.changelog", spec=changelog)
     def test_release_conventional_commits_successfully(
         self,
-        _changelog_mock,
-        _version_mock,
-        _requests_mock,
-        _requests2_mock,
+        changelog_mock,
+        version_mock,
+        requests_mock,
+        requests2_mock,
         _path_mock,
-        _shell_mock,
+        _git_mock,
     ):
-        _version_mock.main.return_value = (True, "MyProject.conf")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (True, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
 
         fake_post = MagicMock(spec=httpx.Response).return_value
         fake_post.status_code = 201
         fake_post.text = self.valid_gh_release_response
-        _requests_mock.post.return_value = fake_post
-        _requests2_mock.post.return_value = fake_post
+        requests_mock.post.return_value = fake_post
+        requests2_mock.post.return_value = fake_post
 
         args = [
             "release",
+            "--project",
+            "foo",
+            "--git-signing-key",
+            "123",
+            "--release-version",
+            "1.2.3",
             "-CC",
         ]
 
-        with redirect_stdout(StringIO()):
+        with temp_git_repository(), redirect_stdout(StringIO()):
             released = release.main(
                 leave=False,
                 args=args,
             )
+
+        version_mock.main.assert_called_with(
+            leave=False, args=["--quiet", "update", "1.2.4", "--develop"]
+        )
         self.assertTrue(released)
 
-    @patch("pontos.release.release.shell_cmd_runner")
+    @patch("pontos.release.release.Git", spec=Git)
     @patch("pontos.release.release.Path", spec=Path)
     @patch("pontos.github.api.api.httpx", spec=httpx)
     @patch("pontos.github.api.release.httpx", spec=httpx)
@@ -122,16 +137,16 @@ class ReleaseTestCase(unittest.TestCase):
     @patch("pontos.release.release.changelog", spec=changelog)
     def test_not_release_successfully_when_github_create_release_fails(
         self,
-        _changelog_mock,
-        _version_mock,
-        _requests_mock,
-        _requests2_mock,
+        changelog_mock,
+        version_mock,
+        requests_mock,
+        requests2_mock,
         _path_mock,
-        _shell_mock,
+        _git_mock,
     ):
 
-        _version_mock.main.return_value = (True, "MyProject.conf")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (True, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
 
         fake_post = MagicMock(spec=httpx.Response).return_value
         fake_post.status_code = 401
@@ -139,10 +154,10 @@ class ReleaseTestCase(unittest.TestCase):
         fake_post.raise_for_status.side_effect = httpx.HTTPStatusError(
             "Authorization required",
             response=fake_post,
-            request=_requests_mock.post,
+            request=requests_mock.post,
         )
-        _requests_mock.post.return_value = fake_post
-        _requests2_mock.post.return_value = fake_post
+        requests_mock.post.return_value = fake_post
+        requests2_mock.post.return_value = fake_post
 
         args = [
             "release",
@@ -150,14 +165,17 @@ class ReleaseTestCase(unittest.TestCase):
             "0.0.1",
         ]
 
-        with redirect_stdout(StringIO()):
+        with temp_git_repository(), redirect_stdout(StringIO()):
+            git = Git()
+            git.add_remote("origin", "https://foo.com/bar.git")
+
             released = release.main(
                 leave=False,
                 args=args,
             )
         self.assertFalse(released)
 
-    @patch("pontos.release.release.shell_cmd_runner")
+    @patch("pontos.release.release.Git", spec=Git)
     @patch("pontos.release.release.Path", spec=Path)
     @patch("pontos.github.api.api.httpx", spec=httpx)
     @patch("pontos.github.api.release.httpx", spec=httpx)
@@ -165,21 +183,21 @@ class ReleaseTestCase(unittest.TestCase):
     @patch("pontos.release.release.changelog", spec=changelog)
     def test_release_to_specific_git_remote(
         self,
-        _changelog_mock,
-        _version_mock,
-        _requests_mock,
-        _requests2_mock,
+        changelog_mock,
+        version_mock,
+        requests_mock,
+        requests2_mock,
         _path_mock,
-        shell_mock,
+        git_mock,
     ):
-        _version_mock.main.return_value = (True, "MyProject.conf")
-        _changelog_mock.update.return_value = ("updated", "changelog")
+        version_mock.main.return_value = (True, "MyProject.conf")
+        changelog_mock.update.return_value = ("updated", "changelog")
 
         fake_post = MagicMock(spec=httpx.Response).return_value
         fake_post.status_code = 201
         fake_post.text = self.valid_gh_release_response
-        _requests_mock.post.return_value = fake_post
-        _requests2_mock.post.return_value = fake_post
+        requests_mock.post.return_value = fake_post
+        requests2_mock.post.return_value = fake_post
 
         args = [
             "release",
@@ -195,24 +213,28 @@ class ReleaseTestCase(unittest.TestCase):
             "1234",
         ]
 
-        with redirect_stdout(StringIO()):
+        with temp_git_repository(), redirect_stdout(StringIO()):
             released = release.main(
                 leave=False,
                 args=args,
             )
         self.assertTrue(released)
 
-        shell_mock.assert_has_calls(
+        git_mock.return_value.push.assert_called_with(
+            follow_tags=True, remote="upstream"
+        )
+        # git_mock.return_value.add.assert_called_with()
+        git_mock.return_value.add.assert_has_calls(
             [
-                call("git push --follow-tags upstream"),
-                call("git add MyProject.conf"),
-                call("git add *__version__.py || echo 'ignoring __version__'"),
-                call("git add CHANGELOG.md"),
-                call(
-                    "git commit -S1234 --no-verify -m 'Automatic adjustments "
-                    "after release\n\n"
-                    "* Update to version 0.0.2.dev1\n"
-                    "* Add empty changelog after 0.0.1'"
-                ),
+                call("MyProject.conf"),
+                call("*__version__.py"),
+                call("CHANGELOG.md"),
             ]
+        )
+        git_mock.return_value.commit.assert_called_with(
+            "Automatic adjustments after release\n\n"
+            "* Update to version 0.0.2.dev1\n"
+            "* Add empty changelog after 0.0.1",
+            verify=False,
+            gpg_signing_key="1234",
         )

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 # Copyright (C) 2020-2022 Greenbone Networks GmbH
 #
 # SPDX-License-Identifier: GPL-3.0-or-later


### PR DESCRIPTION
**What**:

Use Git class instead of shell command runner.

**Why**:

Get rid of shell command runner as much as possible in the release modules.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
