### PR TITLE
Explicitly use token for codecov

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -51,3 +51,4 @@ jobs:
         uses: greenbone/actions/coverage-python@v2
         with:
           version: "3.10"
+          token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## What

Explicitly use token for codecov

## Why

It seems that codecov.io uses token nowadays.

## References

<!-- Add links to issue tickets, etc. -->