### PR TITLE
Async Tags API

### DIFF
--- a/pontos/github/api/api.py
+++ b/pontos/github/api/api.py
@@ -58,6 +58,7 @@ from pontos.github.api.release import (
     GitHubRESTReleaseMixin,
 )
 from pontos.github.api.repositories import GitHubAsyncRESTRepositories
+from pontos.github.api.tags import GitHubAsyncRESTTags
 from pontos.github.api.teams import GitHubAsyncRESTTeams
 from pontos.github.api.workflows import (
     GitHubAsyncRESTWorkflows,
@@ -161,6 +162,13 @@ class GitHubAsyncRESTApi(AbstractAsyncContextManager):
         Teams related API
         """
         return GitHubAsyncRESTTeams(self._client)
+
+    @property
+    def tags(self) -> GitHubAsyncRESTTags:
+        """
+        Tags related API
+        """
+        return GitHubAsyncRESTTags(self._client)
 
     async def __aenter__(self) -> "GitHubAsyncRESTApi":
         await self._client.__aenter__()

--- a/pontos/github/api/tags.py
+++ b/pontos/github/api/tags.py
@@ -1,0 +1,114 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from datetime import datetime
+from typing import Optional, Union
+
+from pontos.github.api.client import GitHubAsyncREST
+from pontos.github.models.tag import GitObjectType, Tag
+from pontos.helper import enum_or_value
+
+
+class GitHubAsyncRESTTags(GitHubAsyncREST):
+    async def create(
+        self,
+        repo: str,
+        tag: str,
+        message: str,
+        name: str,
+        email: str,
+        git_object: str,
+        *,
+        git_object_type: Optional[
+            Union[GitObjectType, str]
+        ] = GitObjectType.COMMIT,
+        date: Optional[datetime] = None,
+    ) -> Tag:
+        """
+        Create a new Git tag
+
+        https://docs.github.com/en/rest/git/tags#create-a-tag-object
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            tag: The tag's name. This is typically a version (e.g., "v0.0.1").
+            message: The tag message.
+            name: The name of the author of the tag
+            email: The email of the author of the tag
+            git_object: The SHA of the git object this is tagging.
+            git_object_type: The type of the object we're tagging. Normally this
+                is a commit type but it can also be a tree or a blob.
+            date: When this object was tagged.
+        """
+        data = {
+            "tag": tag,
+            "message": message,
+            "object": git_object,
+            "type": enum_or_value(git_object_type),
+            "tagger": {
+                "name": name,
+                "email": email,
+            },
+        }
+
+        if date:
+            data["tagger"]["date"] = date.isoformat(timespec="seconds")
+
+        api = f"/repos/{repo}/git/tags"
+        response = await self._client.post(api, data=data)
+        response.raise_for_status()
+        return Tag.from_dict(response.json())
+
+    async def create_tag_reference(
+        self,
+        repo: str,
+        tag: str,
+        sha: str,
+    ) -> None:
+        """
+        Create git tag reference (A real tag in git).
+
+        https://docs.github.com/en/rest/git/refs#create-a-reference
+
+        Args:
+            repo: The name of the repository.
+                The name is not case sensitive.
+            tag: Github tag name.
+            sha: The SHA1 value for this Github tag.
+        """
+
+        data = {
+            "ref": f"refs/tags/{tag}",
+            "sha": sha,
+        }
+
+        api = f"/repos/{repo}/git/refs"
+        response = await self._client.post(api, data=data)
+        response.raise_for_status()
+
+    async def get(self, repo: str, tag_sha: str) -> Tag:
+        """
+        Get information about a git tag
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            tag_sha: SHA of the git tag object
+        """
+        api = f"/repos/{repo}/git/tags/{tag_sha}"
+        response = await self._client.get(api)
+        response.raise_for_status()
+        return Tag.from_dict(response.json())

--- a/pontos/github/models/tag.py
+++ b/pontos/github/models/tag.py
@@ -1,0 +1,85 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+from typing import Optional
+
+from pontos.github.models.base import GitHubModel
+
+__all__ = (
+    "GitObjectType",
+    "Tag",
+    "VerificationReason",
+)
+
+
+class GitObjectType(Enum):
+    COMMIT = "commit"
+    TREE = "tree"
+    BLOB = "blob"
+
+
+@dataclass
+class GitObject(GitHubModel):
+    sha: str
+    type: GitObjectType
+    url: str
+
+
+@dataclass
+class Tagger(GitHubModel):
+    date: datetime
+    email: str
+    name: str
+
+
+class VerificationReason(Enum):
+    EXPIRED_KEY = "expired_key"
+    NOT_SIGNING_KEY = "not_signing_key"
+    GPGVERIFY_ERROR = "gpgverify_error"
+    GPGVERIFY_UNAVAILABLE = "gpgverify_unavailable"
+    UNSIGNED = "unsigned"
+    UNKNOWN_SIGNATURE_TYPE = "unknown_signature_type"
+    NO_USER = "no_user"
+    UNVERIFIED_EMAIL = "unverified_email"
+    BAD_EMAIL = "bad_email"
+    UNKNOWN_KEY = "unknown_key"
+    MALFORMED_SIGNATURE = "malformed_signature"
+    INVALID = "invalid"
+    VALID = "valid"
+
+
+@dataclass
+class Verification(GitHubModel):
+    verified: bool
+    reason: VerificationReason
+    payload: Optional[str] = None
+    signature: Optional[str] = None
+
+
+@dataclass
+class Tag(GitHubModel):
+    node_id: str
+    tag: str
+    sha: str
+    url: str
+    message: str
+    tagger: Tagger
+    object: GitObject
+    verification: Optional[Verification] = None

--- a/tests/github/api/test_tags.py
+++ b/tests/github/api/test_tags.py
@@ -1,0 +1,212 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=line-too-long
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import httpx
+
+from pontos.github.api.tags import GitHubAsyncRESTTags
+from pontos.github.models.tag import GitObjectType, Tag, VerificationReason
+from tests.github.api import GitHubAsyncRESTTestCase, create_response
+
+TAG_JSON = {
+    "node_id": "MDM6VGFnOTQwYmQzMzYyNDhlZmFlMGY5ZWU1YmM3YjJkNWM5ODU4ODdiMTZhYw==",
+    "tag": "v0.0.1",
+    "sha": "940bd336248efae0f9ee5bc7b2d5c985887b16ac",
+    "url": "https://api.github.com/repos/octocat/Hello-World/git/tags/940bd336248efae0f9ee5bc7b2d5c985887b16ac",
+    "message": "initial version",
+    "tagger": {
+        "name": "Monalisa Octocat",
+        "email": "octocat@github.com",
+        "date": "2014-11-07T22:01:45Z",
+    },
+    "object": {
+        "type": "commit",
+        "sha": "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+        "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+    },
+    "verification": {
+        "verified": False,
+        "reason": "unsigned",
+        "signature": None,
+        "payload": None,
+    },
+}
+
+
+class GitHubAsyncRESTTagsTestCase(GitHubAsyncRESTTestCase):
+    api_cls = GitHubAsyncRESTTags
+
+    def assertTag(self, tag: Tag):  # pylint: disable=invalid-name
+        self.assertEqual(
+            tag.node_id,
+            "MDM6VGFnOTQwYmQzMzYyNDhlZmFlMGY5ZWU1YmM3YjJkNWM5ODU4ODdiMTZhYw==",
+        )
+        self.assertEqual(tag.tag, "v0.0.1")
+        self.assertEqual(tag.sha, "940bd336248efae0f9ee5bc7b2d5c985887b16ac")
+        self.assertEqual(
+            tag.url,
+            "https://api.github.com/repos/octocat/Hello-World/git/tags/940bd336248efae0f9ee5bc7b2d5c985887b16ac",
+        )
+        self.assertEqual(tag.message, "initial version")
+
+        tagger = tag.tagger
+        self.assertEqual(tagger.name, "Monalisa Octocat")
+        self.assertEqual(tagger.email, "octocat@github.com")
+        self.assertEqual(
+            tagger.date, datetime(2014, 11, 7, 22, 1, 45, tzinfo=timezone.utc)
+        )
+
+        tag_object = tag.object
+        self.assertEqual(tag_object.type, GitObjectType.COMMIT)
+        self.assertEqual(
+            tag_object.sha, "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c"
+        )
+        self.assertEqual(
+            tag_object.url,
+            "https://api.github.com/repos/octocat/Hello-World/git/commits/c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+        )
+
+        verification = tag.verification
+        self.assertFalse(verification.verified)
+        self.assertEqual(verification.reason, VerificationReason.UNSIGNED)
+        self.assertIsNone(verification.payload)
+        self.assertIsNone(verification.signature)
+
+    async def test_create(self):
+        response = create_response()
+        response.json.return_value = TAG_JSON
+        self.client.post.return_value = response
+
+        tag = await self.api.create(
+            "octocat/Hello-World",
+            "v0.0.1",
+            "initial version",
+            "Monalisa Octocat",
+            "octocat@github.com",
+            "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+        )
+
+        self.client.post.assert_awaited_once_with(
+            "/repos/octocat/Hello-World/git/tags",
+            data={
+                "tag": "v0.0.1",
+                "message": "initial version",
+                "object": "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+                "type": "commit",
+                "tagger": {
+                    "name": "Monalisa Octocat",
+                    "email": "octocat@github.com",
+                },
+            },
+        )
+
+        self.assertTag(tag)
+
+    async def test_create_failure(self):
+        response = create_response()
+        self.client.post.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=response
+        )
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            await self.api.create(
+                "octocat/Hello-World",
+                "v0.0.1",
+                "initial version",
+                "Monalisa Octocat",
+                "octocat@github.com",
+                "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+            )
+
+        self.client.post.assert_awaited_once_with(
+            "/repos/octocat/Hello-World/git/tags",
+            data={
+                "tag": "v0.0.1",
+                "message": "initial version",
+                "object": "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+                "type": "commit",
+                "tagger": {
+                    "name": "Monalisa Octocat",
+                    "email": "octocat@github.com",
+                },
+            },
+        )
+
+    async def test_create_tag_reference(self):
+        response = create_response()
+        self.client.post.return_value = response
+
+        await self.api.create_tag_reference(
+            "foo/bar", "v1.0.0", "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c"
+        )
+
+        self.client.post.assert_awaited_once_with(
+            "/repos/foo/bar/git/refs",
+            data={
+                "ref": "refs/tags/v1.0.0",
+                "sha": "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+            },
+        )
+
+    async def test_create_tag_reference_failure(self):
+        response = create_response()
+        self.client.post.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=response
+        )
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            await self.api.create_tag_reference(
+                "foo/bar", "v1.0.0", "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c"
+            )
+
+        self.client.post.assert_awaited_once_with(
+            "/repos/foo/bar/git/refs",
+            data={
+                "ref": "refs/tags/v1.0.0",
+                "sha": "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+            },
+        )
+
+    async def test_get(self):
+        response = create_response()
+        response.json.return_value = TAG_JSON
+        self.client.get.return_value = response
+
+        tag = await self.api.get("octocat/Hello-World", "v0.0.1")
+
+        self.client.get.assert_awaited_once_with(
+            "/repos/octocat/Hello-World/git/tags/v0.0.1"
+        )
+
+        self.assertTag(tag)
+
+    async def test_get_failure(self):
+        response = create_response()
+        self.client.get.side_effect = httpx.HTTPStatusError(
+            "404", request=MagicMock(), response=response
+        )
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            await self.api.get("octocat/Hello-World", "v0.0.1")
+
+        self.client.get.assert_awaited_once_with(
+            "/repos/octocat/Hello-World/git/tags/v0.0.1"
+        )

--- a/tests/github/models/test_tag.py
+++ b/tests/github/models/test_tag.py
@@ -1,0 +1,87 @@
+# Copyright (C) 2022 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+# pylint: disable=line-too-long
+
+import unittest
+from datetime import datetime, timezone
+
+from pontos.github.models.tag import GitObjectType, Tag, VerificationReason
+
+
+class TagModelTestCase(unittest.TestCase):
+    def test_from_dict(self):
+        data = {
+            "node_id": "MDM6VGFnOTQwYmQzMzYyNDhlZmFlMGY5ZWU1YmM3YjJkNWM5ODU4ODdiMTZhYw==",
+            "tag": "v0.0.1",
+            "sha": "940bd336248efae0f9ee5bc7b2d5c985887b16ac",
+            "url": "https://api.github.com/repos/octocat/Hello-World/git/tags/940bd336248efae0f9ee5bc7b2d5c985887b16ac",
+            "message": "initial version",
+            "tagger": {
+                "name": "Monalisa Octocat",
+                "email": "octocat@github.com",
+                "date": "2014-11-07T22:01:45Z",
+            },
+            "object": {
+                "type": "commit",
+                "sha": "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+                "url": "https://api.github.com/repos/octocat/Hello-World/git/commits/c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+            },
+            "verification": {
+                "verified": False,
+                "reason": "unsigned",
+                "signature": None,
+                "payload": None,
+            },
+        }
+
+        tag = Tag.from_dict(data)
+
+        self.assertEqual(
+            tag.node_id,
+            "MDM6VGFnOTQwYmQzMzYyNDhlZmFlMGY5ZWU1YmM3YjJkNWM5ODU4ODdiMTZhYw==",
+        )
+        self.assertEqual(tag.tag, "v0.0.1")
+        self.assertEqual(tag.sha, "940bd336248efae0f9ee5bc7b2d5c985887b16ac")
+        self.assertEqual(
+            tag.url,
+            "https://api.github.com/repos/octocat/Hello-World/git/tags/940bd336248efae0f9ee5bc7b2d5c985887b16ac",
+        )
+        self.assertEqual(tag.message, "initial version")
+
+        tagger = tag.tagger
+        self.assertEqual(tagger.name, "Monalisa Octocat")
+        self.assertEqual(tagger.email, "octocat@github.com")
+        self.assertEqual(
+            tagger.date, datetime(2014, 11, 7, 22, 1, 45, tzinfo=timezone.utc)
+        )
+
+        tag_object = tag.object
+        self.assertEqual(tag_object.type, GitObjectType.COMMIT)
+        self.assertEqual(
+            tag_object.sha, "c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c"
+        )
+        self.assertEqual(
+            tag_object.url,
+            "https://api.github.com/repos/octocat/Hello-World/git/commits/c3d0be41ecbe669545ee3e94d31ed9a4bc91ee3c",
+        )
+
+        verification = tag.verification
+        self.assertFalse(verification.verified)
+        self.assertEqual(verification.reason, VerificationReason.UNSIGNED)
+        self.assertIsNone(verification.payload)
+        self.assertIsNone(verification.signature)


### PR DESCRIPTION
**What**:

Add an async API for GitHub tags handling

Requires #534

**Why**:

The API was provided by the sync API but not for the async.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
