### PR TITLE
Change: Improve changelog builder

### DIFF
--- a/tests/changelog/test_conventional_commits.py
+++ b/tests/changelog/test_conventional_commits.py
@@ -22,12 +22,11 @@ from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
-from pontos import changelog
 from pontos.changelog.conventional_commits import (
+    ChangelogBuilder,
     ChangelogBuilderError,
     parse_args,
 )
-from pontos.git import Git
 from pontos.git.git import TagSort
 from pontos.testing import temp_directory
 
@@ -37,9 +36,9 @@ class StdOutput:
     stdout: bytes
 
 
-class ConventionalCommitsTestCase(unittest.TestCase):
-    @patch("pontos.changelog.conventional_commits.Git", spec=Git)
-    def test_changelog_builder(self, git_mock):
+class ChangelogBuilderTestCase(unittest.TestCase):
+    @patch("pontos.changelog.conventional_commits.Git", autospec=True)
+    def test_changelog_builder(self, git_mock: MagicMock):
         terminal = MagicMock()
 
         today = datetime.today().strftime("%Y-%m-%d")
@@ -63,7 +62,7 @@ class ConventionalCommitsTestCase(unittest.TestCase):
             "d0c4d0c Doc: bar baz documenting",
         ]
 
-        changelog_builder = changelog.ChangelogBuilder(
+        changelog_builder = ChangelogBuilder(
             terminal=terminal,
             current_version="0.0.1",
             next_version=release_version,
@@ -112,8 +111,8 @@ All notable changes to this project will be documented in this file.
             "v0.0.1..HEAD", oneline=True
         )
 
-    @patch("pontos.changelog.conventional_commits.Git")
-    def test_changelog_builder_no_commits(self, git_mock):
+    @patch("pontos.changelog.conventional_commits.Git", autospec=True)
+    def test_changelog_builder_no_commits(self, git_mock: MagicMock):
         terminal = MagicMock()
 
         own_path = Path(__file__).absolute().parent
@@ -124,7 +123,7 @@ All notable changes to this project will be documented in this file.
         git_mock.return_value.list_tags.return_value = ["v0.0.1"]
         git_mock.return_value.log.return_value = []
 
-        changelog_builder = changelog.ChangelogBuilder(
+        changelog_builder = ChangelogBuilder(
             terminal=terminal,
             current_version="0.0.1",
             next_version=release_version,
@@ -142,8 +141,8 @@ All notable changes to this project will be documented in this file.
             "v0.0.1..HEAD", oneline=True
         )
 
-    @patch("pontos.changelog.conventional_commits.Git")
-    def test_changelog_builder_no_tag(self, git_mock):
+    @patch("pontos.changelog.conventional_commits.Git", autospec=True)
+    def test_changelog_builder_no_tag(self, git_mock: MagicMock):
         terminal = MagicMock()
 
         today = datetime.today().strftime("%Y-%m-%d")
@@ -166,7 +165,7 @@ All notable changes to this project will be documented in this file.
             "d0c4d0c Doc: bar baz documenting",
         ]
 
-        changelog_builder = changelog.ChangelogBuilder(
+        changelog_builder = ChangelogBuilder(
             terminal=terminal,
             current_version="0.0.1",
             next_version=release_version,
@@ -212,8 +211,10 @@ All notable changes to this project will be documented in this file.
         git_mock.return_value.list_tags.assert_called_with(sort=TagSort.VERSION)
         git_mock.return_value.log.assert_called_with(oneline=True)
 
-    @patch("pontos.changelog.conventional_commits.Git")
-    def test_changelog_builder_no_conventional_commits(self, git_mock):
+    @patch("pontos.changelog.conventional_commits.Git", autospec=True)
+    def test_changelog_builder_no_conventional_commits(
+        self, git_mock: MagicMock
+    ):
         terminal = MagicMock()
 
         own_path = Path(__file__).absolute().parent
@@ -225,7 +226,7 @@ All notable changes to this project will be documented in this file.
             "1234567 foo bar",
             "8abcdef bar baz",
         ]
-        changelog_builder = changelog.ChangelogBuilder(
+        changelog_builder = ChangelogBuilder(
             terminal=terminal,
             current_version="0.0.1",
             next_version=release_version,

--- a/tests/changelog/test_conventional_commits.py
+++ b/tests/changelog/test_conventional_commits.py
@@ -240,6 +240,87 @@ All notable changes to this project will be documented in this file.
 
             self.assertIsNone(output_file)
 
+    def test_changelog_builder_config_file_not_exists(self):
+        terminal = MagicMock()
+
+        with temp_directory() as temp_dir, self.assertRaisesRegex(
+            ChangelogBuilderError,
+            r"Changelog Config file '.*\.toml' does not exist\.",
+        ):
+            ChangelogBuilder(
+                terminal=terminal,
+                current_version="0.0.1",
+                next_version="1.0.0",
+                space="foo",
+                project="bar",
+                config=temp_dir / "changelog.toml",
+            )
+
+    @patch("pontos.changelog.conventional_commits.Git", autospec=True)
+    def test_changelog_builder_with_default_changelog_config(
+        self, git_mock: MagicMock
+    ):
+        terminal = MagicMock()
+
+        today = datetime.today().strftime("%Y-%m-%d")
+
+        release_version = "0.0.2"
+        output = f"v{release_version}.md"
+
+        git_mock.return_value.list_tags.return_value = ["v0.0.1"]
+        git_mock.return_value.log.return_value = [
+            "1234567 Add: foo bar",
+            "8abcdef Add: bar baz",
+            "8abcd3f Add bar baz",
+            "8abcd3d Adding bar baz",
+            "1337abc Change: bar to baz",
+            "42a42a4 Remove: foo bar again",
+            "fedcba8 Test: bar baz testing",
+            "dead901 Refactor: bar baz ref",
+            "fedcba8 Fix: bar baz fixing",
+            "d0c4d0c Doc: bar baz documenting",
+        ]
+
+        changelog_builder = ChangelogBuilder(
+            terminal=terminal,
+            current_version="0.0.1",
+            next_version=release_version,
+            space="foo",
+            project="bar",
+            config=None,
+        )
+        expected_output = f"""# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.0.2] - {today}
+
+## Added
+* foo bar [1234567](https://github.com/foo/bar/commit/1234567)
+* bar baz [8abcdef](https://github.com/foo/bar/commit/8abcdef)
+
+## Removed
+* foo bar again [42a42a4](https://github.com/foo/bar/commit/42a42a4)
+
+## Changed
+* bar to baz [1337abc](https://github.com/foo/bar/commit/1337abc)
+
+## Bug Fixes
+* bar baz fixing [fedcba8](https://github.com/foo/bar/commit/fedcba8)
+
+[0.0.2]: https://github.com/foo/bar/compare/0.0.1...0.0.2"""
+
+        with temp_directory(change_into=True):
+            output_file = changelog_builder.create_changelog_file(output)
+            self.assertEqual(
+                output_file.read_text(encoding="utf-8"), expected_output
+            )
+
+        git_mock.return_value.list_tags.assert_called_with(sort=TagSort.VERSION)
+        git_mock.return_value.log.assert_called_with(
+            "v0.0.1..HEAD", oneline=True
+        )
+
 
 class ParseArgsTestCase(unittest.TestCase):
     def test_parse_args(self):


### PR DESCRIPTION
## What

https://github.com/greenbone/greenbone-feed-sync/actions/runs/4017372908/jobs/6901645653 pointed out that the error case for not having a changelog toml config file is not handled very well. Improve the situation by providing a default config and raising a specific error if the config file does not exist.

## Why

Handle not having a changelog config file more carefully.

## References

https://github.com/greenbone/greenbone-feed-sync/actions/runs/4017372908/jobs/6901645653

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


