### PR TITLE
GitHub API changes

### DIFF
--- a/pontos/github/api/client.py
+++ b/pontos/github/api/client.py
@@ -71,6 +71,7 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
         *,
         accept: Optional[str] = DEFAULT_ACCEPT_HEADER,
         content_type: Optional[str] = None,
+        content_length: Optional[int] = None,
     ) -> Headers:
         """
         Get the default request headers
@@ -83,6 +84,8 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
             headers["Authorization"] = f"token {self.token}"
         if content_type:
             headers["Content-Type"] = content_type
+        if content_length:
+            headers["Content-Length"] = str(content_length)
 
         return headers
 
@@ -181,6 +184,7 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
         params: Optional[Params] = None,
         content: Optional[str] = None,
         content_type: Optional[str] = None,
+        content_length: Optional[int] = None,
     ) -> httpx.Response:
         """
         Post request to a GitHub API
@@ -190,7 +194,9 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
             params: Optional params to use for the post request
             data: Optional data to include in the post request
         """
-        headers = self._request_headers(content_type=content_type)
+        headers = self._request_headers(
+            content_type=content_type, content_length=content_length
+        )
         url = self._request_url(api)
         return await self._client.post(
             url, params=params, headers=headers, json=data, content=content

--- a/pontos/github/api/client.py
+++ b/pontos/github/api/client.py
@@ -37,6 +37,7 @@ Params = Dict[str, str]
 # supported GitHub API version
 # https://docs.github.com/en/rest/overview/api-versions
 GITHUB_API_VERSION = "2022-11-28"
+DEFAULT_ACCEPT_HEADER = "application/vnd.github+json"
 
 
 class GitHubAsyncRESTClient(AbstractAsyncContextManager):
@@ -65,13 +66,16 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
         self._client = httpx.AsyncClient(timeout=timeout, http2=True)
 
     def _request_headers(
-        self, *, content_type: Optional[str] = None
+        self,
+        *,
+        accept: Optional[str] = DEFAULT_ACCEPT_HEADER,
+        content_type: Optional[str] = None,
     ) -> Headers:
         """
         Get the default request headers
         """
         headers = {
-            "Accept": "application/vnd.github+json",
+            "Accept": accept,
             "X-GitHub-Api-Version": GITHUB_API_VERSION,
         }
         if self.token:

--- a/pontos/github/api/client.py
+++ b/pontos/github/api/client.py
@@ -38,6 +38,7 @@ Params = Dict[str, str]
 # https://docs.github.com/en/rest/overview/api-versions
 GITHUB_API_VERSION = "2022-11-28"
 DEFAULT_ACCEPT_HEADER = "application/vnd.github+json"
+ACCEPT_HEADER_OCTET_STREAM = "application/octet-stream"
 
 
 class GitHubAsyncRESTClient(AbstractAsyncContextManager):
@@ -248,7 +249,7 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
         Args:
             api: API path to use for the post request
         """
-        headers = self._request_headers()
+        headers = self._request_headers(accept=ACCEPT_HEADER_OCTET_STREAM)
         url = self._request_url(api)
         return self._client.stream(
             "GET", url, headers=headers, follow_redirects=True

--- a/pontos/github/api/release.py
+++ b/pontos/github/api/release.py
@@ -292,6 +292,7 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
                 asset_url,
                 params={"name": file_path.name},
                 content_type=content_type,
+                content_length=file_path.stat().st_size,
                 content=upload(file_path),
             )
             return response, file_path

--- a/pontos/github/api/release.py
+++ b/pontos/github/api/release.py
@@ -133,6 +133,18 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
 
         Raises:
             HTTPStatusError if the request was invalid
