### PR TITLE
Add: Allow to pass a refspec to Git.fetch

### DIFF
--- a/pontos/git/git.py
+++ b/pontos/git/git.py
@@ -371,17 +371,31 @@ class Git:
 
         exec_git(*args, cwd=self._cwd)
 
-    def fetch(self, remote: Optional[str] = None) -> None:
+    def fetch(
+        self,
+        remote: Optional[str] = None,
+        refspec: Optional[str] = None,
+        *,
+        verbose: bool = False,
+    ) -> None:
         """
         Fetch from changes from remote
 
         Args:
             remote: Remote to fetch changes from
+            refspec: Specifies which refs to fetch and which local refs to
+                update.
+            verbose: Print verbose output.
         """
         args = ["fetch"]
 
         if remote:
             args.append(remote)
+        if refspec:
+            args.append(refspec)
+
+        if verbose:
+            args.append("-v")
 
         exec_git(*args, cwd=self._cwd)
 

--- a/tests/git/test_git.py
+++ b/tests/git/test_git.py
@@ -381,6 +381,22 @@ class GitTestCase(unittest.TestCase):
         exec_git_mock.assert_called_once_with("fetch", "foo", cwd=None)
 
     @patch("pontos.git.git.exec_git")
+    def test_fetch_with_remote_and_refspec(self, exec_git_mock):
+        git = Git()
+        git.fetch("foo", "my-branch")
+
+        exec_git_mock.assert_called_once_with(
+            "fetch", "foo", "my-branch", cwd=None
+        )
+
+    @patch("pontos.git.git.exec_git")
+    def test_fetch_with_verbose(self, exec_git_mock):
+        git = Git()
+        git.fetch(verbose=True)
+
+        exec_git_mock.assert_called_once_with("fetch", "-v", cwd=None)
+
+    @patch("pontos.git.git.exec_git")
     def test_add_remote(self, exec_git_mock):
         git = Git()
         git.add_remote("foo", "https://foo.bar/foo.git")


### PR DESCRIPTION


## What

Allow to pass a refspec to Git.fetch

## Why

When fetching from git remotes allow to specify refs that should be fetched explicitly. This will be used for the backport action.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


