### PR TITLE
Add: Add an async API for querying the NIST NVD CPE REST interface

### DIFF
--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -1,0 +1,160 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+from abc import ABC
+from datetime import datetime, timezone
+from types import TracebackType
+from typing import Any, Dict, Optional, Type
+
+from httpx import AsyncClient, Response, Timeout
+
+from pontos.helper import snake_case
+
+SLEEP_TIMEOUT = 30.0  # in seconds
+DEFAULT_TIMEOUT = 180.0  # three minutes
+DEFAULT_TIMEOUT_CONFIG = Timeout(DEFAULT_TIMEOUT)  # three minutes
+
+Headers = Dict[str, str]
+Params = Dict[str, str]
+
+__all__ = (
+    "now",
+    "format_date",
+    "convert_camel_case",
+    "NVDApi",
+    "DEFAULT_TIMEOUT_CONFIG",
+)
+
+
+def now() -> datetime:
+    """
+    Return current datetime with UTC timezone applied
+    """
+    return datetime.now(tz=timezone.utc)
+
+
+def format_date(date: datetime) -> str:
+    return date.isoformat(timespec="seconds")
+
+
+def convert_camel_case(dct: Dict[str, Any]) -> Dict[str, Any]:
+    """
+    Convert camel case keys into snake case keys
+    """
+    converted = {}
+    for key, value in dct.items():
+        converted[snake_case(key)] = value
+    return converted
+
+
+async def sleep() -> None:
+    await asyncio.sleep(SLEEP_TIMEOUT)
+
+
+class NVDApi(ABC):
+    """
+    Base class for querying the NIST NVD API.
+
+    Should be used as an async context manager.
+
+    """
+
+    def __init__(
+        self,
+        url: str,
+        *,
+        token: Optional[str] = None,
+        timeout: Optional[Timeout] = DEFAULT_TIMEOUT_CONFIG,
+        rate_limit: bool = True,
+    ) -> None:
+        """
+        Create a new instance of the CVE API.
+
+        Args:
+            url: The API URL to use.
+            token: The API key to use. Using an API key allows to run more
+                requests at the same time.
+            timeout: Timeout settings for the HTTP requests
+            rate_limit: Set to False to ignore rate limits. The public rate
+                limit (without an API key) is 5 requests in a rolling 30 second
+                window. The rate limit with an API key is 50 requests in a
+                rolling 30 second window.
+                See https://nvd.nist.gov/developers/start-here#divRateLimits
+                Default: True.
+        """
+        self._url = url
+        self._token = token
+        self._client = AsyncClient(http2=True, timeout=timeout)
+
+        if rate_limit:
+            self._rate_limit = 50 if token else 5
+        else:
+            self._rate_limit = None
+
+        self._request_count = 0
+
+    def _request_headers(self) -> Headers:
+        """
+        Get the default request headers
+        """
+        headers = {}
+
+        if self._token:
+            headers["apiKey"] = self._token
+
+        return headers
+
+    async def _consider_rate_limit(self) -> None:
+        """
+        Apply rate limit if necessary
+        """
+        if not self._rate_limit:
+            return
+
+        self._request_count += 1
+        if self._request_count > self._rate_limit:
+            await sleep()
+            self._request_count = 0
+
+    async def _get(
+        self,
+        *,
+        params: Optional[Params] = None,
+    ) -> Response:
+        """
+        A request against the NIST NVD CVE REST API.
+        """
+        headers = self._request_headers()
+
+        await self._consider_rate_limit()
+
+        return await self._client.get(self._url, headers=headers, params=params)
+
+    async def __aenter__(self) -> "NVDApi":
+        # reset rate limit counter
+        self._request_count = 0
+        await self._client.__aenter__()
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: Optional[Type[BaseException]],
+        exc_value: Optional[BaseException],
+        traceback: Optional[TracebackType],
+    ) -> Optional[bool]:
+        return await self._client.__aexit__(exc_type, exc_value, traceback)

