### PR TITLE
Fix: Ensure loading version module from file

### DIFF
--- a/pontos/version/python.py
+++ b/pontos/version/python.py
@@ -151,6 +151,11 @@ class PythonVersionCommand(VersionCommand):
             )
             version_module = importlib.util.module_from_spec(spec)
             spec.loader.exec_module(version_module)
+        except FileNotFoundError:
+            raise VersionError(
+                f"Could not load version from '{module_name}'. "
+                f"{self.version_file_path} not found."
+            ) from None
         except ModuleNotFoundError:
             raise VersionError(
                 f"Could not load version from '{module_name}'. Import failed."

--- a/pontos/version/python.py
+++ b/pontos/version/python.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-import importlib
+import importlib.util
 from pathlib import Path
 
 import tomlkit
@@ -146,7 +146,11 @@ class PythonVersionCommand(VersionCommand):
         ]
         module_name = ".".join(module_parts)
         try:
-            version_module = importlib.import_module(module_name)
+            spec = importlib.util.spec_from_file_location(
+                module_name, self.version_file_path
+            )
+            version_module = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(version_module)
         except ModuleNotFoundError:
             raise VersionError(
                 f"Could not load version from '{module_name}'. Import failed."

--- a/tests/release/test_helper.py
+++ b/tests/release/test_helper.py
@@ -131,6 +131,7 @@ class TestHelperFunctions(unittest.TestCase):
             init_file.touch()
 
             version_file = module_path / "__version__.py"
+            version_file.write_text('__version__ = "1.2.3"')
 
             toml = tmp_dir / "pyproject.toml"
             toml.write_text(

--- a/tests/version/test_python_version.py
+++ b/tests/version/test_python_version.py
@@ -90,7 +90,7 @@ class GetCurrentPythonVersionCommandTestCase(unittest.TestCase):
         fake_path.exists.return_value = True
 
         with self.assertRaisesRegex(
-            VersionError, "Could not load version from 'foo'. Import failed."
+            VersionError, r"Could not load version from 'foo'\. .* not found."
         ):
             cmd = PythonVersionCommand(project_file_path=fake_path)
             cmd.get_current_version()
@@ -107,7 +107,7 @@ class GetCurrentPythonVersionCommandTestCase(unittest.TestCase):
         fake_path.exists.return_value = True
 
         content = "__version__ = '1.2.3'"
-        with temp_python_module(content, name="foo"):
+        with temp_python_module(content, name="foo", change_into=True):
             cmd = PythonVersionCommand(project_file_path=fake_path)
             version = cmd.get_current_version()
 


### PR DESCRIPTION
## What

Ensure loading version module from file

## Why

Allow pontos to release itself even when another pontos version is installed. With the old implementation it always would load the version module from the installed pontos and not from the to be released code.