### PR TITLE
Async sign

### DIFF
--- a/pontos/release/main.py
+++ b/pontos/release/main.py
@@ -223,8 +223,8 @@ def parse_args(args) -> Tuple[str, str, Namespace]:
         "--dry-run", action="store_true", help="Do not upload signed files."
     )
     parsed_args = parser.parse_args(args)
-    token = os.getenv("GITHUB_TOKEN") if not args else "TOKEN"
-    user = os.getenv("GITHUB_USER") if not args else "USER"
+    token = os.environ.get("GITHUB_TOKEN")
+    user = os.environ.get("GITHUB_USER")
     return user, token, parsed_args
 
 

--- a/pontos/testing/__init__.py
+++ b/pontos/testing/__init__.py
@@ -19,12 +19,13 @@ import os
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Generator, Optional
+from typing import Any, AsyncIterator, Awaitable, Generator, Iterable, Optional
 
 from pontos.git.git import exec_git
 from pontos.helper import add_sys_path, ensure_unload_module, unload_module
 
 __all__ = (
+    "AsyncIteratorMock",
     "temp_directory",
     "temp_git_repository",
     "temp_file",
@@ -210,3 +211,14 @@ def temp_python_module(
         test_file = tmp_dir / f"{name}.py"
         test_file.write_text(content, encoding="utf8")
         yield test_file
+
+
+class AsyncIteratorMock(AsyncIterator):
+    def __init__(self, iterable: Iterable[Any]) -> None:
+        self.iterator = iter(iterable)
+
+    async def __anext__(self) -> Awaitable[Any]:
+        try:
+            return next(self.iterator)
+        except StopIteration:
+            raise StopAsyncIteration() from None

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -19,9 +19,10 @@
 
 import builtins
 import sys
-from typing import Any, AsyncIterator, Awaitable, Iterable
 from unittest import IsolatedAsyncioTestCase
 from unittest.mock import AsyncMock
+
+from pontos.testing import AsyncIteratorMock
 
 if sys.version_info.minor < 10:
     # aiter and anext have been added in Python 3.10
@@ -38,17 +39,6 @@ else:
 
     def anext(obj):  # pylint: disable=redefined-builtin
         return builtins.anext(obj)
-
-
-class AsyncIteratorMock(AsyncIterator):
-    def __init__(self, iterable: Iterable[Any]) -> None:
-        self.iterator = iter(iterable)
-
-    async def __anext__(self) -> Awaitable[Any]:
-        try:
-            return next(self.iterator)
-        except StopIteration:
-            raise StopAsyncIteration() from None
 
 
 __all__ = (

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # pylint: disable=C0413,W0108
 
-import os
 import unittest
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call, patch
@@ -35,11 +34,8 @@ def mock_terminal() -> MagicMock:
     return MagicMock(spec=Terminal)
 
 
+@patch.dict("os.environ", {"GITHUB_TOKEN": "foo", "GITHUB_USER": "user"})
 class ReleaseTestCase(unittest.TestCase):
-    def setUp(self) -> None:
-        os.environ["GITHUB_TOKEN"] = "foo"
-        os.environ["GITHUB_USER"] = "bar"
-
     @patch("pontos.release.release.Git", autospec=True)
     @patch(
         "pontos.release.release.ReleaseCommand._update_version", autospec=True
@@ -95,7 +91,7 @@ class ReleaseTestCase(unittest.TestCase):
         )
 
         self.assertEqual(
-            create_release_mock.await_args.args[1:], ("0.0.1", "TOKEN")
+            create_release_mock.await_args.args[1:], ("0.0.1", "foo")
         )
 
         self.assertEqual(released, ReleaseReturnValue.SUCCESS)
@@ -155,7 +151,7 @@ class ReleaseTestCase(unittest.TestCase):
         )
 
         self.assertEqual(
-            create_release_mock.await_args.args[1:], ("0.0.1", "TOKEN")
+            create_release_mock.await_args.args[1:], ("0.0.1", "foo")
         )
         self.assertEqual(released, ReleaseReturnValue.SUCCESS)
 
@@ -265,7 +261,7 @@ class ReleaseTestCase(unittest.TestCase):
         )
 
         self.assertEqual(
-            create_release_mock.await_args.args[1:], ("0.0.1", "TOKEN")
+            create_release_mock.await_args.args[1:], ("0.0.1", "foo")
         )
 
         self.assertEqual(released, ReleaseReturnValue.SUCCESS)
@@ -330,7 +326,7 @@ class ReleaseTestCase(unittest.TestCase):
         )
 
         self.assertEqual(
-            create_release_mock.await_args.args[1:], ("0.0.1", "TOKEN")
+            create_release_mock.await_args.args[1:], ("0.0.1", "foo")
         )
 
         self.assertEqual(released, ReleaseReturnValue.SUCCESS)

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -16,7 +16,6 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 # pylint: disable=C0413,W0108
 
