### PR TITLE
Major minor updates

### DIFF
--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -29,9 +29,9 @@ class ReleaseType(Enum):
     PATCH = "patch"
     CALENDAR = "calendar"
     VERSION = "version"
+    MAJOR = "major"
+    MINOR = "minor"
     # for the future we need
-    # MAJOR = "major"
-    # MINOR = "minor"
     # PRE_RELEASE = "pre-release"
 
 

--- a/pontos/release/prepare.py
+++ b/pontos/release/prepare.py
@@ -67,6 +67,12 @@ class PrepareCommand:
         if release_type == ReleaseType.PATCH:
             return calculator.next_patch_version(current_version)
 
+        if release_type == ReleaseType.MINOR:
+            return calculator.next_minor_version(current_version)
+
+        if release_type == ReleaseType.MAJOR:
+            return calculator.next_major_version(current_version)
+
         if not release_version:
             raise VersionError(
                 "No release version provided. Either use a different release "

--- a/pontos/version/calculator.py
+++ b/pontos/version/calculator.py
@@ -38,7 +38,7 @@ class VersionCalculator:
         try:
             current_version = Version(version)
 
-            if current_version.dev is not None:
+            if current_version.is_prerelease:
                 next_version = Version(
                     f"{current_version.major}."
                     f"{current_version.minor}."
@@ -96,3 +96,21 @@ class VersionCalculator:
                 f"'{current_version}' is higher than "
                 f"'{current_year_short}.{today.month}'."
             )
+
+    def next_minor_version(self, version: str) -> str:
+        try:
+            current_version = Version(version)
+            release_version = Version(
+                f"{current_version.major}.{current_version.minor +1}.0"
+            )
+            return str(release_version)
+        except InvalidVersion as e:
+            raise VersionError(e) from None
+
+    def next_major_version(self, version: str) -> str:
+        try:
+            current_version = Version(version)
+            release_version = Version(f"{current_version.major + 1}.0.0")
+            return str(release_version)
+        except InvalidVersion as e:
+            raise VersionError(e) from None

--- a/tests/version/test_calculator.py
+++ b/tests/version/test_calculator.py
@@ -25,21 +25,28 @@ from pontos.version.errors import VersionError
 class VersionCalculatorTestCase(unittest.TestCase):
     def test_next_patch_version(self):
         calculator = VersionCalculator()
-        today = datetime.today()
 
         current_versions = [
-            "20.4.1.dev3",
-            f"{str(today.year % 100)}.4.1.dev3",
-            f"19.{str(today.month)}.1.dev3",
-            f"{str(today.year % 100)}.{str(today.month)}.1",
-            "20.6.1",
+            "0.0.1",
+            "1.2.3",
+            "1.2.3.post1",
+            "1.2.3a1",
+            "1.2.3b1",
+            "1.2.3rc1",
+            "22.4.1",
+            "22.4.1.dev1",
+            "22.4.1.dev3",
         ]
         assert_versions = [
-            "20.4.1",
-            f"{str(today.year % 100)}.4.1",
-            f"19.{str(today.month)}.1",
-            f"{str(today.year % 100)}.{str(today.month)}.2",
-            "20.6.2",
+            "0.0.2",
+            "1.2.4",
+            "1.2.4",
+            "1.2.3",
+            "1.2.3",
+            "1.2.3",
+            "22.4.2",
+            "22.4.1",
+            "22.4.1",
         ]
 
         for current_version, assert_version in zip(
@@ -91,3 +98,77 @@ class VersionCalculatorTestCase(unittest.TestCase):
             calculator.next_calendar_version(
                 f"{year_short}.{today.month + 1}.0"
             )
+
+    def test_next_minor_version(self):
+        calculator = VersionCalculator()
+
+        current_versions = [
+            "0.0.1",
+            "1.2.3",
+            "1.2.3.post1",
+            "1.2.3a1",
+            "1.2.3b1",
+            "1.2.3rc1",
+            "22.4.1",
+            "22.4.1.dev1",
+            "22.4.1.dev3",
+        ]
+        assert_versions = [
+            "0.1.0",
+            "1.3.0",
+            "1.3.0",
+            "1.3.0",
+            "1.3.0",
+            "1.3.0",
+            "22.5.0",
+            "22.5.0",
+            "22.5.0",
+        ]
+
+        for current_version, assert_version in zip(
+            current_versions, assert_versions
+        ):
+            release_version = calculator.next_minor_version(current_version)
+            self.assertEqual(release_version, assert_version)
+
+    def test_next_minor_version_error(self):
+        calculator = VersionCalculator()
+        with self.assertRaisesRegex(VersionError, "Invalid version: 'abc'"):
+            calculator.next_minor_version("abc")
+
+    def test_next_major_version(self):
+        calculator = VersionCalculator()
+
+        current_versions = [
+            "0.0.1",
+            "1.2.3",
+            "1.2.3.post1",
+            "1.2.3a1",
+            "1.2.3b1",
+            "1.2.3rc1",
+            "22.4.1",
+            "22.4.1.dev1",
+            "22.4.1.dev3",
+        ]
+        assert_versions = [
+            "1.0.0",
+            "2.0.0",
+            "2.0.0",
+            "2.0.0",
+            "2.0.0",
+            "2.0.0",
+            "23.0.0",
+            "23.0.0",
+            "23.0.0",
+        ]
+
+        for current_version, assert_version in zip(
+            current_versions, assert_versions
+        ):
+            release_version = calculator.next_major_version(current_version)
+            self.assertEqual(release_version, assert_version)
+
+    def test_next_major_version_error(self):
+        calculator = VersionCalculator()
+        with self.assertRaisesRegex(VersionError, "Invalid version: 'abc'"):
+            calculator.next_major_version("abc")


### PR DESCRIPTION
## What

Support creating major and minor releases.

`pontos-release prepare --release-type minor` and `pontos-release prepare --release-type major`

## Why

It will be required to do all kind of releases with the 3rd gen.

## References

DEVOPS-549

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


