### PR TITLE
Changelog output and cli

### DIFF
--- a/pontos/changelog/__init__.py
+++ b/pontos/changelog/__init__.py
@@ -16,8 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .conventional_commits import ChangelogBuilder, main
+from .conventional_commits import ChangelogBuilder
 from .errors import ChangelogBuilderError, ChangelogError
+from .main import main
 
 __all__ = [
     "ChangelogError",

--- a/pontos/changelog/conventional_commits.py
+++ b/pontos/changelog/conventional_commits.py
@@ -28,7 +28,6 @@ import tomlkit
 
 from pontos.changelog.errors import ChangelogBuilderError
 from pontos.git import Git
-from pontos.terminal import Terminal
 from pontos.terminal.null import NullTerminal
 from pontos.terminal.rich import RichTerminal
 
@@ -52,14 +51,11 @@ class ChangelogBuilder:
     def __init__(
         self,
         *,
-        terminal: Terminal,
         space: str,
         project: str,
         git_tag_prefix: Optional[str] = "v",
         config: Optional[Path] = None,
     ):
-        self._terminal = terminal
-
         if config:
             if not config.exists():
                 raise ChangelogBuilderError(
@@ -191,7 +187,6 @@ class ChangelogBuilder:
                             f"{cleaned_msg} [{commit[0]}]"
                             f"({commit_link}{commit[0]})"
                         )
-                        self._terminal.info(f"{commit[0]}: {cleaned_msg}")
 
         return commit_dict
 
@@ -352,7 +347,6 @@ def main(
     with term.indent():
         try:
             changelog_builder = ChangelogBuilder(
-                terminal=term,
                 config=parsed_args.config,
                 project=args.project,
                 space=args.space,

--- a/pontos/changelog/main.py
+++ b/pontos/changelog/main.py
@@ -15,9 +15,111 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-# pylint: disable=invalid-name
+import sys
+from argparse import ArgumentParser
+from pathlib import Path
+from typing import Iterable, NoReturn
 
-from .conventional_commits import main
+from pontos.changelog.conventional_commits import ChangelogBuilder
+from pontos.errors import PontosError
+from pontos.release.helper import get_last_release_version
+from pontos.terminal.null import NullTerminal
+from pontos.terminal.rich import RichTerminal
+
+
+def parse_args(args: Iterable[str] = None) -> ArgumentParser:
+    parser = ArgumentParser(
+        description="Conventional commits utility.",
+        prog="pontos-changelog",
+    )
+
+    parser.add_argument(
+        "--config",
+        "-C",
+        default="changelog.toml",
+        type=Path,
+        help="Conventional commits config file (toml), including conventions.",
+    )
+
+    parser.add_argument(
+        "--project",
+        required=True,
+        help="The github project",
+    )
+
+    parser.add_argument(
+        "--space",
+        default="greenbone",
+        help="User/Team name in github",
+    )
+
+    parser.add_argument(
+        "--current-version",
+        help="Current version before these changes",
+    )
+
+    parser.add_argument(
+        "--next-version",
+        help="The planned release version",
+    )
+
+    parser.add_argument(
+        "--git-tag-prefix",
+        default="v",
+        help="Prefix for git tag versions. Default: %(default)s",
+    )
+
+    parser.add_argument(
+        "--output",
+        "-o",
+        type=Path,
+        help="Write changelog to this file.",
+    )
+
+    parser.add_argument(
+        "--quiet",
+        "-q",
+        action="store_true",
+        help="Don't print messages to the terminal",
+    )
+
+    return parser.parse_args(args=args)
+
+
+def main(args: Iterable[str] = None) -> NoReturn:
+    parsed_args = parse_args(args)
+
+    term = NullTerminal if parsed_args.quiet else RichTerminal()
+
+    if parsed_args.current_version:
+        last_version = parsed_args.current_version
+    else:
+        last_version = get_last_release_version(parsed_args.git_tag_prefix)
+
+    try:
+        changelog_builder = ChangelogBuilder(
+            config=parsed_args.config,
+            project=parsed_args.project,
+            space=parsed_args.space,
+        )
+        if parsed_args.output:
+            changelog_builder.create_changelog_file(
+                parsed_args.output,
+                last_version=last_version,
+                next_version=parsed_args.next_version,
+            )
+        else:
+            changelog = changelog_builder.create_changelog(
+                last_version=last_version,
+                next_version=parsed_args.next_version,
+            )
+            print(changelog)
+    except PontosError as e:
+        term.error(str(e))
+        sys.exit(1)
+
+    sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/pontos/release/prepare.py
+++ b/pontos/release/prepare.py
@@ -87,7 +87,6 @@ class PrepareCommand:
     def _create_changelog(self, release_version: str, cc_config: Path) -> str:
         last_release_version = get_last_release_version(self.git_tag_prefix)
         changelog_builder = ChangelogBuilder(
-            terminal=self.terminal,
             space=self.space,
             project=self.project,
             config=cc_config,

--- a/tests/changelog/test_conventional_commits.py
+++ b/tests/changelog/test_conventional_commits.py
@@ -40,8 +40,6 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 
     @patch("pontos.changelog.conventional_commits.Git", autospec=True)
     def test_changelog_builder(self, git_mock: MagicMock):
-        terminal = MagicMock()
-
         today = datetime.today().strftime("%Y-%m-%d")
 
         own_path = Path(__file__).absolute().parent
@@ -92,7 +90,6 @@ All notable changes to this project will be documented in this file.
 [0.0.2]: https://github.com/foo/bar/compare/v0.0.1...v0.0.2"""
 
         changelog_builder = ChangelogBuilder(
-            terminal=terminal,
             space="foo",
             project="bar",
             config=config_toml,
@@ -109,8 +106,6 @@ All notable changes to this project will be documented in this file.
 
     @patch("pontos.changelog.conventional_commits.Git", autospec=True)
     def test_changelog_builder_no_commits(self, git_mock: MagicMock):
-        terminal = MagicMock()
-
         today = datetime.today().strftime("%Y-%m-%d")
 
         own_path = Path(__file__).absolute().parent
@@ -126,7 +121,6 @@ All notable changes to this project will be documented in this file.
         git_mock.return_value.log.return_value = []
 
         changelog_builder = ChangelogBuilder(
-            terminal=terminal,
             space="foo",
             project="bar",
             config=config_toml,
@@ -143,8 +137,6 @@ All notable changes to this project will be documented in this file.
 
     @patch("pontos.changelog.conventional_commits.Git", autospec=True)
     def test_changelog_builder_no_last_version(self, git_mock: MagicMock):
-        terminal = MagicMock()
-
         today = datetime.today().strftime("%Y-%m-%d")
 
         own_path = Path(__file__).absolute().parent
@@ -195,7 +187,6 @@ All notable changes to this project will be documented in this file.
 [0.0.2]: https://github.com/foo/bar/compare/123...v0.0.2"""
 
         changelog_builder = ChangelogBuilder(
-            terminal=terminal,
             project="bar",
             space="foo",
             config=config_toml,
@@ -208,8 +199,6 @@ All notable changes to this project will be documented in this file.
 
     @patch("pontos.changelog.conventional_commits.Git", autospec=True)
     def test_changelog_builder_no_next_version(self, git_mock: MagicMock):
-        terminal = MagicMock()
-
         own_path = Path(__file__).absolute().parent
         config_toml = own_path / "changelog.toml"
 
@@ -258,7 +247,6 @@ All notable changes to this project will be documented in this file.
 [Unreleased]: https://github.com/foo/bar/compare/v0.0.1...HEAD"""
 
         changelog_builder = ChangelogBuilder(
-            terminal=terminal,
             project="bar",
             space="foo",
             config=config_toml,
@@ -275,8 +263,6 @@ All notable changes to this project will be documented in this file.
     def test_changelog_builder_no_next_and_last_version(
         self, git_mock: MagicMock
     ):
-        terminal = MagicMock()
-
         own_path = Path(__file__).absolute().parent
         config_toml = own_path / "changelog.toml"
 
@@ -325,7 +311,6 @@ All notable changes to this project will be documented in this file.
 [Unreleased]: https://github.com/foo/bar/compare/123...HEAD"""
 
         changelog_builder = ChangelogBuilder(
-            terminal=terminal,
             project="bar",
             space="foo",
             config=config_toml,
@@ -340,8 +325,6 @@ All notable changes to this project will be documented in this file.
     def test_changelog_builder_no_conventional_commits(
         self, git_mock: MagicMock
     ):
-        terminal = MagicMock()
-
         today = datetime.today().strftime("%Y-%m-%d")
 
         own_path = Path(__file__).absolute().parent
@@ -360,7 +343,6 @@ All notable changes to this project will be documented in this file.
             "8abcdef bar baz",
         ]
         changelog_builder = ChangelogBuilder(
-            terminal=terminal,
             space="foo",
             project="bar",
             config=config_toml,
@@ -376,14 +358,11 @@ All notable changes to this project will be documented in this file.
         )
 
     def test_changelog_builder_config_file_not_exists(self):
-        terminal = MagicMock()
-
         with temp_directory() as temp_dir, self.assertRaisesRegex(
             ChangelogBuilderError,
             r"Changelog Config file '.*\.toml' does not exist\.",
         ):
             ChangelogBuilder(
-                terminal=terminal,
                 space="foo",
                 project="bar",
                 config=temp_dir / "changelog.toml",
@@ -393,8 +372,6 @@ All notable changes to this project will be documented in this file.
     def test_changelog_builder_with_default_changelog_config(
         self, git_mock: MagicMock
     ):
-        terminal = MagicMock()
-
         today = datetime.today().strftime("%Y-%m-%d")
 
         git_mock.return_value.log.return_value = [
@@ -411,7 +388,6 @@ All notable changes to this project will be documented in this file.
         ]
 
         changelog_builder = ChangelogBuilder(
-            terminal=terminal,
             space="foo",
             project="bar",
         )
@@ -449,8 +425,6 @@ All notable changes to this project will be documented in this file.
     def test_changelog_builder_with_empty_git_tag_prefix(
         self, git_mock: MagicMock
     ):
-        terminal = MagicMock()
-
         today = datetime.today().strftime("%Y-%m-%d")
 
         git_mock.return_value.log.return_value = [
@@ -467,7 +441,6 @@ All notable changes to this project will be documented in this file.
         ]
 
         changelog_builder = ChangelogBuilder(
-            terminal=terminal,
             space="foo",
             project="bar",
             git_tag_prefix="",
@@ -504,8 +477,6 @@ All notable changes to this project will be documented in this file.
 
     @patch("pontos.changelog.conventional_commits.Git", autospec=True)
     def test_write_changelog_to_file(self, git_mock: MagicMock):
-        terminal = MagicMock()
-
         today = datetime.today().strftime("%Y-%m-%d")
 
         own_path = Path(__file__).absolute().parent
@@ -556,7 +527,7 @@ All notable changes to this project will be documented in this file.
 [0.0.2]: https://github.com/foo/bar/compare/v0.0.1...v0.0.2"""
 
         changelog_builder = ChangelogBuilder(
-            terminal=terminal, space="foo", project="bar", config=config_toml
+            space="foo", project="bar", config=config_toml
         )
 
         with temp_directory() as temp_dir:

--- a/tests/changelog/test_conventional_commits.py
+++ b/tests/changelog/test_conventional_commits.py
@@ -25,7 +25,6 @@ from unittest.mock import MagicMock, patch
 from pontos.changelog.conventional_commits import (
     ChangelogBuilder,
     ChangelogBuilderError,
-    parse_args,
 )
 from pontos.testing import temp_directory
 
@@ -542,14 +541,3 @@ All notable changes to this project will be documented in this file.
         git_mock.return_value.log.assert_called_once_with(
             "v0.0.1..HEAD", oneline=True
         )
-
-
-class ParseArgsTestCase(unittest.TestCase):
-    def test_parse_args(self):
-        parsed_args = parse_args(
-            ["-q", "--log-file", "blah", "--project", "urghs"]
-        )
-
-        self.assertTrue(parsed_args.quiet)
-        self.assertEqual(parsed_args.log_file, "blah")
-        self.assertEqual(parsed_args.project, "urghs")

--- a/tests/changelog/test_parser.py
+++ b/tests/changelog/test_parser.py
@@ -1,0 +1,52 @@
+# Copyright (C) 2021-2023 Greenbone Networks GmbH
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import unittest
+from pathlib import Path
+
+from pontos.changelog.main import parse_args
+
+
+class ParseArgsTestCase(unittest.TestCase):
+    def test_parse_args(self):
+        parsed_args = parse_args(
+            [
+                "-q",
+                "--project",
+                "urghs",
+                "--space",
+                "bla",
+                "--config",
+                "foo.toml",
+                "--current-version",
+                "1.2.3",
+                "--next-version",
+                "2.3.4",
+                "--git-tag-prefix",
+                "a",
+                "--output",
+                "changelog.md",
+            ]
+        )
+
+        self.assertTrue(parsed_args.quiet)
+        self.assertEqual(parsed_args.project, "urghs")
+        self.assertEqual(parsed_args.space, "bla")
+        self.assertEqual(parsed_args.config, Path("foo.toml"))
+        self.assertEqual(parsed_args.current_version, "1.2.3")
+        self.assertEqual(parsed_args.next_version, "2.3.4")
+        self.assertEqual(parsed_args.git_tag_prefix, "a")
+        self.assertEqual(parsed_args.output, Path("changelog.md"))


### PR DESCRIPTION
## What

Remove terminal from ChangelogBuilder and improve `pontos-changelog` CLI

## Why

Don't write output to the console in ChangelogBuilder and make `pontos-changelog` behave similar to `pontos-release prepare`.