-import os
 import unittest
 from unittest.mock import MagicMock, patch
 
@@ -31,9 +30,9 @@ def mock_terminal() -> MagicMock:
     return MagicMock(spec=Terminal)
 
 
+@patch.dict("os.environ", {"GITHUB_TOKEN": "foo"})
 class SignTestCase(unittest.TestCase):
     def setUp(self) -> None:
-        os.environ["GITHUB_TOKEN"] = "foo"
         self.valid_gh_release_response = (
             '{"zipball_url": "zip", "tarball_url":'
             ' "tar", "upload_url":"upload"}'

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -17,41 +17,25 @@
 # pylint: disable=C0413,W0108
 
 import unittest
-from unittest.mock import MagicMock, patch
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, call, patch
 
 import httpx
 
 from pontos.release.main import parse_args
 from pontos.release.sign import SignReturnValue, sign
-from pontos.terminal.terminal import Terminal
+from pontos.terminal.rich import RichTerminal
+from pontos.testing import AsyncIteratorMock, temp_directory
 
 
 def mock_terminal() -> MagicMock:
-    return MagicMock(spec=Terminal)
+    return MagicMock(spec=RichTerminal)
 
 
 @patch.dict("os.environ", {"GITHUB_TOKEN": "foo"})
 class SignTestCase(unittest.TestCase):
-    def setUp(self) -> None:
-        self.valid_gh_release_response = (
-            '{"zipball_url": "zip", "tarball_url":'
-            ' "tar", "upload_url":"upload"}'
-        )
-
-    @patch("pontos.release.sign.shell_cmd_runner", autospec=True)
-    @patch("pontos.release.sign.Path", autospec=True)
-    @patch("pontos.github.api.api.httpx", autospec=True)
-    def test_fail_sign_on_invalid_get_response(
-        self,
-        requests_mock,
-        _path_mock,
-        _shell_mock,
-    ):
-        fake_get = MagicMock()
-        fake_get.status_code = 404
-        fake_get.text = self.valid_gh_release_response
-        requests_mock.get.return_value = fake_get
-
+    @patch.dict("os.environ", {"GITHUB_TOKEN": ""})
+    def test_no_token(self):
         _, token, args = parse_args(
             [
                 "sign",
@@ -62,108 +46,454 @@ class SignTestCase(unittest.TestCase):
             ]
         )
 
-        with self.assertRaises(httpx.HTTPError):
-            sign(
+        result = sign(
+            terminal=mock_terminal(),
+            args=args,
+            token=token,
+        )
+
+        self.assertEqual(result, SignReturnValue.TOKEN_MISSING)
+
+    def test_no_project(self):
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                ]
+            )
+
+            result = sign(
                 terminal=mock_terminal(),
                 args=args,
                 token=token,
             )
 
