### PR TITLE
Change: Merge get_next_bugfix_version and get_next_patch_version

### DIFF
--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -31,7 +31,7 @@ from pontos.release.prepare import DEFAULT_CHANGELOG_FILE, RELEASE_TEXT_FILE
 from pontos.terminal import Terminal
 from pontos.version.commands import get_current_version, update_version
 from pontos.version.errors import VersionError
-from pontos.version.helper import get_next_bugfix_version
+from pontos.version.helper import get_next_patch_version
 from pontos.version.version import VersionUpdate
 
 from .helper import find_signing_key, get_git_repository_name
@@ -155,7 +155,7 @@ class ReleaseCommand:
         next_version = (
             next_version
             if next_version is not None
-            else get_next_bugfix_version(release_version)
+            else get_next_patch_version(release_version)
         )
 
         self.terminal.info("Pushing changes")

--- a/pontos/version/helper.py
+++ b/pontos/version/helper.py
@@ -113,40 +113,34 @@ def calculate_calendar_version(current_version_str: str) -> str:
         )
 
 
-def get_next_patch_version(current_version_str: str) -> str:
-    """find the correct next patch version by checking latest version"""
-
-    current_version = Version(current_version_str)
-
-    if current_version.dev is not None:
-        release_version = Version(
-            f"{current_version.major}."
-            f"{current_version.minor}."
-            f"{current_version.micro}"
-        )
-    else:
-        release_version = Version(
-            f"{current_version.major}."
-            f"{current_version.minor}."
-            f"{current_version.micro + 1}"
-        )
-
-    return str(release_version)
-
-
-def get_next_bugfix_version(release_version: str) -> str:
+def get_next_patch_version(release_version: str) -> str:
     """
-    Get the next bugfix Version from a valid version
+    Get the next patch version from a valid version
 
-    For example passing "1.2.3" will return "1.2.4".
+    Examples:
+        "1.2.3" will return "1.2.4"
+        "1.2.3.dev1" will return "1.2.3"
+
+    Raises:
+        VersionError if release_version is invalid.
     """
+
     try:
-        release_version_obj = Version(release_version)
-        next_version_obj = Version(
-            f"{release_version_obj.major}."
-            f"{release_version_obj.minor}."
-            f"{release_version_obj.micro + 1}"
-        )
-        return str(next_version_obj)
+        current_version = Version(release_version)
+
+        if current_version.dev is not None:
+            next_version = Version(
+                f"{current_version.major}."
+                f"{current_version.minor}."
+                f"{current_version.micro}"
+            )
+        else:
+            next_version = Version(
+                f"{current_version.major}."
+                f"{current_version.minor}."
+                f"{current_version.micro + 1}"
+            )
+
+        return str(next_version)
     except InvalidVersion as e:
         raise VersionError(e) from None

--- a/tests/version/test_helper.py
+++ b/tests/version/test_helper.py
@@ -21,7 +21,6 @@ from datetime import datetime
 from pontos.version.errors import VersionError
 from pontos.version.helper import (
     calculate_calendar_version,
-    get_next_bugfix_version,
     get_next_patch_version,
     is_version_pep440_compliant,
     safe_version,
@@ -158,27 +157,6 @@ class GetNextPatchVersionTestCase(unittest.TestCase):
 
             self.assertEqual(release_version, assert_version)
 
-
-class GetNextBugfixVersionTestCase(unittest.TestCase):
-    def test_get_next_bugfix_version(self):
-        current_versions = [
-            "20.4.1",
-            "20.4.1",
-            "19.1.2",
-            "1.1.1",
-            "20.6.1",
-        ]
-        assert_versions = [
-            "20.4.2",
-            "20.4.2",
-            "19.1.3",
-            "1.1.2",
-            "20.6.2",
-        ]
-
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
-            next_version = get_next_bugfix_version(current_version)
-
-            self.assertEqual(assert_version, next_version)
+    def test_invalid_version(self):
+        with self.assertRaisesRegex(VersionError, "Invalid version: 'abc'"):
+            get_next_patch_version("abc")


### PR DESCRIPTION
## What

Merge get_next_bugfix_version and get_next_patch_version
## Why

Both functions are very similar and are now merged into one single function.

## References

DEVOPS-551

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


