### PR TITLE
Add: Allow to update JavaScript project versions

### DIFF
--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -25,7 +25,11 @@ from packaging.version import InvalidVersion, Version
 from pontos import version
 from pontos.git import Git, GitError
 from pontos.terminal import Terminal
-from pontos.version import CMakeVersionCommand, PythonVersionCommand
+from pontos.version import (
+    CMakeVersionCommand,
+    JavaScriptVersionCommand,
+    PythonVersionCommand,
+)
 from pontos.version.helper import VersionError
 
 DEFAULT_TIMEOUT = 1000
@@ -112,6 +116,7 @@ def get_current_version(terminal: Terminal) -> Optional[str]:
     available_cmds = [
         ("CMakeLists.txt", CMakeVersionCommand),
         ("pyproject.toml", PythonVersionCommand),
+        ("package.json", JavaScriptVersionCommand),
     ]
     for file_name, cmd in available_cmds:
         project_definition_path = Path.cwd() / file_name

--- a/pontos/release/prepare.py
+++ b/pontos/release/prepare.py
@@ -61,6 +61,9 @@ def prepare(
     else:
         release_version: str = args.release_version
 
+    if not release_version:
+        sys.exit(1)
+
     terminal.info(f"Preparing the release {release_version}")
 
     # guardian


### PR DESCRIPTION
**What**:

Add missing JavaScriptVersionCommand to get_current_version release helper function to allow updating the release version in JavaScript based projects.

**Why**:

Allow to update the release version in JavaScript based projects

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