-    @patch("pontos.release.sign.shell_cmd_runner", autospec=True)
-    @patch("pontos.release.sign.Path", autospec=True)
-    @patch("pontos.helper.Path", autospec=True)
-    @patch("pontos.github.api.api.httpx", autospec=True)
-    @patch("pontos.github.api.release.httpx", autospec=True)
-    @patch("pontos.helper.httpx.stream", autospec=True)
-    def test_fail_sign_on_upload_fail(
+            self.assertEqual(result, SignReturnValue.NO_PROJECT)
+
+    def test_no_project_setup(self):
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                    "--project",
+                    "foo",
+                ]
+            )
+
+            result = sign(
+                terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
+
+            self.assertEqual(result, SignReturnValue.NO_RELEASE_VERSION)
+
+    @patch("pontos.release.sign.GitHubAsyncRESTApi.releases", autospec=True)
+    def test_release_does_not_exist(self, github_mock: AsyncMock):
+        github_mock.exists = AsyncMock(return_value=False)
+
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                    "--project",
+                    "foo",
+                    "--release",
+                    "1.2.3",
+                ]
+            )
+
+            result = sign(
+                terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
+
+            self.assertEqual(result, SignReturnValue.NO_RELEASE)
+
+    @patch("pontos.release.sign.cmd_runner", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_asset", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_tar", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_zip", autospec=True)
+    @patch("pontos.release.sign.GitHubAsyncRESTApi.releases", autospec=True)
+    def test_sign_success(
         self,
-        stream_mock,
-        request_mock,
-        request2_mock,
-        _path_mock,
-        _path2_mock,
-        _shell_mock,
+        github_releases_mock: AsyncMock,
+        download_zip_mock: AsyncMock,
+        download_tar_mock: AsyncMock,
+        download_asset_mock: AsyncMock,
+        cmd_runner_mock: MagicMock,
     ):
-        fake_get = MagicMock()
-        fake_get.status_code = 200
-        fake_get.text = self.valid_gh_release_response
-        fake_post = MagicMock()
-        fake_post.status_code = 500
-        fake_post.is_success = False
-        fake_post.text = self.valid_gh_release_response
-        fake_post.raise_for_status.side_effect = httpx.HTTPStatusError(
-            "Server Error", request=MagicMock(), response=fake_post
+        tar_file = Path("file.tar")
+        zip_file = Path("file.zip")
+        some_asset = Path("file1")
+        other_asset = Path("file2")
+        download_tar_mock.return_value = tar_file
+        download_zip_mock.return_value = zip_file
+        download_asset_mock.side_effect = [some_asset, other_asset]
+        github_releases_mock.exists = AsyncMock(return_value=True)
+        github_releases_mock.download_release_assets.return_value = (
+            AsyncIteratorMock(
+                [
+                    (
+                        "foo",
+                        MagicMock(),
+                    ),
+                    ("bar", MagicMock()),
+                ]
+            )
         )
-        request_mock.get.return_value = fake_get
-        request_mock.post.return_value = fake_post
-        request2_mock.get.return_value = fake_get
-        request2_mock.post.return_value = fake_post
+        cmd_runner_mock.return_value = MagicMock(returncode=0)
 
-        response = MagicMock()
-        response.iter_bytes.side_effect = [
-            [b"foo", b"bar", b"baz"],
-            [b"lorem", b"ipsum"],
-        ]
-        response_stream = MagicMock()
-        response_stream.__enter__.return_value = response
-        stream_mock.return_value = response_stream
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                    "--project",
+                    "foo",
+                    "--release-version",
+                    "1.2.3",
+                ]
+            )
 
-        _, token, args = parse_args(
-            [
-                "sign",
-                "--project",
-                "foo",
-                "--release-version",
-                "0.0.1",
-            ]
-        )
-        released = sign(terminal=mock_terminal(), args=args, token=token)
+            result = sign(
+                terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
 
-        self.assertEqual(released, SignReturnValue.UPLOAD_ASSET_ERROR)
+            self.assertEqual(result, SignReturnValue.SUCCESS)
 
-    @patch("pontos.release.sign.shell_cmd_runner", autospec=True)
-    @patch("pontos.release.sign.Path", autospec=True)
-    @patch("pontos.helper.Path", autospec=True)
-    @patch("pontos.github.api.api.httpx", autospec=True)
-    @patch("pontos.github.api.release.httpx", autospec=True)
-    @patch("pontos.helper.httpx.stream", autospec=True)
-    def test_successfully_sign(
+            cmd_runner_mock.assert_has_calls(
+                [
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        zip_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        tar_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        some_asset,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        other_asset,
+                    ),
+                ]
+            )
+
+            github_releases_mock.upload_release_assets.assert_called_once_with(
+                "greenbone/foo",
+                "v1.2.3",
+                [
+                    (Path("file.zip.asc"), "application/pgp-signature"),
+                    (Path("file.tar.asc"), "application/pgp-signature"),
+                    (Path("file1.asc"), "application/pgp-signature"),
+                    (Path("file2.asc"), "application/pgp-signature"),
+                ],
+            )
+
+    @patch("pontos.release.sign.cmd_runner", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_asset", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_tar", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_zip", autospec=True)
+    @patch("pontos.release.sign.GitHubAsyncRESTApi.releases", autospec=True)
+    def test_sign_success_dry_run(
         self,
-        stream_mock,
-        request_mock,
-        request_mock2,
-        _path_mock,
-        _path2_mock,
-        _shell_mock,
+        github_releases_mock: AsyncMock,
+        download_zip_mock: AsyncMock,
+        download_tar_mock: AsyncMock,
+        download_asset_mock: AsyncMock,
+        cmd_runner_mock: MagicMock,
     ):
-        fake_get = MagicMock()
-        fake_get.status_code = 200
-        fake_get.text = self.valid_gh_release_response
-        fake_post = MagicMock()
-        fake_post.status_code = 201
-        fake_post.text = self.valid_gh_release_response
-        request_mock.get.return_value = fake_get
-        request_mock.post.return_value = fake_post
-        request_mock2.get.return_value = fake_get
-        request_mock2.post.return_value = fake_post
-
-        response = MagicMock()
-        response.iter_bytes.side_effect = [
-            [b"foo", b"bar", b"baz"],
-            [b"lorem", b"ipsum"],
-        ]
-        response_stream = MagicMock()
-        response_stream.__enter__.return_value = response
-        stream_mock.return_value = response_stream
-
-        _, token, args = parse_args(
-            args=[
-                "sign",
-                "--project",
-                "bar",
-                "--release-version",
-                "0.0.1",
-            ]
+        tar_file = Path("file.tar")
+        zip_file = Path("file.zip")
+        some_asset = Path("file1")
+        other_asset = Path("file2")
+        download_tar_mock.return_value = tar_file
+        download_zip_mock.return_value = zip_file
+        download_asset_mock.side_effect = [some_asset, other_asset]
+        github_releases_mock.exists = AsyncMock(return_value=True)
+        github_releases_mock.download_release_assets.return_value = (
+            AsyncIteratorMock(
+                [
+                    (
+                        "foo",
+                        MagicMock(),
+                    ),
+                    ("bar", MagicMock()),
+                ]
+            )
         )
-        released = sign(terminal=mock_terminal(), args=args, token=token)
-        self.assertEqual(released, SignReturnValue.SUCCESS)
+        cmd_runner_mock.return_value = MagicMock(returncode=0)
+
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                    "--project",
+                    "foo",
+                    "--release-version",
+                    "1.2.3",
+                    "--dry-run",
+                ]
+            )
+
+            result = sign(
+                terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
+
+            self.assertEqual(result, SignReturnValue.SUCCESS)
+
+            cmd_runner_mock.assert_has_calls(
+                [
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        zip_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        tar_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        some_asset,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        other_asset,
+                    ),
+                ]
+            )
+
+            github_releases_mock.upload_release_assets.assert_not_called()
+
+    @patch("pontos.release.sign.cmd_runner", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_asset", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_tar", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_zip", autospec=True)
+    @patch("pontos.release.sign.GitHubAsyncRESTApi.releases", autospec=True)
+    def test_sign_signature_failure(
+        self,
+        github_releases_mock: AsyncMock,
+        download_zip_mock: AsyncMock,
+        download_tar_mock: AsyncMock,
+        download_asset_mock: AsyncMock,
+        cmd_runner_mock: MagicMock,
+    ):
+        tar_file = Path("file.tar")
+        zip_file = Path("file.zip")
+        some_asset = Path("file1")
+        other_asset = Path("file2")
+        download_tar_mock.return_value = tar_file
+        download_zip_mock.return_value = zip_file
+        download_asset_mock.side_effect = [some_asset, other_asset]
+        github_releases_mock.exists = AsyncMock(return_value=True)
+        github_releases_mock.download_release_assets.return_value = (
+            AsyncIteratorMock(
+                [
+                    (
+                        "foo",
+                        MagicMock(),
+                    ),
+                    ("bar", MagicMock()),
+                ]
+            )
+        )
+        cmd_runner_mock.return_value = MagicMock(
+            returncode=2, stderr="An error"
+        )
+
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                    "--project",
+                    "foo",
+                    "--release-version",
+                    "1.2.3",
+                ]
+            )
+
+            result = sign(
+                terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
+
+            self.assertEqual(
+                result, SignReturnValue.SIGNATURE_GENERATION_FAILED
+            )
+
+            cmd_runner_mock.assert_has_calls(
+                [
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        zip_file,
+                    ),
+                ]
+            )
+
+            github_releases_mock.upload_release_assets.assert_not_called()
+
+    @patch("pontos.release.sign.cmd_runner", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_asset", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_tar", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_zip", autospec=True)
+    @patch("pontos.release.sign.GitHubAsyncRESTApi.releases", autospec=True)
+    def test_sign_upload_failure(
+        self,
+        github_releases_mock: AsyncMock,
+        download_zip_mock: AsyncMock,
+        download_tar_mock: AsyncMock,
+        download_asset_mock: AsyncMock,
+        cmd_runner_mock: MagicMock,
+    ):
+        tar_file = Path("file.tar")
+        zip_file = Path("file.zip")
+        some_asset = Path("file1")
+        other_asset = Path("file2")
+        download_tar_mock.return_value = tar_file
+        download_zip_mock.return_value = zip_file
+        download_asset_mock.side_effect = [some_asset, other_asset]
+        github_releases_mock.exists = AsyncMock(return_value=True)
+        github_releases_mock.download_release_assets.return_value = (
+            AsyncIteratorMock(
+                [
+                    (
+                        "foo",
+                        MagicMock(),
+                    ),
+                    ("bar", MagicMock()),
+                ]
+            )
+        )
+        github_releases_mock.upload_release_assets.side_effect = (
+            httpx.HTTPStatusError(
+                "An error",
+                request=MagicMock(spec=httpx.Request),
+                response=MagicMock(spec=httpx.Response),
+            )
+        )
+        cmd_runner_mock.return_value = MagicMock(returncode=0)
+
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                    "--project",
+                    "foo",
+                    "--release-version",
+                    "1.2.3",
+                ]
+            )
+
+            result = sign(
+                terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
+
+            self.assertEqual(result, SignReturnValue.UPLOAD_ASSET_ERROR)
+
+            cmd_runner_mock.assert_has_calls(
+                [
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        zip_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        tar_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        some_asset,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        other_asset,
+                    ),
+                ]
+            )
+
+            github_releases_mock.upload_release_assets.assert_called_once_with(
+                "greenbone/foo",
+                "v1.2.3",
+                [
+                    (Path("file.zip.asc"), "application/pgp-signature"),
+                    (Path("file.tar.asc"), "application/pgp-signature"),
+                    (Path("file1.asc"), "application/pgp-signature"),
+                    (Path("file2.asc"), "application/pgp-signature"),
+                ],
+            )

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -17,6 +17,7 @@
 # pylint: disable=C0413,W0108
 
 import unittest
