### PR TITLE
Fix: Fix pontos-version show command

### DIFF
--- a/pontos/version/__init__.py
+++ b/pontos/version/__init__.py
@@ -69,7 +69,7 @@ def main() -> NoReturn:
             else:
                 print("Version is already up-to-date.")
         elif args.command == "show":
-            print(command.current_version())
+            print(command.get_current_version())
         elif args.command == "verify":
             command.verify_version(args.version)
     except VersionError as e:


### PR DESCRIPTION
**What**:

Fix pontos-version show command

Use correct method of VersionCommand instance.

**Why**:

`pontos-version show` was broken.