### PR TITLE
Fix: Releasing GoLang projects

### DIFF
--- a/pontos/git/git.py
+++ b/pontos/git/git.py
@@ -60,10 +60,13 @@ def exec_git(
     try:
         cmd_args = ["git"]
         cmd_args.extend(args)
-        output = subprocess.check_output(
-            cmd_args, cwd=fspath(cwd) if cwd else None
+        output = subprocess.run(
+            cmd_args,
+            cwd=fspath(cwd) if cwd else None,
+            check=True,
+            stdout=subprocess.PIPE,
         )
-        return output.decode()
+        return output.stdout.decode()
     except subprocess.CalledProcessError as e:
         if ignore_errors:
             return ""
@@ -329,7 +332,7 @@ class Git:
             verify: Set to False to skip git hooks
             gpg_signing_key: GPG Key ID to use to sign the commit
         """
-        args = ["commit"]
+        args = ["commit", "--verbose"]
         if verify is False:
             args.append("--no-verify")
         if gpg_signing_key:

--- a/pontos/git/git.py
+++ b/pontos/git/git.py
@@ -332,7 +332,7 @@ class Git:
             verify: Set to False to skip git hooks
             gpg_signing_key: GPG Key ID to use to sign the commit
         """
-        args = ["commit", "--verbose"]
+        args = ["commit"]
         if verify is False:
             args.append("--no-verify")
         if gpg_signing_key:

--- a/pontos/git/git.py
+++ b/pontos/git/git.py
@@ -65,8 +65,10 @@ def exec_git(
             cwd=fspath(cwd) if cwd else None,
             check=True,
             stdout=subprocess.PIPE,
+            encoding="utf8",
+            errors="replace",
         )
-        return output.stdout.decode()
+        return output.stdout
     except subprocess.CalledProcessError as e:
         if ignore_errors:
             return ""

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -230,7 +230,7 @@ def update_version(
         command = cmd()
         project_file = command.project_file_found()
         if project_file:
-            # we use version.go as version file, but go.mod as indicator 
+            # we use version.go as version file, but go.mod as indicator
             # for a go project to change the version, we hack in the correct
             # file to adjust the version in and commit
             if isinstance(command, GoVersionCommand):

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -25,6 +25,7 @@ from packaging.version import InvalidVersion, Version
 from pontos.git import Git, GitError
 from pontos.terminal import Terminal
 from pontos.version import COMMANDS
+from pontos.version.go import GoVersionCommand
 from pontos.version.helper import VersionError
 
 DEFAULT_TIMEOUT = 1000
@@ -229,6 +230,8 @@ def update_version(
         command = cmd()
         project_file = command.project_file_found()
         if project_file:
+            if isinstance(command, GoVersionCommand):
+                project_file = Path.cwd() / "version.go"
             break
 
     if not project_file:

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -234,7 +234,7 @@ def update_version(
             # for a go project to change the version, we hack in the correct
             # file to adjust the version in and commit
             if isinstance(command, GoVersionCommand):
-                project_file = Path.cwd() / "version.go"
+                project_file = command.version_file_path
             break
 
     if not project_file:

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -230,9 +230,9 @@ def update_version(
         command = cmd()
         project_file = command.project_file_found()
         if project_file:
-            # we use version.go as version file, but go.mod as indicator for a go project
-            # to change the version, we hack in the correct file to adjust the version in
-            # and commit
+            # we use version.go as version file, but go.mod as indicator 
+            # for a go project to change the version, we hack in the correct
+            # file to adjust the version in and commit
             if isinstance(command, GoVersionCommand):
                 project_file = Path.cwd() / "version.go"
             break

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -230,6 +230,9 @@ def update_version(
         command = cmd()
         project_file = command.project_file_found()
         if project_file:
+            # we use version.go as version file, but go.mod as indicator for a go project
+            # to change the version, we hack in the correct file to adjust the version in
+            # and commit
             if isinstance(command, GoVersionCommand):
                 project_file = Path.cwd() / "version.go"
             break

--- a/tests/release/test_helper.py
+++ b/tests/release/test_helper.py
@@ -112,7 +112,11 @@ class TestHelperFunctions(unittest.TestCase):
     def test_update_version_not_found(self):
         terminal = MagicMock()
 
-        with temp_directory(change_into=True):
+        with temp_directory(change_into=True), patch.object(
+            Git,
+            "list_tags",
+            MagicMock(return_value=["21.4.4"]),
+        ):
             executed, filename = update_version(
                 terminal, to="21.4.4", develop=True
             )
@@ -123,7 +127,13 @@ class TestHelperFunctions(unittest.TestCase):
     def test_update_version_no_version_file(self):
         terminal = MagicMock()
 
-        with temp_directory(change_into=True, add_to_sys_path=True) as tmp_dir:
+        with temp_directory(
+            change_into=True, add_to_sys_path=True
+        ) as tmp_dir, patch.object(
+            Git,
+            "list_tags",
+            MagicMock(return_value=["1.2.3"]),
+        ):
             module_path = tmp_dir / "testrepo"
             module_path.mkdir(parents=True, exist_ok=True)
 

--- a/tests/version/test_go_version.py
+++ b/tests/version/test_go_version.py
@@ -145,6 +145,7 @@ class UpdateGoVersionCommandTestCase(unittest.TestCase):
                 self.assertIn(version, content)
                 self.assertEqual(updated_version_obj.previous, "21.0.1")
                 self.assertEqual(updated_version_obj.new, version)
+                version_file_path.unlink()
 
     def test_update_version(self):
         with temp_file(
@@ -161,6 +162,7 @@ class UpdateGoVersionCommandTestCase(unittest.TestCase):
 
             content = version_file_path.read_text(encoding="utf-8")
             self.assertIn(version, content)
+            version_file_path.unlink()
 
     def test_create_file_update_version(self):
         with temp_file(
@@ -179,6 +181,7 @@ class UpdateGoVersionCommandTestCase(unittest.TestCase):
                 version_file_path = Path(VERSION_FILE_PATH)
                 content = version_file_path.read_text(encoding="utf-8")
                 self.assertIn(version, content)
+                version_file_path.unlink()
 
 
 class ProjectFileGoVersionCommandTestCase(unittest.TestCase):


### PR DESCRIPTION
## What

* [Change: Use subprocess.run instead of check_output](https://github.com/greenbone/pontos/pull/608/commits/534a5d797db225e3cc0fb8d4c361eb6b6c1906d3)
* [Fix: Releasing GoLang projects](https://github.com/greenbone/pontos/pull/608/commits/22806beb331fc3f619e32ec5a7b119a8cd0722f1)

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

* Hack to use the right "version file" for go projects
* A Version file called `version.go` in the root dir of the (git) project is required. It is also checked for the last version (with `pontos-version`).

<!-- Describe why are these changes necessary? -->

## References

DEVOPS-541
DEVOPS-553

<!-- Add links to issue tickets, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


