### PR TITLE
Remove: Drop unused testing helper function use_cwd

### DIFF
--- a/tests/release/__init__.py
+++ b/tests/release/__init__.py
@@ -14,21 +14,3 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-
-import os
-from contextlib import contextmanager
-from pathlib import Path
-
-
-@contextmanager
-def use_cwd(path: Path) -> None:
-    """
-    Context Manager to change the current working directory temporaryly
-    """
-    current_cwd = Path.cwd()
-
-    os.chdir(str(path))
-
-    yield
-
-    os.chdir(str(current_cwd))


### PR DESCRIPTION
## What

Drop unused testing helper function use_cwd

## Why

The function isn't used anywhere in our tests anymore.