--- a/pontos/nvd/cpe/__init__.py
+++ b/pontos/nvd/cpe/__init__.py
@@ -1,0 +1,70 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import asyncio
+from argparse import ArgumentParser, Namespace
+
+from pontos.nvd.cpe.api import CPEApi
+
+
+async def query_cpe(args: Namespace) -> None:
+    async with CPEApi(token=args.token) as api:
+        cpe = await api.cpe(args.cpe_name_id)
+        print(cpe)
+
+
+async def query_cpes(args: Namespace) -> None:
+    async with CPEApi(token=args.token) as api:
+        async for cpe in api.cpes(
+            keywords=args.keywords, cpe_match_string=args.cpe_match_string
+        ):
+            print(cpe)
+
+
+def cpe_main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("--token", help="API key to use for querying.")
+    parser.add_argument(
+        "cpe_name_id", metavar="CPE Name ID", help="UUID of the CPE"
+    )
+
+    main(parser, query_cpe)
+
+
+def cpes_main() -> None:
+    parser = ArgumentParser()
+    parser.add_argument("--token", help="API key to use for querying.")
+    parser.add_argument(
+        "--cpe-match-string",
+        help="Search for CPE names that exist in the Official CPE Dictionary.",
+    )
+    parser.add_argument(
+        "--keywords",
+        nargs="*",
+        help="Search for CPEs containing the keyword in their titles and "
+        "references.",
+    )
+
+    main(parser, query_cpes)
+
+
+def main(parser: ArgumentParser, func: callable) -> None:
+    try:
+        args = parser.parse_args()
+        asyncio.run(func(args))
+    except KeyboardInterrupt:
+        pass

