### PR TITLE
Fix: Remove warning in GitHub file_status command test

### DIFF
--- a/tests/github/test_cmds.py
+++ b/tests/github/test_cmds.py
@@ -51,9 +51,9 @@ class TestCmds(IsolatedAsyncioTestCase):
             ],
         }
 
-        with temp_file(name="some.file") as test_file:
-            output = test_file.open("w", encoding="utf-8")
-
+        with temp_file(name="some.file") as test_file, test_file.open(
+            "w", encoding="utf8"
+        ) as output:
             args = Namespace(
                 repo="foo/bar",
                 pull_request=8,


### PR DESCRIPTION
**What**:

Ensure that the opened test file is always closed in the test for the GitHub file_status command function.

**Why**:

Get rid of a warning raised during test runs.

**How**:

<!--
  How did you verify the changes in this PR?
  If this PR contains tests this section can be considered done.
  Otherwise please write down the steps on how you did test your changes and
  verified that the changes are working as expected.

  See https://www.ministryoftesting.com/dojo/lessons/community-stories-to-shift-left-start-right
  for some background.
 -->

**Checklist**:

<!-- add "N/A" to the end of each line not applicable to your changes -->

<!-- to check an item, place an "x" in the box like so: "- [x] Tests" -->

- [ ] Tests
- [ ] Conventional commit message
- [ ] Documentation
