### PR TITLE
Fix: Add undocumented "pending" workflow run status

### DIFF
--- a/pontos/github/models/workflow.py
+++ b/pontos/github/models/workflow.py
@@ -135,6 +135,7 @@ class WorkflowRunStatus(Enum):
     SUCCESS = "success"
     TIMED_OUT = "timed_out"
     WAITING = "waiting"
+    PENDING = "pending"  # not listed in GitHub docs
 
 
 @dataclass


### PR DESCRIPTION
**What**:

Add undocumented "pending" workflow run status

**Why**:

The "pending" workflow run status is not mentioned in GitHub's REST API docs but actually exists https://github.com/greenbone/feed-deployment-pipeline/actions/runs/3938129442/jobs/6737751768