+from asyncio.subprocess import Process
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -122,7 +123,7 @@ class SignTestCase(unittest.TestCase):
         download_zip_mock: AsyncMock,
         download_tar_mock: AsyncMock,
         download_asset_mock: AsyncMock,
-        cmd_runner_mock: MagicMock,
+        cmd_runner_mock: AsyncMock,
     ):
         tar_file = Path("file.tar")
         zip_file = Path("file.zip")
@@ -143,7 +144,9 @@ class SignTestCase(unittest.TestCase):
                 ]
             )
         )
-        cmd_runner_mock.return_value = MagicMock(returncode=0)
+        process = AsyncMock(spec=Process, returncode=0)
+        process.communicate.return_value = ("", "")
+        cmd_runner_mock.return_value = process
 
         with temp_directory(change_into=True):
             _, token, args = parse_args(
@@ -248,7 +251,9 @@ class SignTestCase(unittest.TestCase):
                 ]
             )
         )
-        cmd_runner_mock.return_value = MagicMock(returncode=0)
+        process = AsyncMock(spec=Process, returncode=0)
+        process.communicate.return_value = ("", "")
+        cmd_runner_mock.return_value = process
 
         with temp_directory(change_into=True):
             _, token, args = parse_args(
@@ -345,9 +350,9 @@ class SignTestCase(unittest.TestCase):
                 ]
             )
         )
-        cmd_runner_mock.return_value = MagicMock(
-            returncode=2, stderr="An error"
-        )
+        process = AsyncMock(spec=Process, returncode=2)
+        process.communicate.return_value = ("", b"An Error")
+        cmd_runner_mock.return_value = process
 
         with temp_directory(change_into=True):
             _, token, args = parse_args(
@@ -425,7 +430,9 @@ class SignTestCase(unittest.TestCase):
                 response=MagicMock(spec=httpx.Response),
             )
         )
-        cmd_runner_mock.return_value = MagicMock(returncode=0)
+        process = AsyncMock(spec=Process, returncode=0)
+        process.communicate.return_value = ("", "")
+        cmd_runner_mock.return_value = process
 
         with temp_directory(change_into=True):
             _, token, args = parse_args(


### PR DESCRIPTION
## What

Rewrite `pontos-release sign` to use async GitHub API

## Why

We want to get rid of the sync GitHub API

## References

#609
DEVOPS-545

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


