### PR TITLE
Change: Order of languages, to prioritize GoLang over Python

### DIFF
--- a/pontos/version/__init__.py
+++ b/pontos/version/__init__.py
@@ -29,9 +29,9 @@ from .python import PythonVersionCommand
 
 COMMANDS = (
     CMakeVersionCommand,
-    PythonVersionCommand,
-    JavaScriptVersionCommand,
     GoVersionCommand,
+    JavaScriptVersionCommand,
+    PythonVersionCommand,
 )
 
 


### PR DESCRIPTION
## What

* in pontos-version:
  * Order of languages, to prioritize GoLang over Python

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

* if we have a `pyproject.toml` in a go project, `pontos-version` will not look up for the go version, but searches for the pyproject.toml

<!-- Describe why are these changes necessary? -->

## References

DEVOPS-541

<!-- Add links to issue tickets, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


