### PR TITLE
Add: Add async api to get pull request information

### DIFF
--- a/pontos/github/api/pull_requests.py
+++ b/pontos/github/api/pull_requests.py
@@ -39,6 +39,27 @@ class GitHubAsyncRESTPullRequests(GitHubAsyncREST):
         response = await self._client.get(api)
         return response.is_success
 
+    async def get(self, repo: str, pull_request: int) -> PullRequest:
+        """
+        Get information about a pull request
+
+        https://docs.github.com/en/rest/pulls/pulls#get-a-pull-request
+
+        Args:
+            repo: GitHub repository (owner/name) to use
+            pull_request: Pull request number
+
+        Returns:
+            Information about the pull request
+
+        Raises:
+            httpx.HTTPStatusError if the request was invalid
+        """
+        api = f"/repos/{repo}/pulls/{pull_request}"
+        response = await self._client.get(api)
+        response.raise_for_status()
+        return PullRequest.from_dict(response.json())
+
     async def commits(
         self, repo: str, pull_request: int
     ) -> AsyncIterator[PullRequestCommit]:
@@ -54,7 +75,7 @@ class GitHubAsyncRESTPullRequests(GitHubAsyncREST):
             pull_request: Pull request number
 
         Returns:
-            Information about the commits in the pull request as a dict
+            Information about the commits in the pull request
         """
         # per default github only shows 35 commits and at max it is only
         # possible to receive 100

--- a/pontos/github/models/pull_request.py
+++ b/pontos/github/models/pull_request.py
@@ -26,6 +26,7 @@ from pontos.github.models.organization import Repository
 __all__ = (
     "AuthorAssociation",
     "FileStatus",
+    "MergeMethod",
     "MilestoneState",
     "PullRequest",
     "PullRequestCommit",
@@ -180,6 +181,20 @@ class AuthorAssociation(Enum):
     OWNER = "OWNER"
 
 
+class MergeMethod(Enum):
+    MERGE = "merge"
+    SQUASH = "squash"
+    REBASE = "rebase"
+
+
+@dataclass
+class AutoMerge(GitHubModel):
+    enabled_by: User
+    merge_method: MergeMethod
+    commit_title: str
+    commit_message: str
+
+
 @dataclass
 class PullRequest(GitHubModel):
     additions: int
@@ -216,7 +231,7 @@ class PullRequest(GitHubModel):
     active_lock_reason: Optional[str] = None
     assignee: Optional[User] = None
     assignees: List[User] = field(default_factory=list)
-    auto_merge: Optional[bool] = None
+    auto_merge: Optional[AutoMerge] = None
     body: Optional[str] = None
     closed_at: Optional[datetime] = None
     draft: Optional[bool] = None

--- a/tests/github/api/test_pull_requests.py
+++ b/tests/github/api/test_pull_requests.py
@@ -1049,6 +1049,35 @@ class GitHubAsyncRESTPullRequestsTestCase(GitHubAsyncRESTTestCase):
             params={"per_page": "100"},
         )
 
+    async def test_get(self):
+        response = create_response()
+        response.json.return_value = PULL_REQUEST_JSON
+        self.client.get.return_value = response
+
+        pr = await self.api.get(
+            "foo/bar",
+            1,
+        )
+
+        self.client.get.assert_awaited_once_with(
+            "/repos/foo/bar/pulls/1",
+        )
+
+        self.assertEqual(pr.id, 1)
+
+    async def test_get_failure(self):
+        response = create_response()
+        self.client.get.side_effect = HTTPStatusError(
+            "404", request=MagicMock(), response=response
+        )
+
+        with self.assertRaises(HTTPStatusError):
+            await self.api.get("foo/bar", 123)
+
+        self.client.get.assert_awaited_once_with(
+            "/repos/foo/bar/pulls/123",
+        )
+
 
 class GitHubPullRequestsTestCase(unittest.TestCase):
     @patch("pontos.github.api.api.httpx.get")


### PR DESCRIPTION
## What

Add async api to get pull request information

## Why

Add missing API to get information about a single pull request.

## References

Required for DEVOPS-364

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


