### PR TITLE
Change: Async pontos-github CLI

### DIFF
--- a/pontos/github/argparser.py
+++ b/pontos/github/argparser.py
@@ -229,7 +229,7 @@ def parse_args(
     label_parser.set_defaults(func=labels)
 
     label_parser.add_argument(
-        "repo", help=("GitHub repository (owner/name) to use")
+        "repo", help="GitHub repository (owner/name) to use"
     )
 
     label_parser.add_argument(
@@ -286,7 +286,7 @@ def parse_args(
     repos_parser.add_argument(
         "-p",
         "--path",
-        help="Define the Path to save the Repository Information JSON",
+        help="Define the Path to save the Repository Information",
     )
 
     # create a release from command line

--- a/pontos/github/cmds.py
+++ b/pontos/github/cmds.py
@@ -15,135 +15,106 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import json
 import sys
 from argparse import Namespace
 from pathlib import Path
 
 import httpx
 
-from pontos.github.api import GitHubRESTApi
+from pontos.github.api import GitHubAsyncRESTApi
 from pontos.terminal import Terminal
 
 
-def tag(terminal: Terminal, args: Namespace) -> None:
+async def tag(terminal: Terminal, args: Namespace) -> None:
     """Github release function for argument class to call"""
+    await args.tag_func(terminal, args)
 
-    args.tag_func(terminal, args)
 
-
-def create_tag(terminal: Terminal, args: Namespace) -> None:
+async def create_tag(terminal: Terminal, args: Namespace) -> None:
     """Github create tag function for
     argument class to call"""
+    async with GitHubAsyncRESTApi(token=args.token) as api:
+        try:
+            # Create tag
+            new_tag = await api.tags.create(
+                repo=args.repo,
+                tag=args.tag,
+                message=args.message,
+                git_object=args.git_object,
+                name=args.name,
+                email=args.email,
+                git_object_type=args.git_object_type,
+                date=args.date,
+            )
 
-    git = GitHubRESTApi(token=args.token)
+            # Create tag reference
+            await api.tags.create_tag_reference(
+                repo=args.repo, tag=args.tag, sha=new_tag.sha
+            )
 
-    try:
-        # Create tag
-        sha = git.create_tag(
-            repo=args.repo,
-            tag=args.tag,
-            message=args.message,
-            git_object=args.git_object,
-            name=args.name,
-            email=args.email,
-            git_object_type=args.git_object_type,
-            date=args.date,
-        )
+        except httpx.HTTPError as e:
+            terminal.error(str(e))
+            sys.exit(1)
 
-        # Create tag reference
-        git.create_tag_reference(repo=args.repo, tag=args.tag, sha=sha)
-
-    except httpx.HTTPError as e:
-        terminal.error(str(e))
-        sys.exit(1)
-
-    terminal.ok("Tag created.")
+        terminal.ok("Tag created.")
 
 
-def release(terminal: Terminal, args: Namespace) -> None:
+async def release(terminal: Terminal, args: Namespace) -> None:
     """Github release function for argument class to call"""
+    await args.re_func(terminal, args)
 
-    args.re_func(terminal, args)
 
-
-def create_release(terminal: Terminal, args: Namespace) -> None:
+async def create_release(terminal: Terminal, args: Namespace) -> None:
     """Github create release function for
     argument class to call"""
 
-    git = GitHubRESTApi(token=args.token)
+    async with GitHubAsyncRESTApi(token=args.token) as api:
+        try:
+            # Check if release exist
+            exists = await api.releases.exists(repo=args.repo, tag=args.tag)
+            if exists:
+                terminal.error(f"Release {args.tag} exist.")
+                sys.exit(1)
 
-    try:
-        # Check if release exist
-        if git.release_exists(repo=args.repo, tag=args.tag):
-            terminal.error(f"Release {args.tag} exist.")
-            sys.exit(1)
-
-        # Create release
-        git.create_release(
-            repo=args.repo,
-            tag=args.tag,
-            body=args.body,
-            name=args.name,
-            target_commitish=args.target_commitish,
-            draft=args.draft,
-            prerelease=args.prerelease,
-        )
-    except httpx.HTTPError as e:
-        terminal.error(str(e))
-        sys.exit(1)
-
-    terminal.ok("Release created.")
-
-
-def pull_request(terminal: Terminal, args: Namespace):
-    args.pr_func(terminal, args)
-
-
-def create_pull_request(terminal: Terminal, args: Namespace):
-    git = GitHubRESTApi(token=args.token)
-
-    try:
-        # check if branches exist
-        if not git.branch_exists(repo=args.repo, branch=args.head):
-            terminal.error(
-                f"Head branch {args.head} is not existing "
-                "or authorisation failed."
+            # Create release
+            await api.releases.create(
+                repo=args.repo,
+                tag=args.tag,
+                body=args.body,
+                name=args.name,
+                target_commitish=args.target_commitish,
+                draft=args.draft,
+                prerelease=args.prerelease,
             )
+
+            terminal.ok("Release created.")
+        except httpx.HTTPError as e:
+            terminal.error(str(e))
             sys.exit(1)
 
-        terminal.ok(f"Head branch {args.head} is existing.")
 
-        if not git.branch_exists(repo=args.repo, branch=args.target):
-            terminal.error(
-                f"Target branch {args.target} is not existing or "
-                "authorisation failed."
-            )
-            sys.exit(1)
-
-        terminal.ok(f"Target branch {args.target} exists.")
-
-        git.create_pull_request(
-            repo=args.repo,
-            head_branch=args.head,
-            base_branch=args.target,
-            title=args.title,
-            body=args.body,
-        )
-    except httpx.HTTPError as e:
-        terminal.error(str(e))
-        sys.exit(1)
-
-    terminal.ok("Pull Request created.")
+async def pull_request(terminal: Terminal, args: Namespace):
+    await args.pr_func(terminal, args)
 
 
-def update_pull_request(terminal: Terminal, args: Namespace):
-    git = GitHubRESTApi(token=args.token)
-
-    try:
-        if args.target:
+async def create_pull_request(terminal: Terminal, args: Namespace):
+    async with GitHubAsyncRESTApi(token=args.token) as api:
+        try:
             # check if branches exist
-            if not git.branch_exists(repo=args.repo, branch=args.target):
+            exists = await api.branches.exists(repo=args.repo, branch=args.head)
+            if not exists:
+                terminal.error(
+                    f"Head branch {args.head} is not existing "
+                    "or authorisation failed."
+                )
+                sys.exit(1)
+
+            terminal.ok(f"Head branch {args.head} is existing.")
+
+            exists = await api.branches.exists(
+                repo=args.repo, branch=args.target
+            )
+            if not exists:
                 terminal.error(
                     f"Target branch {args.target} is not existing or "
                     "authorisation failed."
@@ -151,103 +122,147 @@ def update_pull_request(terminal: Terminal, args: Namespace):
                 sys.exit(1)
 
             terminal.ok(f"Target branch {args.target} exists.")
-        git.update_pull_request(
-            repo=args.repo,
-            pull_request=args.pull_request,
-            base_branch=args.target,
-            title=args.title,
-            body=args.body,
-        )
-    except httpx.HTTPError as e:
-        terminal.error(str(e))
-        sys.exit(1)
 
-    terminal.ok("Pull Request updated.")
-
-
-def file_status(terminal: Terminal, args: Namespace):
-    git = GitHubRESTApi(token=args.token)
-
-    try:
-        # check if PR is existing
-        if not git.pull_request_exists(
-            repo=args.repo, pull_request=args.pull_request
-        ):
-            terminal.error(
-                f"PR {args.pull_request} is not existing "
-                "or authorisation failed."
+            await api.pulls.create(
+                repo=args.repo,
+                head_branch=args.head,
+                base_branch=args.target,
+                title=args.title,
+                body=args.body,
             )
-            sys.exit(1)
-        terminal.ok(f"PR {args.pull_request} exists.")
 
-        file_dict = git.pull_request_files(
-            repo=args.repo,
-            pull_request=args.pull_request,
-            status_list=args.status,
-        )
-        for status in args.status:
-            terminal.info(f"{status.value}:")
-            files = [str(f.resolve()) for f in file_dict[status]]
-
-            for file_string in files:
-                terminal.print(file_string)
-
-            if args.output:
-                args.output.write("\n".join(files) + "\n")
-
-    except httpx.HTTPError as e:
-        terminal.error(str(e))
-        sys.exit(1)
-
-
-def labels(terminal: Terminal, args: Namespace):
-    git = GitHubRESTApi(token=args.token)
-
-    try:
-        # check if PR is existing
-        if not git.pull_request_exists(repo=args.repo, pull_request=args.issue):
-            terminal.error(
-                f"PR {args.issue} is not existing or authorisation failed."
-            )
+            terminal.ok("Pull Request created.")
+        except httpx.HTTPError as e:
+            terminal.error(str(e))
             sys.exit(1)
 
-        terminal.ok(f"PR {args.issue} exists.")
 
-        issue_labels = git.get_labels(
-            repo=args.repo,
-            issue=args.issue,
-        )
+async def update_pull_request(terminal: Terminal, args: Namespace):
+    async with GitHubAsyncRESTApi(token=args.token) as api:
+        try:
+            if args.target:
+                # check if branches exist
+                exists = await api.branches.exists(
+                    repo=args.repo, branch=args.target
+                )
+                if not exists:
+                    terminal.error(
+                        f"Target branch {args.target} is not existing or "
+                        "authorisation failed."
+                    )
+                    sys.exit(1)
 
-        issue_labels.extend(args.labels)
+                terminal.ok(f"Target branch {args.target} exists.")
 
-        git.set_labels(repo=args.repo, issue=args.issue, labels=issue_labels)
-
-    except httpx.HTTPError as e:
-        terminal.error(str(e))
-        sys.exit(1)
-
-
-def repos(terminal: Terminal, args: Namespace):
-    git = GitHubRESTApi(token=args.token)
-
-    try:
-        # check if Orga is existing
-        if not git.organisation_exists(orga=args.orga):
-            terminal.error(
-                f"PR {args.orga} is not existing or authorisation failed."
+            await api.pulls.update(
+                repo=args.repo,
+                pull_request=args.pull_request,
+                base_branch=args.target,
+                title=args.title,
+                body=args.body,
             )
-            sys.exit(1)
-        terminal.ok(f"Organization {args.orga} exists.")
-        orga_json = git.get_repositories(
-            orga=args.orga, repository_type=args.type
-        )
-        if args.path:
-            repo_info = Path(args.path)
-            with open(repo_info, encoding="utf-8", mode="w") as fp:
-                json.dump(orga_json, fp, indent=2)
-        else:
-            terminal.print(orga_json)
 
-    except httpx.HTTPError as e:
-        terminal.error(str(e))
-        sys.exit(1)
+            terminal.ok("Pull Request updated.")
+        except httpx.HTTPError as e:
+            terminal.error(str(e))
+            sys.exit(1)
+
+
+async def file_status(terminal: Terminal, args: Namespace):
+    async with GitHubAsyncRESTApi(token=args.token) as api:
+        try:
+            # check if PR is existing
+            exists = await api.pulls.exists(
+                repo=args.repo, pull_request=args.pull_request
+            )
+            if not exists:
+                terminal.error(
+                    f"PR {args.pull_request} is not existing "
+                    "or authorisation failed."
+                )
+                sys.exit(1)
+
+            terminal.ok(f"PR {args.pull_request} exists.")
+
+            file_dict = await api.pulls.files(
+                repo=args.repo,
+                pull_request=args.pull_request,
+                status_list=args.status,
+            )
+            for status in args.status:
+                terminal.info(f"{status.value}:")
+                files = [str(f.resolve()) for f in file_dict[status]]
+
+                for file_string in files:
+                    terminal.print(file_string)
+
+                if args.output:
+                    args.output.write("\n".join(files) + "\n")
+
+        except httpx.HTTPError as e:
+            terminal.error(str(e))
+            sys.exit(1)
+
+
+async def labels(terminal: Terminal, args: Namespace):
+    async with GitHubAsyncRESTApi(token=args.token) as api:
+        try:
+            # check if PR is existing
+            exists = await api.pulls.exists(
+                repo=args.repo, pull_request=args.issue
+            )
+            if not exists:
+                terminal.error(
+                    f"PR {args.issue} is not existing or authorisation failed."
+                )
+                sys.exit(1)
+
+            terminal.ok(f"PR {args.issue} exists.")
+
+            issue_labels = []
+            async for label in api.labels.get_all(
+                repo=args.repo,
+                issue=args.issue,
+            ):
+                issue_labels.append(label)
+
+            issue_labels.extend(args.labels)
+
+            await api.labels.set_all(
+                repo=args.repo, issue=args.issue, labels=issue_labels
+            )
+        except httpx.HTTPError as e:
+            terminal.error(str(e))
+            sys.exit(1)
+
+
+async def repos(terminal: Terminal, args: Namespace):
+    async with GitHubAsyncRESTApi(token=args.token) as api:
+        try:
+            # check if Orga is existing
+            exists = await api.organizations.exists(args.orga)
+            if not exists:
+                terminal.error(
+                    f"PR {args.orga} is not existing or authorisation failed."
+                )
+                sys.exit(1)
+
+            terminal.ok(f"Organization {args.orga} exists.")
+
+            if args.path:
+                repo_info = Path(args.path)
+                with repo_info.open(encoding="utf-8", mode="w") as fp:
+                    async for repo in api.organizations.get_repositories(
+                        organization=args.orga, repository_type=args.type
+                    ):
+                        fp.write(repr(repo))
+
+            else:
+                async for repo in api.organizations.get_repositories(
+                    organization=args.orga, repository_type=args.type
+                ):
+                    terminal.print(repo)
+
+        except httpx.HTTPError as e:
+            terminal.error(str(e))
+            sys.exit(1)

--- a/pontos/github/main.py
+++ b/pontos/github/main.py
@@ -15,6 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+import asyncio
 import sys
 
 from pontos.github.argparser import parse_args
@@ -37,7 +38,7 @@ def main(args=None):
             term.error("A Github User Token is required.")
             sys.exit(1)
 
-        parsed_args.func(term, parsed_args)
+        asyncio.run(parsed_args.func(term, parsed_args))
 
 
 if __name__ == "__main__":

--- a/pontos/testing/__init__.py
+++ b/pontos/testing/__init__.py
@@ -139,9 +139,9 @@ def temp_git_repository(
 
 @contextmanager
 def temp_file(
-    content: str,
+    content: Optional[str] = None,
     *,
-    name: Optional[str] = "test.toml",
+    name: str = "test.toml",
     change_into: bool = False,
 ) -> Generator[Path, None, None]:
     """
@@ -166,7 +166,11 @@ def temp_file(
     """
     with temp_directory(change_into=change_into) as tmp_dir:
         test_file = tmp_dir / name
-        test_file.write_text(content, encoding="utf8")
+        if content:
+            test_file.write_text(content, encoding="utf8")
+        else:
+            test_file.touch()
+
         yield test_file
 
 

--- a/tests/github/test_cmds.py
+++ b/tests/github/test_cmds.py
@@ -17,62 +17,75 @@
 
 # pylint: disable=no-member
 
-import io
-import unittest
 from argparse import Namespace
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, call, patch
 
 from pontos.github.api import FileStatus
-from pontos.github.cmds import file_status, create_release, create_tag
+from pontos.github.cmds import (
+    create_pull_request,
+    create_release,
+    create_tag,
+    file_status,
+    labels,
+    repos,
+    update_pull_request,
+)
+from pontos.github.models.organization import RepositoryType
+from pontos.testing import temp_file
+from tests import AsyncIteratorMock, IsolatedAsyncioTestCase
 
 here = Path(__file__).parent
 
 
-class TestArgparsing(unittest.TestCase):
-    @patch("pontos.github.cmds.GitHubRESTApi")
-    def test_file_status(self, api_mock):
+class TestCmds(IsolatedAsyncioTestCase):
+    @patch("pontos.github.api.api.GitHubAsyncRESTPullRequests", spec=True)
+    async def test_file_status(self, api_mock):
         terminal = MagicMock()
-        api_mock.return_value.pull_request_exists.return_value = True
-        api_mock.return_value.pull_request_files.return_value = {
+        api_mock.return_value.exists.return_value = True
+        api_mock.return_value.files.return_value = {
             FileStatus.ADDED: [Path("tests/github/foo/bar")],
             FileStatus.MODIFIED: [
                 Path("tests/github/bar/baz"),
                 Path("tests/github/baz/boo"),
             ],
         }
-        test_file = Path("some.file")
-        output = io.open(test_file, mode="w", encoding="utf-8")
 
-        args = Namespace(
-            command="FS",
-            func=file_status,
-            repo="foo/bar",
-            pull_request=8,
-            output=output,
-            status=[FileStatus.ADDED, FileStatus.MODIFIED],
-            token="GITHUB_TOKEN",
-        )
+        with temp_file(name="some.file") as test_file:
+            output = test_file.open("w", encoding="utf-8")
 
-        file_status(terminal, args)
+            args = Namespace(
+                repo="foo/bar",
+                pull_request=8,
+                output=output,
+                status=[FileStatus.ADDED, FileStatus.MODIFIED],
+                token="GITHUB_TOKEN",
+            )
 
-        output.close()
+            await file_status(terminal, args)
 
-        content = test_file.read_text(encoding="utf-8")
-        self.assertEqual(
-            content, f"{here}/foo/bar\n{here}/bar/baz\n{here}/baz/boo\n"
-        )
+            api_mock.return_value.exists.assert_awaited_once_with(
+                repo="foo/bar", pull_request=8
+            )
+            api_mock.return_value.files.assert_awaited_once_with(
+                repo="foo/bar",
+                pull_request=8,
+                status_list=[FileStatus.ADDED, FileStatus.MODIFIED],
+            )
 
-        test_file.unlink()
+            output.flush()
 
-    @patch("pontos.github.cmds.GitHubRESTApi")
-    def test_create_release_no_tag(self, api_mock):
+            content = test_file.read_text(encoding="utf-8")
+            self.assertEqual(
+                content, f"{here}/foo/bar\n{here}/bar/baz\n{here}/baz/boo\n"
+            )
+
+    @patch("pontos.github.api.api.GitHubAsyncRESTReleases", spec=True)
+    async def test_create_release_no_tag(self, api_mock):
         terminal = MagicMock()
-        api_mock.return_value.release_exists.return_value = True
+        api_mock.return_value.exists.return_value = True
 
         args = Namespace(
-            command="RE",
-            func=create_release,
             repo="foo/bar",
             tag="test_tag",
             name="test_release",
@@ -84,19 +97,21 @@ class TestArgparsing(unittest.TestCase):
         )
 
         with self.assertRaises(SystemExit) as syse:
-            create_release(terminal, args)
+            await create_release(terminal, args)
 
         self.assertEqual(syse.exception.code, 1)
 
-    @patch("pontos.github.cmds.GitHubRESTApi")
-    def test_create_release(self, api_mock):
+        api_mock.return_value.exists.assert_awaited_once_with(
+            repo="foo/bar", tag="test_tag"
+        )
+
+    @patch("pontos.github.api.api.GitHubAsyncRESTReleases", spec=True)
+    async def test_create_release(self, api_mock):
         terminal = MagicMock()
-        api_mock.return_value.release_exists.return_value = False
-        api_mock.return_value.create_release.return_value = True
+        api_mock.return_value.exists.return_value = False
+        api_mock.return_value.create.return_value = True
 
         args = Namespace(
-            command="RE",
-            func=create_release,
             repo="foo/bar",
             tag="test_tag",
             name="test_release",
@@ -107,26 +122,180 @@ class TestArgparsing(unittest.TestCase):
             token="GITHUB_TOKEN",
         )
 
-        create_release(terminal, args)
+        await create_release(terminal, args)
 
-    @patch("pontos.github.cmds.GitHubRESTApi")
-    def test_create_tag(self, api_mock):
+        api_mock.return_value.exists.assert_awaited_once_with(
+            repo="foo/bar", tag="test_tag"
+        )
+        api_mock.return_value.create.assert_awaited_once_with(
+            repo="foo/bar",
+            tag="test_tag",
+            body=None,
+            name="test_release",
+            target_commitish=None,
+            draft=False,
+            prerelease=False,
+        )
+
+    @patch("pontos.github.api.api.GitHubAsyncRESTTags", spec=True)
+    async def test_create_tag(self, api_mock):
         terminal = MagicMock()
+        api_mock.return_value.create.return_value = MagicMock(sha="123")
         api_mock.return_value.create_tag_reference.return_value = True
-        api_mock.return_value.create_tag.return_value = True
 
         args = Namespace(
-            command="TAG",
-            func=create_tag,
             repo="foo/bar",
             tag="test_tag",
             name="test_release",
             message="test msg",
-            git_object="commit-sha",
+            git_object="commit",
             git_object_type=None,
             email="test@test.test",
             date=None,
             token="GITHUB_TOKEN",
         )
 
-        create_tag(terminal, args)
+        await create_tag(terminal, args)
+
+        api_mock.return_value.create.assert_awaited_once_with(
+            repo="foo/bar",
+            tag="test_tag",
+            message="test msg",
+            git_object="commit",
+            name="test_release",
+            email="test@test.test",
+            git_object_type=None,
+            date=None,
+        )
+        api_mock.return_value.create_tag_reference.assert_awaited_once_with(
+            repo="foo/bar", tag="test_tag", sha="123"
+        )
+
+    @patch("pontos.github.api.api.GitHubAsyncRESTBranches", spec=True)
+    @patch("pontos.github.api.api.GitHubAsyncRESTPullRequests", spec=True)
+    async def test_create_pull_request(
+        self,
+        pulls_api_mock,
+        branches_api_mock,
+    ):
+        terminal = MagicMock()
+        branches_api_mock.return_value.exists.return_value = [False, False]
+        pulls_api_mock.return_value.create.return_value = True
+
+        args = Namespace(
+            repo="foo/bar",
+            head="some-branch",
+            target="main",
+            title="foo",
+            body="foo bar",
+            token="GITHUB_TOKEN",
+        )
+
+        await create_pull_request(terminal, args)
+
+        branches_api_mock.return_value.exists.assert_has_awaits(
+            [
+                call(repo="foo/bar", branch="some-branch"),
+                call(repo="foo/bar", branch="main"),
+            ]
+        )
+
+        pulls_api_mock.return_value.create.assert_awaited_once_with(
+            repo="foo/bar",
+            head_branch="some-branch",
+            base_branch="main",
+            title="foo",
+            body="foo bar",
+        )
+
+    @patch("pontos.github.api.api.GitHubAsyncRESTBranches", spec=True)
+    @patch("pontos.github.api.api.GitHubAsyncRESTPullRequests", spec=True)
+    async def test_update_pull_request(
+        self,
+        pulls_api_mock,
+        branches_api_mock,
+    ):
+        terminal = MagicMock()
+        branches_api_mock.return_value.exists.return_value = True
+        pulls_api_mock.return_value.create.return_value = True
+
+        args = Namespace(
+            repo="foo/bar",
+            target="main",
+            pull_request=9,
+            title="foo",
+            body="foo bar",
+            token="GITHUB_TOKEN",
+        )
+
+        await update_pull_request(terminal, args)
+
+        branches_api_mock.return_value.exists.assert_awaited_once_with(
+            repo="foo/bar", branch="main"
+        )
+
+        pulls_api_mock.return_value.update.assert_awaited_once_with(
+            repo="foo/bar",
+            pull_request=9,
+            base_branch="main",
+            title="foo",
+            body="foo bar",
+        )
+
+    @patch("pontos.github.api.api.GitHubAsyncRESTPullRequests", spec=True)
+    @patch("pontos.github.api.api.GitHubAsyncRESTLabels", spec=True)
+    async def test_labels(
+        self,
+        labels_api_mock,
+        pulls_api_mock,
+    ):
+        terminal = MagicMock()
+        pulls_api_mock.return_value.exists.return_value = True
+        labels_api_mock.return_value.get_all.return_value = AsyncIteratorMock(
+            ["foo", "bar"]
+        )
+
+        args = Namespace(
+            repo="foo/bar",
+            issue=9,
+            labels=["baz"],
+            token="GITHUB_TOKEN",
+        )
+
+        await labels(terminal, args)
+
+        pulls_api_mock.return_value.exists.assert_awaited_once_with(
+            repo="foo/bar", pull_request=9
+        )
+
+        labels_api_mock.return_value.get_all.assert_called_once_with(
+            repo="foo/bar",
+            issue=9,
+        )
+
+        labels_api_mock.return_value.set_all.assert_awaited_once_with(
+            repo="foo/bar", issue=9, labels=["foo", "bar", "baz"]
+        )
+
+    @patch("pontos.github.api.api.GitHubAsyncRESTOrganizations", spec=True)
+    async def test_repos(self, api_mock):
+        terminal = MagicMock()
+        api_mock.return_value.exists.return_value = True
+        api_mock.return_value.get_repositories.return_value = AsyncIteratorMock(
+            ["repo1", "repo2"]
+        )
+
+        args = Namespace(
+            orga="foo",
+            repo="bar",
+            path=None,
+            type=RepositoryType.PUBLIC,
+            token="GITHUB_TOKEN",
+        )
+
+        await repos(terminal, args)
+
+        api_mock.return_value.exists.assert_awaited_once_with("foo")
+        api_mock.return_value.get_repositories.assert_called_once_with(
+            organization="foo", repository_type=RepositoryType.PUBLIC
+        )

--- a/tests/testing/test_testing.py
+++ b/tests/testing/test_testing.py
@@ -121,6 +121,14 @@ class TempFileTestCase(unittest.TestCase):
 
         self.assertFalse(test_file.exists())
 
+    def test_temp_file_without_content(self):
+        with temp_file(name="foo.bar") as test_file:
+            self.assertTrue(test_file.exists())
+            self.assertTrue(test_file.is_file())
+            self.assertEqual("", test_file.read_text(encoding="utf8"))
+
+        self.assertFalse(test_file.exists())
+
     def test_temp_file_exception(self):
         try:
             with temp_file("my content") as test_file:


### PR DESCRIPTION
**What**:

Refactor `pontos-github` CLI to use the async GitHub API.

Requires #536

**Why**:

The sync API will be removed in future.

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [x] Tests
- [x] Conventional commit message
