### PR TITLE
Fix: Don't fail with error when files not found

### DIFF
--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -17,6 +17,7 @@
 
 import datetime
 import sys
+from pathlib import Path
 from typing import Optional, Tuple
 
 from packaging.version import InvalidVersion, Version
@@ -28,6 +29,9 @@ from pontos.version.helper import VersionError
 
 DEFAULT_TIMEOUT = 1000
 DEFAULT_CHUNK_SIZE = 4096
+
+DEFAULT_PYTHON_VERSION_FILE = "*__version__.py"
+DEFAULT_GO_VERSION_FILE = Path("version.go")
 
 
 def commit_files(
@@ -51,11 +55,10 @@ def commit_files(
     git.add(filename)
 
     try:
-        git.add("*__version__.py")
-    except GitError:
-        pass
-    try:
-        git.add("version.go")
+        if list(Path.cwd().glob(DEFAULT_PYTHON_VERSION_FILE)):
+            git.add(DEFAULT_PYTHON_VERSION_FILE)
+        if DEFAULT_GO_VERSION_FILE.exists():
+            git.add(DEFAULT_GO_VERSION_FILE)
     except GitError:
         pass
 

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -244,8 +244,6 @@ class ReleaseTestCase(unittest.TestCase):
         git_mock.return_value.add.assert_has_calls(
             [
                 call("MyProject.conf"),
-                call("*__version__.py"),
-                call("version.go"),
                 call("CHANGELOG.md"),
             ]
         )


### PR DESCRIPTION
## What

* Don't fail with `subprocess.CalledProcessError` when `git add` fails

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

* don't exit programm

<!-- Describe why are these changes necessary? -->

## References

<!-- Add links to issue tickets, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