+
+        Example:
+            .. code-block:: python
+
+            async with api.download_release_tarball(
+                "foo/bar", "v1.0.0"
+            ) as download:
+                file_path = Path("a.file.tar.gz")
+                with file_path.open("wb") as f:
+                    async for content, progress in download:
+                        f.write(content)
+                        print(progress)
         """
         api = f"https://github.com/{repo}/archive/refs/tags/{tag}.tar.gz"
         return download_async(self._client.stream(api))
@@ -151,6 +163,18 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
 
         Raises:
             HTTPStatusError if the request was invalid
+
+        Example:
+            .. code-block:: python
+
+            async with api.download_release_zip(
+                "foo/bar", "v1.0.0"
+            ) as download:
+                file_path = Path("a.file.zip")
+                with file_path.open("wb") as f:
+                    async for content, progress in download:
+                        f.write(content)
+                        print(progress)
         """
         api = f"https://github.com/{repo}/archive/refs/tags/{tag}.zip"
         return download_async(self._client.stream(api))
@@ -180,12 +204,14 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
         Example:
             .. code-block:: python
 
-            async def download_asset(name, download_cm):
+            async def download_asset(name: str, download_cm) -> Path:
                 async with download_cm as iterator:
-                    with Path(name).open("wb") as f:
+                    file_path = Path(name)
+                    with file_path.open("wb") as f:
                         async for content, progress in iterator:
                             f.write(content)
                             print(name, progress)
+                    return file_path
 
 
             tasks = []
@@ -196,7 +222,7 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
                     download_asset(name, download_cm)
                 )
 