--- a/pontos/nvd/cpe/api.py
+++ b/pontos/nvd/cpe/api.py
@@ -1,0 +1,186 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+from datetime import datetime
+from typing import Any, AsyncIterator, Dict, List, Optional, Union
+
+from httpx import Timeout
+
+from pontos.errors import PontosError
+from pontos.nvd.api import (
+    DEFAULT_TIMEOUT_CONFIG,
+    NVDApi,
+    convert_camel_case,
+    format_date,
+    now,
+)
+from pontos.nvd.models.cpe import CPE
+
+DEFAULT_NIST_NVD_CPES_URL = "https://services.nvd.nist.gov/rest/json/cpes/2.0"
+
+
+class CPEApi(NVDApi):
+    """
+    API for querying the NIST NVD CPE information.
+
+    Should be used as an async context manager.
+
+    Example:
+        .. code-block:: python
+
+        async with CPEApi() as api:
+            cpe = await api.cpe("")
+    """
+
+    def __init__(
+        self,
+        *,
+        token: Optional[str] = None,
+        timeout: Optional[Timeout] = DEFAULT_TIMEOUT_CONFIG,
+        rate_limit: bool = True,
+    ) -> None:
+        """
+        Create a new instance of the CPE API.
+
+        Args:
+            token: The API key to use. Using an API key allows to run more
+                requests at the same time.
+            timeout: Timeout settings for the HTTP requests
+            rate_limit: Set to False to ignore rate limits. The public rate
+                limit (without an API key) is 5 requests in a rolling 30 second
+                window. The rate limit with an API key is 50 requests in a
+                rolling 30 second window.
+                See https://nvd.nist.gov/developers/start-here#divRateLimits
+                Default: True.
+        """
+        super().__init__(
+            DEFAULT_NIST_NVD_CPES_URL,
+            token=token,
+            timeout=timeout,
+            rate_limit=rate_limit,
+        )
+
+    async def cpe(self, cpe_name_id: str) -> str:
+        """
+        Returns a single CPE matching the CPE ID.
+
+        Args:
+            cpe_name_id: Returns a specific CPE record identified by a Universal
+                Unique Identifier (UUID).
+
+        Example:
+            .. code-block:: python
+
+            async with CPEApi() as api:
+                cpe = await api.cpe("87316812-5F2C-4286-94FE-CC98B9EAEF53"):
+                    print(cpe)
+        """
+        if not cpe_name_id:
+            raise PontosError("Missing CPE Name ID.")
+
+        response = await self._get(params={"cpeNameId": cpe_name_id})
+        response.raise_for_status()
+        data = response.json(object_hook=convert_camel_case)
+        products = data["products"]
+        if not products:
+            raise PontosError(f"No CPE with CPE Name ID '{cpe_name_id}' found.")
+
+        product = products[0]
+        return CPE.from_dict(product["cpe"])
+
+    async def cpes(
+        self,
+        *,
+        last_modified_start_date: Optional[datetime] = None,
+        last_modified_end_date: Optional[datetime] = None,
+        cpe_match_string: Optional[str] = None,
+        keywords: Optional[Union[List[str], str]] = None,
+        match_criteria_id: Optional[str] = None,
+    ) -> AsyncIterator[CPE]:
+        """
+        Get all CPEs for the provided arguments
+
+        https://nvd.nist.gov/developers/products
+
+        Args:
+            last_modified_start_date: Return all CPEs modified after this date.
+            last_modified_end_date: Return all CPEs modified before this date.
+                If last_modified_start_date is set but no
+                last_modified_end_date is passed it is set to now.
+            cpe_match_string: Returns all CPE names that exist in the Official
+                CPE Dictionary.
+            keywords: Returns only the CPEs where a word or phrase is found in
+                the metadata title or reference links.
+            match_criteria_id: Returns all CPE records associated with a match
+                string identified by its UUID.
+
+        Example:
+            .. code-block:: python
+
+            async with CPEApi() as api:
+                async for cpe in api.cpes(keywords=["Mac OS X"]):
+                    print(cpe.cpe_name, cpe.cpe_name_id)
+        """
+        total_results = None
+
+        params = {}
+        if last_modified_start_date:
+            params["lastModStartDate"] = format_date(last_modified_start_date)
+            if not last_modified_end_date:
+                params["lastModEndDate"] = format_date(now())
+        if last_modified_end_date:
+            params["lastModEndDate"] = format_date(last_modified_end_date)
+
+        if cpe_match_string:
+            params["cpeMatchString"] = cpe_match_string
+
+        if keywords:
+            if isinstance(keywords, str):
+                keywords = [keywords]
+
+            params["keywordSearch"] = " ".join(keywords)
+            if any((" " in keyword for keyword in keywords)):
+                params["keywordExactMatch"] = ""
+
+        if match_criteria_id:
+            params["matchCriteriaId"] = match_criteria_id
+
+        start_index = 0
+        results_per_page = None
+
+        while total_results is None or start_index < total_results:
+            params["startIndex"] = start_index
+
+            if results_per_page is not None:
+                params["resultsPerPage"] = results_per_page
+
+            response = await self._get(params=params)
+            response.raise_for_status()
+
+            data: Dict[str, Union[int, str, Dict[str, Any]]] = response.json(
+                object_hook=convert_camel_case
+            )
+
+            results_per_page: int = data["results_per_page"]
+            total_results: int = data["total_results"]
+            products = data.get("products", [])
+
+            for product in products:
+                yield CPE.from_dict(product["cpe"])
+
+            start_index += results_per_page

--- a/pontos/nvd/cpe/api.py
+++ b/pontos/nvd/cpe/api.py
@@ -75,7 +75,7 @@ class CPEApi(NVDApi):
             rate_limit=rate_limit,
         )
 
