### PR TITLE
Fix: Allow list model fields contain dicts

### DIFF
--- a/pontos/models/__init__.py
+++ b/pontos/models/__init__.py
@@ -93,6 +93,11 @@ class Model:
             value = Model._get_value_from_model_field_cls(
                 model_field_cls, value
             )
+        elif get_origin(model_field_cls) == dict:
+            model_field_cls = dict
+            value = Model._get_value_from_model_field_cls(
+                model_field_cls, value
+            )
         elif get_origin(model_field_cls) == Union:
             possible_types = get_args(model_field_cls)
             current_type = type(value)

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -20,7 +20,7 @@
 import unittest
 from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 from pontos.models import Model, ModelAttribute, dotted_attributes
 
@@ -189,3 +189,11 @@ class DottedAttributesTestCase(unittest.TestCase):
         self.assertEqual(foo.bar, 123)
         self.assertEqual(foo.baz, [1, 2, 3])
         self.assertEqual(foo.hello, "World")
+
+    def test_list_with_dict(self):
+        @dataclass
+        class ExampleModel(Model):
+            foo: List[Dict]
+
+        model = ExampleModel.from_dict({"foo": [{"a": 1}, {"b": 2}, {"c": 3}]})
+        self.assertEqual(model.foo, [{"a": 1}, {"b": 2}, {"c": 3}])


### PR DESCRIPTION
**What**:

Allow list model fields contain dicts

**Why**:

Support the following field in a model.

```python
class MyModel(Model):
  myfield: List[Dict[str, str]]
```