-            await asyncio.gather(*tasks)
+            file_paths = await asyncio.gather(*tasks)
 
         """
         release = await self.get(repo, tag)

--- a/pontos/github/api/release.py
+++ b/pontos/github/api/release.py
@@ -286,7 +286,7 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
         asset_url = release.upload_url.replace("{?name,label}", "")
 
         async def upload_file(
-            file_path, content_type
+            file_path: Path, content_type: str
         ) -> Tuple[httpx.Response, Path]:
             response = await self._client.post(
                 asset_url,

--- a/pontos/github/api/release.py
+++ b/pontos/github/api/release.py
@@ -235,7 +235,7 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
 
         assets_json = response.json()
         for asset_json in assets_json:
-            asset_url: str = asset_json.get("browser_download_url", "")
+            asset_url: str = asset_json.get("url", "")
             name: str = asset_json.get("name", "")
 
             if match_pattern and not Path(name).match(match_pattern):

--- a/tests/github/api/test_client.py
+++ b/tests/github/api/test_client.py
@@ -164,6 +164,24 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
             content=None,
         )
 
+    async def test_post_with_content_length(self):
+        await self.client.post(
+            "/foo/bar", data={"foo": "bar"}, content_length=123
+        )
+
+        self.http_client.post.assert_awaited_once_with(
+            f"{DEFAULT_GITHUB_API_URL}/foo/bar",
+            headers={
+                "Accept": DEFAULT_ACCEPT_HEADER,
+                "Authorization": "token token",
+                "X-GitHub-Api-Version": GITHUB_API_VERSION,
+                "Content-Length": "123",
+            },
+            json={"foo": "bar"},
+            params=None,
+            content=None,
+        )
+
     async def test_put(self):
         await self.client.put("/foo/bar", data={"foo": "bar"})
 

--- a/tests/github/api/test_client.py
+++ b/tests/github/api/test_client.py
@@ -19,7 +19,11 @@
 
 from unittest.mock import MagicMock, call, patch
 
-from pontos.github.api.client import GITHUB_API_VERSION, GitHubAsyncRESTClient
+from pontos.github.api.client import (
+    DEFAULT_ACCEPT_HEADER,
+    GITHUB_API_VERSION,
+    GitHubAsyncRESTClient,
+)
 from pontos.github.api.helper import DEFAULT_GITHUB_API_URL
 from tests import AsyncMock, IsolatedAsyncioTestCase, aiter, anext
 
@@ -37,7 +41,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
         self.http_client.get.assert_awaited_once_with(
             f"{DEFAULT_GITHUB_API_URL}/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -51,7 +55,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
         self.http_client.get.assert_awaited_once_with(
             "https://github.com/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -81,7 +85,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
                 call(
                     f"{DEFAULT_GITHUB_API_URL}/foo/bar",
                     headers={
-                        "Accept": "application/vnd.github+json",
+                        "Accept": DEFAULT_ACCEPT_HEADER,
                         "Authorization": "token token",
                         "X-GitHub-Api-Version": GITHUB_API_VERSION,
                     },
@@ -91,7 +95,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
                 call(
                     f"{url}",
                     headers={
-                        "Accept": "application/vnd.github+json",
+                        "Accept": DEFAULT_ACCEPT_HEADER,
                         "Authorization": "token token",
                         "X-GitHub-Api-Version": GITHUB_API_VERSION,
                     },
@@ -107,7 +111,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
         self.http_client.delete.assert_awaited_once_with(
             f"{DEFAULT_GITHUB_API_URL}/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -120,7 +124,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
         self.http_client.delete.assert_awaited_once_with(
             "https://github.com/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -133,7 +137,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
         self.http_client.post.assert_awaited_once_with(
             f"{DEFAULT_GITHUB_API_URL}/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -150,7 +154,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
         self.http_client.post.assert_awaited_once_with(
             "https://github.com/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -165,7 +169,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
         self.http_client.put.assert_awaited_once_with(
             f"{DEFAULT_GITHUB_API_URL}/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -180,7 +184,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
         self.http_client.put.assert_awaited_once_with(
             "https://github.com/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -195,7 +199,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
         self.http_client.patch.assert_awaited_once_with(
             f"{DEFAULT_GITHUB_API_URL}/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -212,7 +216,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
         self.http_client.patch.assert_awaited_once_with(
             "https://github.com/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -234,7 +238,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
             "GET",
             f"{DEFAULT_GITHUB_API_URL}/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -254,7 +258,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
             "GET",
             "https://github.com/foo/bar",
             headers={
-                "Accept": "application/vnd.github+json",
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },

--- a/tests/github/api/test_client.py
+++ b/tests/github/api/test_client.py
@@ -20,6 +20,7 @@
 from unittest.mock import MagicMock, call, patch
 
 from pontos.github.api.client import (
+    ACCEPT_HEADER_OCTET_STREAM,
     DEFAULT_ACCEPT_HEADER,
     GITHUB_API_VERSION,
     GitHubAsyncRESTClient,
@@ -238,7 +239,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
             "GET",
             f"{DEFAULT_GITHUB_API_URL}/foo/bar",
             headers={
-                "Accept": DEFAULT_ACCEPT_HEADER,
+                "Accept": ACCEPT_HEADER_OCTET_STREAM,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -258,7 +259,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
             "GET",
             "https://github.com/foo/bar",
             headers={
-                "Accept": DEFAULT_ACCEPT_HEADER,
+                "Accept": ACCEPT_HEADER_OCTET_STREAM,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },

--- a/tests/github/api/test_release.py
+++ b/tests/github/api/test_release.py
@@ -299,8 +299,8 @@ class GitHubAsyncRESTReleasesTestCase(GitHubAsyncRESTTestCase):
         get_assets_url_response.json.return_value = data
         get_assets_response = create_response()
         get_assets_response.json.return_value = [
-            {"browser_download_url": "http://bar", "name": "bar"},
-            {"browser_download_url": "http://baz", "name": "baz"},
+            {"url": "http://bar", "name": "bar"},
+            {"url": "http://baz", "name": "baz"},
         ]
         response = create_response(headers=MagicMock())
         response.headers.get.return_value = 2
@@ -389,8 +389,8 @@ class GitHubAsyncRESTReleasesTestCase(GitHubAsyncRESTTestCase):
         get_assets_url_response.json.return_value = data
         get_assets_response = create_response()
         get_assets_response.json.return_value = [
-            {"browser_download_url": "http://bar", "name": "bar"},
-            {"browser_download_url": "http://baz", "name": "baz"},
+            {"url": "http://bar", "name": "bar"},
+            {"url": "http://baz", "name": "baz"},
         ]
         response = create_response(headers=MagicMock())
         response.headers.get.return_value = 2


### PR DESCRIPTION
## What

It seems GitHub has changed some details on their REST API for downloading and uploading release artifacts.

## Why

Allow to download and upload release files again.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


