### PR TITLE
Rework Actions

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -52,3 +52,14 @@ jobs:
         with:
           version: "3.10"
           token: ${{ secrets.CODECOV_TOKEN }}
+
+  check-version:
+    name: Check versioning for consistency
+    runs-on: "ubuntu-latest"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Install python, poetry and dependencies
+        uses: greenbone/actions/poetry@v2
+      - name: Check version
+        run: |
+          poetry run pontos-version verify current

--- a/.github/workflows/release-pontos.yml
+++ b/.github/workflows/release-pontos.yml
@@ -19,16 +19,56 @@ jobs:
           else
             echo "RELEASE_REF=${{ github.base_ref }}" >> $GITHUB_ENV
           fi
-      - name: Release with release action
-        uses: greenbone/actions/release@v2
+      - uses: actions/checkout@v3
         with:
-          python-version: "3.10"
-          conventional-commits: true
-          github-user: ${{ secrets.GREENBONE_BOT }}
-          github-user-mail: ${{ secrets.GREENBONE_BOT_MAIL }}
-          github-user-token: ${{ secrets.GREENBONE_BOT_TOKEN }}
-          gpg-key: ${{ secrets.GPG_KEY }}
-          gpg-fingerprint: ${{ secrets.GPG_FINGERPRINT }}
-          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
-          strategy: calendar
+          fetch-depth: ${{ env.FETCH_DEPTH }}
+          persist-credentials: false
           ref: ${{ env.RELEASE_REF }}
+      - name: Set git name, mail and origin
+        run: |
+          git config --global user.name "${{ secrets.GREENBONE_BOT }}"
+          git config --global user.email "${{ secrets.GREENBONE_BOT_MAIL }}"
+          git remote set-url origin https://${{ secrets.GREENBONE_BOT_TOKEN }}@github.com/${{ github.repository }}
+          - name: allow admin users bypassing protection on ${{ env.RELEASE_REF }} branch
+      - uses: actions/poetry@v2
+      - name: Allow admin users bypassing protection on ${{ env.RELEASE_REF }} branch
+        run: |
+          poetry run pontos-github-script scripts/github/enforce-admins.py ${{ github.repository }} ${{ env.RELEASE_REF }} --allow
+        env:
+          GITHUB_USER: ${{ secrets.GREENBONE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
+      - name: Prepare release
+        run: |
+          poetry run pontos-release prepare --release-type calendar
+        env:
+          GITHUB_USER: ${{ secrets.GREENBONE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
+      - name: Get release version
+        run: |
+          VERSION=$(poetry run pontos-version show)
+          echo "Releasing $VERSION"
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+      - name: Create release
+        run: |
+          poetry run pontos-release release
+        env:
+          GITHUB_USER: ${{ secrets.GREENBONE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
+      - name: Disable bypassing protection on ${{ env.RELEASE_REF }} branch for admin users
+        run: |
+          poetry run pontos-github-script scripts/github/enforce-admins.py ${{ github.repository }} ${{ env.RELEASE_REF }} --no-allow
+        env:
+          GITHUB_USER: ${{ secrets.GREENBONE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
+      - name: Import gpg key from secrets
+        run: |
+          echo -e "${{ secrets.GPG_KEY }}" >> tmp.file
+          gpg --pinentry-mode loopback --passphrase ${{ secrets.GPG_PASSPHRASE }} --import tmp.file
+          rm tmp.file
+      - name: Sign assets for released version
+        run: |
+          echo "Signing assets for ${{env.VERSION}}"
+          poetry run pontos-release sign --signing-key ${{ secrets.GPG_FINGERPRINT }} --passphrase ${{ secrets.GPG_PASSPHRASE }} --release-version ${{ env.VERSION }}
+        env:
+          GITHUB_USER: ${{ secrets.GREENBONE_BOT }}
+          GITHUB_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}


### PR DESCRIPTION
## What

 Change: Use code checkout to release pontos

When using our action to release pontos we actually use the last
released version of pontos to create the new release of pontos. If
pontos has a bug in the new release code we can't fix it without
uploading a new release to pypi manually with this approach. Therefore
drop the action usage and release pontos with it's current to be
released code. This ensures that the release fails if there is some bug
in the release code.

 Change: Add explicit CI job for checking the versioning

Checking the versioning got removed from the lint-python action with the
last v2 release.