-    async def cpe(self, cpe_name_id: str) -> str:
+    async def cpe(self, cpe_name_id: str) -> CPE:
         """
         Returns a single CPE matching the CPE ID.
 

--- a/pontos/nvd/models/cpe.py
+++ b/pontos/nvd/models/cpe.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import List, Optional
+
+from pontos.models import Model
+
+
+@dataclass
+class Title(Model):
+    title: str
+    lang: str
+
+
+class ReferenceType(Enum):
+    ADVISORY = "Advisory"
+    CHANGELOG = "Change Log"
+    PRODUCT = "Product"
+    PROJECT = "Project"
+    VENDOR = "Vendor"
+    VERSION = "Version"
+
+
+@dataclass
+class Reference(Model):
+    ref: str
+    type: Optional[ReferenceType] = None
+
+
+@dataclass
+class DeprecatedBy(Model):
+    cpe_name: Optional[str] = None
+    cpe_name_id: Optional[str] = None
+
+
+@dataclass
+class CPE(Model):
+    cpe_name: str
+    cpe_name_id: str
+    deprecated: bool
+    last_modified: datetime
+    created: datetime
+    titles: List[Title] = field(default_factory=list)
+    refs: List[Reference] = field(default_factory=list)
+    deprecated_by: List[DeprecatedBy] = field(default_factory=list)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,8 @@ pontos-github-actions = 'pontos.github.actions:main'
 pontos-github-script = 'pontos.github.script:main'
 pontos-nvd-cve = 'pontos.nvd.cve:cve_main'
 pontos-nvd-cves = 'pontos.nvd.cve:cves_main'
+pontos-nvd-cpe = 'pontos.nvd.cpe:cpe_main'
+pontos-nvd-cpes = 'pontos.nvd.cpe:cpes_main'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/nvd/__init__.py
+++ b/tests/nvd/__init__.py
@@ -52,3 +52,17 @@ def get_cve_data(data: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
     if data:
         cve.update(data)
     return cve
+
+
+def get_cpe_data(update: Dict[str, Any] = None) -> Dict[str, Any]:
+    data = {
+        "deprecated": False,
+        "cpe_name": "cpe:2.3:o:microsoft:windows_10_22h2:-:*:*:*:*:*:arm64:*",
+        "cpe_name_id": "9BAECDB2-614D-4E9C-9936-190C30246F03",
+        "last_modified": "2022-12-09T18:15:16.973",
+        "created": "2022-12-09T16:20:06.943",
+    }
+
+    if update:
+        data.update(update)
+    return data

--- a/tests/nvd/cpe/__init__.py
+++ b/tests/nvd/cpe/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/nvd/cpe/test_api.py
+++ b/tests/nvd/cpe/test_api.py
@@ -1,0 +1,315 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=line-too-long, arguments-differ, redefined-builtin
+
+from datetime import datetime
+from typing import Any, Dict, List, Optional
+from unittest.mock import MagicMock, patch
+
+from httpx import AsyncClient, Response
+
+from pontos.errors import PontosError
+from pontos.nvd.api import now, sleep
+from pontos.nvd.cpe.api import CPEApi
+from tests import AsyncMock, IsolatedAsyncioTestCase, aiter, anext
+from tests.nvd import get_cpe_data
+
+
+def create_cpe_response(
+    cpe_name_id: str, update: Optional[Dict[str, Any]] = None
+) -> MagicMock:
+    data = {
+        "products": [{"cpe": get_cpe_data({"cpe_name_id": cpe_name_id})}],
+        "results_per_page": 1,
+    }
+    if update:
+        data.update(update)
+
+    response = MagicMock(spec=Response)
+    response.json.return_value = data
+    return response
+
+
+def create_cpes_responses(count: int = 2) -> List[MagicMock]:
+    return [
+        create_cpe_response(f"CPE-{i}", {"total_results": count})
+        for i in range(1, count + 1)
+    ]
+
+
+class CPEApiTestCase(IsolatedAsyncioTestCase):
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    def setUp(self, async_client: MagicMock) -> None:
+        self.http_client = AsyncMock()
+        async_client.return_value = self.http_client
+        self.api = CPEApi()
+
+    async def test_no_cpe_name_id(self):
+        with self.assertRaises(PontosError):
+            await self.api.cpe(None)
+
+    @patch("pontos.nvd.api.sleep", spec=sleep)
+    async def test_rate_limit(self, sleep_mock: MagicMock):
+        self.http_client.get.side_effect = create_cpes_responses(6)
+
+        it = aiter(self.api.cpes())
+        await anext(it)
+        await anext(it)
+        await anext(it)
+        await anext(it)
+        await anext(it)
+
+        sleep_mock.assert_not_called()
+
+        await anext(it)
+
+        sleep_mock.assert_called_once_with()
+
+    @patch("pontos.nvd.cpe.api.now", spec=now)
+    async def test_cves_last_modified_start_date(self, now_mock: MagicMock):
+        now_mock.return_value = datetime(2022, 12, 31)
+        self.http_client.get.side_effect = create_cpes_responses()
+
+        it = aiter(
+            self.api.cpes(last_modified_start_date=datetime(2022, 12, 1))
+        )
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-1")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 0,
+                "lastModStartDate": "2022-12-01T00:00:00",
+                "lastModEndDate": "2022-12-31T00:00:00",
+            },
+        )
+
+        self.http_client.get.reset_mock()
+
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-2")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 1,
+                "lastModStartDate": "2022-12-01T00:00:00",
+                "lastModEndDate": "2022-12-31T00:00:00",
+                "resultsPerPage": 1,
+            },
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            cve = await anext(it)
+
+    async def test_cves_last_modified_end_date(self):
+        self.http_client.get.side_effect = create_cpes_responses()
+
+        it = aiter(
+            self.api.cpes(
+                last_modified_start_date=datetime(2022, 12, 1),
+                last_modified_end_date=datetime(2022, 12, 31),
+            )
+        )
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-1")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 0,
+                "lastModStartDate": "2022-12-01T00:00:00",
+                "lastModEndDate": "2022-12-31T00:00:00",
+            },
+        )
+
+        self.http_client.get.reset_mock()
+
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-2")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 1,
+                "lastModStartDate": "2022-12-01T00:00:00",
+                "lastModEndDate": "2022-12-31T00:00:00",
+                "resultsPerPage": 1,
+            },
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            cve = await anext(it)
+
+    async def test_cpes_keywords(self):
+        self.http_client.get.side_effect = create_cpes_responses()
+
+        it = aiter(self.api.cpes(keywords=["Mac OS X", "kernel"]))
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-1")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 0,
+                "keywordSearch": "Mac OS X kernel",
+                "keywordExactMatch": "",
+            },
+        )
+
+        self.http_client.get.reset_mock()
+
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-2")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 1,
+                "resultsPerPage": 1,
+                "keywordSearch": "Mac OS X kernel",
+                "keywordExactMatch": "",
+            },
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            cve = await anext(it)
+
+    async def test_cpes_keyword(self):
+        self.http_client.get.side_effect = create_cpes_responses()
+
+        it = aiter(self.api.cpes(keywords="macOS"))
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-1")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 0,
+                "keywordSearch": "macOS",
+            },
+        )
+
+        self.http_client.get.reset_mock()
+
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-2")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 1,
+                "resultsPerPage": 1,
+                "keywordSearch": "macOS",
+            },
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            cve = await anext(it)
+
+    async def test_cpes_cpe_match_string(self):
+        self.http_client.get.side_effect = create_cpes_responses()
+
+        it = aiter(
+            self.api.cpes(
+                cpe_match_string="cpe:2.3:o:microsoft:windows_10:20h2:*:*:*:*:*:*:*"
+            )
+        )
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-1")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 0,
+                "cpeMatchString": "cpe:2.3:o:microsoft:windows_10:20h2:*:*:*:*:*:*:*",
+            },
+        )
+
+        self.http_client.get.reset_mock()
+
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-2")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 1,
+                "resultsPerPage": 1,
+                "cpeMatchString": "cpe:2.3:o:microsoft:windows_10:20h2:*:*:*:*:*:*:*",
+            },
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            cve = await anext(it)
+
+    async def test_cpes_match_criteria_id(self):
+        self.http_client.get.side_effect = create_cpes_responses()
+
+        it = aiter(
+            self.api.cpes(
+                match_criteria_id="36FBCF0F-8CEE-474C-8A04-5075AF53FAF4"
+            )
+        )
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-1")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 0,
+                "matchCriteriaId": "36FBCF0F-8CEE-474C-8A04-5075AF53FAF4",
+            },
+        )
+
+        self.http_client.get.reset_mock()
+
+        cve = await anext(it)
+
+        self.assertEqual(cve.cpe_name_id, "CPE-2")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/cpes/2.0",
+            headers={},
+            params={
+                "startIndex": 1,
+                "resultsPerPage": 1,
+                "matchCriteriaId": "36FBCF0F-8CEE-474C-8A04-5075AF53FAF4",
+            },
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            cve = await anext(it)
+
+    async def test_context_manager(self):
+        async with self.api:
+            pass
+
+        self.http_client.__aenter__.assert_awaited_once()
+        self.http_client.__aexit__.assert_awaited_once()

--- a/tests/nvd/cve/test_api.py
+++ b/tests/nvd/cve/test_api.py
@@ -64,6 +64,18 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
         with self.assertRaises(PontosError):
             await self.api.cve(None)
 
+    async def test_no_cve(self):
+        data = {
+            "vulnerabilities": [],
+            "results_per_page": 1,
+        }
+        response = MagicMock(spec=Response)
+        response.json.return_value = data
+        self.http_client.get.return_value = response
+
+        with self.assertRaises(PontosError):
+            await self.api.cve("CVE-1")
+
     async def test_cve(self):
         data = {"vulnerabilities": [{"cve": get_cve_data()}]}
         response = MagicMock(spec=Response)

--- a/tests/nvd/models/test_cpe.py
+++ b/tests/nvd/models/test_cpe.py
@@ -1,0 +1,114 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=line-too-long
+
+import unittest
+from datetime import datetime
+
+from pontos.nvd.models.cpe import CPE, ReferenceType
+from tests.nvd import get_cpe_data
+
+
+class CPETestCase(unittest.TestCase):
+    def test_required_only(self):
+        cpe = CPE.from_dict(get_cpe_data())
+
+        self.assertEqual(
+            cpe.cpe_name,
+            "cpe:2.3:o:microsoft:windows_10_22h2:-:*:*:*:*:*:arm64:*",
+        )
+        self.assertEqual(
+            cpe.cpe_name_id, "9BAECDB2-614D-4E9C-9936-190C30246F03"
+        )
+        self.assertFalse(cpe.deprecated)
+        self.assertEqual(
+            cpe.last_modified, datetime(2022, 12, 9, 18, 15, 16, 973000)
+        )
+        self.assertEqual(cpe.created, datetime(2022, 12, 9, 16, 20, 6, 943000))
+
+        self.assertEqual(cpe.titles, [])
+        self.assertEqual(cpe.refs, [])
+        self.assertEqual(cpe.deprecated_by, [])
+
+    def test_titles(self):
+        cpe = CPE.from_dict(
+            get_cpe_data(
+                {
+                    "titles": [
+                        {
+                            "title": "Microsoft Windows 10 22h2 on ARM64",
+                            "lang": "en",
+                        }
+                    ],
+                }
+            )
+        )
+
+        self.assertEqual(len(cpe.titles), 1)
+
+        title = cpe.titles[0]
+        self.assertEqual(title.title, "Microsoft Windows 10 22h2 on ARM64")
+        self.assertEqual(title.lang, "en")
+
+    def test_refs(self):
+        cpe = CPE.from_dict(
+            get_cpe_data(
+                {
+                    "refs": [
+                        {
+                            "ref": "https://learn.microsoft.com/en-us/windows/release-health/release-information",
+                            "type": "Version",
+                        }
+                    ],
+                }
+            )
+        )
+
+        self.assertEqual(len(cpe.refs), 1)
+
+        reference = cpe.refs[0]
+        self.assertEqual(
+            reference.ref,
+            "https://learn.microsoft.com/en-us/windows/release-health/release-information",
+        )
+        self.assertEqual(reference.type, ReferenceType.VERSION)
+
+    def test_deprecated(self):
+        cpe = CPE.from_dict(
+            get_cpe_data(
+                {
+                    "deprecated": True,
+                    "deprecated_by": [
+                        {
+                            "cpe_name": "cpe:2.3:o:microsoft:windows_10_22h2:-:*:*:*:*:*:x64:*",
+                            "cpe_name_id": "A09335E2-B42F-4820-B487-57A4BF0CEE98",
+                        }
+                    ],
+                }
+            )
+        )
+
+        self.assertTrue(cpe.deprecated)
+        self.assertEqual(len(cpe.deprecated_by), 1)
+
+        deprecated_by = cpe.deprecated_by[0]
+        self.assertEqual(
+            deprecated_by.cpe_name,
+            "cpe:2.3:o:microsoft:windows_10_22h2:-:*:*:*:*:*:x64:*",
+        )
+        self.assertEqual(
+            deprecated_by.cpe_name_id, "A09335E2-B42F-4820-B487-57A4BF0CEE98"
+        )

--- a/tests/nvd/test_api.py
+++ b/tests/nvd/test_api.py
@@ -17,12 +17,34 @@
 
 # pylint: disable=protected-access
 
+import unittest
+from datetime import datetime
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from httpx import AsyncClient
 
-from pontos.nvd.api import NVDApi, sleep
+from pontos.nvd.api import NVDApi, convert_camel_case, format_date, sleep
 from tests import IsolatedAsyncioTestCase
+
+
+class ConvertCamelCaseTestCase(unittest.TestCase):
+    def test_convert(self):
+        data = {
+            "someValue": 123,
+            "otherValue": "bar",
+        }
+
+        converted = convert_camel_case(data)
+        self.assertEqual(converted["some_value"], 123)
+        self.assertEqual(converted["other_value"], "bar")
+
+
+class FormatDateTestCase(unittest.TestCase):
+    def test_format_date(self):
+        dt = datetime(2022, 12, 10, 10, 0, 12, 123)
+        fd = format_date(dt)
+
+        self.assertEqual(fd, "2022-12-10T10:00:12")
 
 
 class NVDApiTestCase(IsolatedAsyncioTestCase):

--- a/tests/nvd/test_api.py
+++ b/tests/nvd/test_api.py
@@ -1,0 +1,105 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=protected-access
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from httpx import AsyncClient
+
+from pontos.nvd.api import NVDApi, sleep
+from tests import IsolatedAsyncioTestCase
+
+
+class NVDApiTestCase(IsolatedAsyncioTestCase):
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    async def test_context_manager(self, async_client: MagicMock):
+        http_client = AsyncMock()
+        async_client.return_value = http_client
+        api = NVDApi("https://foo.bar/baz", token="token")
+
+        async with api:
+            pass
+
+        http_client.__aenter__.assert_awaited_once()
+        http_client.__aexit__.assert_awaited_once()
+
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    async def test_get_without_token(self, async_client: MagicMock):
+        http_client = AsyncMock()
+        async_client.return_value = http_client
+        api = NVDApi("https://foo.bar/baz")
+
+        await api._get()
+
+        http_client.get.assert_awaited_once_with(
+            "https://foo.bar/baz", headers={}, params=None
+        )
+
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    async def test_get_with_token(self, async_client: MagicMock):
+        http_client = AsyncMock()
+        async_client.return_value = http_client
+        api = NVDApi("https://foo.bar/baz", token="token")
+
+        await api._get()
+
+        http_client.get.assert_awaited_once_with(
+            "https://foo.bar/baz", headers={"apiKey": "token"}, params=None
+        )
+
+    @patch("pontos.nvd.api.sleep", spec=sleep)
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    async def test_rate_limit(
+        self, async_client: MagicMock, sleep_mock: MagicMock
+    ):
+        http_client = AsyncMock()
+        async_client.return_value = http_client
+        api = NVDApi("https://foo.bar/baz")
+
+        await api._get()
+        await api._get()
+        await api._get()
+        await api._get()
+        await api._get()
+
+        sleep_mock.assert_not_called()
+
+        await api._get()
+
+        sleep_mock.assert_called_once_with()
+
+    @patch("pontos.nvd.api.sleep", spec=sleep)
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    async def test_no_rate_limit(
+        self, async_client: MagicMock, sleep_mock: MagicMock
+    ):
+        http_client = AsyncMock()
+        async_client.return_value = http_client
+        api = NVDApi("https://foo.bar/baz", rate_limit=False)
+
+        await api._get()
+        await api._get()
+        await api._get()
+        await api._get()
+        await api._get()
+
+        sleep_mock.assert_not_called()
+
+        await api._get()
+
+        sleep_mock.assert_not_called()


### PR DESCRIPTION
**What**:

Implement a CPE API for querying the NIST NVD CPE information.

DEVOPS-469

**Why**:

We need to convert our current CPE download to the new NIST CPE API in 2023 because the old API will be shut down.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
- [ ] Documentation
