### PR TITLE
Change: Ensure links are rendered for URLs in displayed in GitHub scripts

### DIFF
--- a/scripts/github/artifacts.py
+++ b/scripts/github/artifacts.py
@@ -45,8 +45,9 @@ async def github_script(api: GitHubAsyncRESTApi, args: Namespace) -> int:
         table.add_row(
             artifact.name,
             str(artifact.id),
-            artifact.archive_download_url,
-            artifact.updated_at,
+            f"[link={artifact.archive_download_url}]"
+            f"{artifact.archive_download_url}[/link]",
+            str(artifact.updated_at),
             str(artifact.expired),
             f"{artifact.size_in_bytes / 1024:.2f}",
         )

--- a/scripts/github/members.py
+++ b/scripts/github/members.py
@@ -73,7 +73,10 @@ async def github_script(api: GitHubAsyncRESTApi, args: Namespace) -> int:
     async for user in api.organizations.members(
         args.organization, member_filter=args.filter, role=args.role
     ):
-        table.add_row(user.login, user.html_url)
+        table.add_row(
+            user.login,
+            f"[link={user.html_url}]{user.html_url}[/link]",
+        )
         member_count += 1
 
     console = Console()

--- a/scripts/github/repositories.py
+++ b/scripts/github/repositories.py
@@ -61,7 +61,10 @@ async def github_script(api: GitHubAsyncRESTApi, args: Namespace) -> int:
         args.organization, repository_type=args.type
     ):
         table.add_row(
-            repo.name, repo.description, repo.html_url, repo.visibility
+            repo.name,
+            repo.description,
+            f"[link={repo.html_url}]{repo.html_url}[/link]",
+            repo.visibility,
         )
 
         repo_count += 1

--- a/scripts/github/teams.py
+++ b/scripts/github/teams.py
@@ -44,7 +44,7 @@ async def github_script(api: GitHubAsyncRESTApi, args: Namespace) -> int:
         table.add_row(
             team.name,
             team.description,
-            team.html_url,
+            f"[link={team.html_url}]{team.html_url}[/link]",
             team.privacy.value,
         )
         count += 1

--- a/scripts/github/workflow-runs.py
+++ b/scripts/github/workflow-runs.py
@@ -76,7 +76,7 @@ async def github_script(api: GitHubAsyncRESTApi, args: Namespace) -> int:
         table.add_row(
             run.name,
             str(run.id),
-            run.html_url,
+            f"[link={run.html_url}]{run.html_url}[/link]",
             run.head_branch,
             run.event.value,
             run.conclusion,


### PR DESCRIPTION
**What**:

While rendering links in table rows it may be possible that the texts are shortened. 

**Why**:

Ensure that the URL are always clickable.

**How**:

Run the scripts and checked the generated links.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Conventional commit message
