### PR TITLE
Change: Improve error message if model can't be created

### DIFF
--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from typing import Dict, List, Optional, Union
 
-from pontos.models import Model, ModelAttribute, dotted_attributes
+from pontos.models import Model, ModelAttribute, ModelError, dotted_attributes
 
 
 class ModelTestCase(unittest.TestCase):
@@ -197,3 +197,15 @@ class DottedAttributesTestCase(unittest.TestCase):
 
         model = ExampleModel.from_dict({"foo": [{"a": 1}, {"b": 2}, {"c": 3}]})
         self.assertEqual(model.foo, [{"a": 1}, {"b": 2}, {"c": 3}])
+
+    def test_model_error(self):
+        @dataclass
+        class ExampleModel(Model):
+            foo: Optional[str] = None
+
+        with self.assertRaisesRegex(
+            ModelError,
+            "Error while creating ExampleModel. Could not set value for 'foo' "
+            "from '{'bar': 'baz'}'.",
+        ):
+            ExampleModel.from_dict({"foo": {"bar": "baz"}})


### PR DESCRIPTION
## What

Improve error message if model can't be created

## Why

Sometimes the models are incomplete or the schema description at the GitHub REST API docs are wrong, in this case we need error information about which property can't be set from which value. This allows for easier fixing of the model.

## References

<!-- Add links to issue tickets, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


