### PR TITLE
Release with empty changelog

### DIFF
--- a/pontos/changelog/conventional_commits.py
+++ b/pontos/changelog/conventional_commits.py
@@ -40,8 +40,6 @@ DEFAULT_CHANGELOG_CONFIG = """commit_types = [
     { message = "^change", group = "Changed"},
     { message = "^fix", group = "Bug Fixes"},
 ]
-
-changelog_dir = "changelog"
 """
 
 

--- a/pontos/git/git.py
+++ b/pontos/git/git.py
@@ -124,6 +124,9 @@ class Git:
         """
         self._cwd = cwd.absolute()
 
+    def exec(self, *args: str) -> str:
+        return exec_git(*args, cwd=self._cwd)
+
     def init(self, *, bare: Optional[bool] = False) -> None:
         """
         Init a git repository
@@ -135,7 +138,8 @@ class Git:
         args = ["init"]
         if bare:
             args.append("--bare")
-        exec_git(*args, cwd=self._cwd)
+
+        self.exec(*args)
 
     def create_branch(
         self, branch: str, *, start_point: Optional[str] = None
@@ -152,7 +156,7 @@ class Git:
         if start_point:
             args.append(start_point)
 
-        exec_git(*args, cwd=self._cwd)
+        self.exec(*args)
 
     def rebase(
         self,
@@ -188,7 +192,7 @@ class Git:
         if head:
             args.append(head)
 
-        exec_git(*args, cwd=self._cwd)
+        self.exec(*args)
 
     def clone(
         self,
@@ -217,10 +221,7 @@ class Git:
             args.extend(["--depth", str(depth)])
         args.extend([repo_url, str(destination.absolute())])
 
-        exec_git(
-            *args,
-            cwd=self._cwd,
-        )
+        self.exec(*args)
 
     def push(
         self,
@@ -251,7 +252,7 @@ class Git:
             if branch:
                 args.append(branch)
 
-        exec_git(*args, cwd=self._cwd)
+        self.exec(*args)
 
     def config(
         self,
@@ -277,7 +278,7 @@ class Git:
         if value is not None:
             args.append(value)
 
-        return exec_git(*args, cwd=self._cwd)
+        return self.exec(*args)
 
     def cherry_pick(self, commits: Union[str, List[str]]) -> None:
         """
@@ -293,7 +294,7 @@ class Git:
         args = ["cherry-pick"]
         args.extend(commits)
 
-        exec_git(*args, cwd=self._cwd)
+        self.exec(*args)
 
     def list_tags(self, *, sort: Optional[TagSort] = None) -> List[str]:
         """
@@ -302,7 +303,8 @@ class Git:
         args = ["tag", "-l"]
         if sort:
             args.append(f"--sort={sort.value}")
-        return exec_git(*args, cwd=self._cwd).splitlines()
+
+        return self.exec(*args).splitlines()
 
     def add(self, files: Union[PathLike, List[PathLike]]) -> None:
         """
@@ -317,7 +319,7 @@ class Git:
         args = ["add"]
         args.extend([fspath(file) for file in files])
 
-        exec_git(*args, cwd=self._cwd)
+        self.exec(*args)
 
     def commit(
         self,
@@ -342,7 +344,7 @@ class Git:
 
         args.extend(["-m", message])
 
-        exec_git(*args, cwd=self._cwd)
+        self.exec(*args)
 
     def tag(
         self,
@@ -374,7 +376,7 @@ class Git:
 
         args.append(tag)
 
-        exec_git(*args, cwd=self._cwd)
+        self.exec(*args)
 
     def fetch(
         self,
@@ -402,7 +404,7 @@ class Git:
         if verbose:
             args.append("-v")
 
-        exec_git(*args, cwd=self._cwd)
+        self.exec(*args)
 
     def add_remote(self, remote: str, url: str) -> None:
         """
@@ -415,7 +417,7 @@ class Git:
 
         args = ["remote", "add", remote, url]
 
-        exec_git(*args, cwd=self._cwd)
+        self.exec(*args)
 
     def remote_url(self, remote: str = "origin") -> str:
         """
@@ -425,7 +427,7 @@ class Git:
             remote: Name of the remote. Default: origin.
         """
         args = ["remote", "get-url", remote]
-        return exec_git(*args, cwd=self._cwd)
+        return self.exec(*args)
 
     def checkout(
         self, branch: str, *, start_point: Optional[str] = None
@@ -444,7 +446,7 @@ class Git:
         else:
             args = ["checkout", branch]
 
-        exec_git(*args, cwd=self._cwd)
+        self.exec(*args)
 
     def log(self, *log_args: str, oneline: Optional[bool] = None) -> List[str]:
         """
@@ -458,4 +460,4 @@ class Git:
 
         args.extend(log_args)
 
-        return exec_git(*args, cwd=self._cwd).splitlines()
+        return self.exec(*args).splitlines()

--- a/pontos/git/git.py
+++ b/pontos/git/git.py
@@ -461,3 +461,41 @@ class Git:
         args.extend(log_args)
 
         return self.exec(*args).splitlines()
+
+    def rev_list(
+        self,
+        *commit: str,
+        max_parents: Optional[int] = None,
+        abbrev_commit: Optional[bool] = False,
+    ) -> List[str]:
+        """
+        Lists commit objects in reverse chronological order
+
+        Args:
+            commit: commit objects.
+            max_parents: Only list nth oldest commits
+            abbrev_commit: Set to True to show  prefix that names the commit
+                object uniquely instead of the full commit ID.
+
+        Examples:
+            .. code-block:: python
+
+            git = Git()
+            git.rev_list("foo", "bar", "^baz")
+
+            This will "list all the commits which are reachable from foo or bar,
+            but not from baz".
+
+            git = Git()
+            git.rev_list("foo", max_parents=0)
+
+            This will return the first commit of foo.
+        """
+        args = ["rev-list"]
+        if max_parents is not None:
+            args.append(f"--max-parents={max_parents}")
+        if abbrev_commit:
+            args.append("--abbrev-commit")
+
+        args.extend(commit)
+        return self.exec(*args).splitlines()

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -35,7 +35,9 @@ class ReleaseType(Enum):
     # PRE_RELEASE = "pre-release"
 
 
-def get_last_release_version() -> Optional[str]:
+def get_last_release_version(
+    git_tag_prefix: Optional[str] = "",
+) -> Optional[str]:
     """Get the last released Version from git.
 
     Returns:
@@ -45,7 +47,12 @@ def get_last_release_version() -> Optional[str]:
 
     git_interface = Git()
     tag_list = git_interface.list_tags()
-    return tag_list[-1] if tag_list else None
+
+    if not tag_list:
+        return None
+
+    last_release_version = tag_list[-1]
+    return last_release_version.strip(git_tag_prefix)
 
 
 def get_git_repository_name(

--- a/pontos/release/prepare.py
+++ b/pontos/release/prepare.py
@@ -85,22 +85,24 @@ class PrepareCommand:
         return git_version in git_tags
 
     def _create_changelog(self, release_version: str, cc_config: Path) -> str:
-        last_release_version = get_last_release_version()
+        last_release_version = get_last_release_version(self.git_tag_prefix)
         changelog_builder = ChangelogBuilder(
             terminal=self.terminal,
-            current_version=last_release_version,
-            next_version=release_version,
             space=self.space,
             project=self.project,
             config=cc_config,
             git_tag_prefix=self.git_tag_prefix,
         )
 
-        output_file = changelog_builder.create_changelog_file(
-            f"v{release_version}.md"
+        changelog_file = Path("changelog") / f"v{release_version}.md"
+
+        changelog_builder.create_changelog_file(
+            changelog_file,
+            last_version=last_release_version,
+            next_version=release_version,
         )
-        self.git.add(output_file)
-        return output_file.read_text(encoding="utf-8").replace(
+        self.git.add(changelog_file)
+        return changelog_file.read_text(encoding="utf-8").replace(
             "# Changelog\n\n"
             "All notable changes to this project "
             "will be documented in this file.\n\n",

--- a/tests/git/test_git.py
+++ b/tests/git/test_git.py
@@ -25,6 +25,13 @@ from pontos.git.git import ConfigScope, MergeStrategy, TagSort
 
 class GitTestCase(unittest.TestCase):
     @patch("pontos.git.git.exec_git")
+    def test_exec(self, exec_git_mock):
+        git = Git()
+        git.exec("foo", "bar", "baz")
+
+        exec_git_mock.assert_called_once_with("foo", "bar", "baz", cwd=None)
+
+    @patch("pontos.git.git.exec_git")
     def test_clone(self, exec_git_mock):
         git = Git()
         git.clone("http://foo/foo.git", Path("/bar"))

--- a/tests/git/test_git.py
+++ b/tests/git/test_git.py
@@ -500,3 +500,18 @@ e6ea80d Update README
 
         self.assertEqual(logs[0], "50f9963 Add CircleCI config for pontos")
         self.assertEqual(logs[5], "464f24d Initial commit")
+
+    @patch("pontos.git.git.exec_git")
+    def test_rev_list(self, exec_git_mock):
+        git = Git()
+        git.rev_list("foo", "bar", "baz", max_parents=123, abbrev_commit=True)
+
+        exec_git_mock.assert_called_once_with(
+            "rev-list",
+            "--max-parents=123",
+            "--abbrev-commit",
+            "foo",
+            "bar",
+            "baz",
+            cwd=None,
+        )

--- a/tests/release/test_helper.py
+++ b/tests/release/test_helper.py
@@ -108,3 +108,11 @@ class GetLastReleaseVersionTestCase(unittest.TestCase):
         git_interface = _git_interface_mock.return_value
         git_interface.list_tags.return_value = []
         self.assertIsNone(get_last_release_version())
+
+    @patch("pontos.release.helper.Git", spec=Git)
+    def test_get_last_release_version_with_git_prefix(
+        self, _git_interface_mock
+    ):
+        git_interface = _git_interface_mock.return_value
+        git_interface.list_tags.return_value = ["v1", "v2", "v3.55"]
+        self.assertEqual(get_last_release_version("v"), "3.55")


### PR DESCRIPTION
## What

Release with empty changelog.

Refactor ChangelogBuilder
* allow creating changelogs for different releases with one ChangelogBuilder instance
* don't require writing a generated changelog to a file
* remove changelog_dir settings from the conventional commit config
* fix GitHub diff links for first releases
* allow to create releases with empty changes
* fix several issues with git tag prefixes

## Why

We need to be able to create releases without requiring having conventional commit changes.

## References

DEVOPS-548

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


