### PR TITLE
Additional release types

### DIFF
--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -31,8 +31,9 @@ class ReleaseType(Enum):
     VERSION = "version"
     MAJOR = "major"
     MINOR = "minor"
-    # for the future we need
-    # PRE_RELEASE = "pre-release"
+    ALPHA = "alpha"
+    BETA = "beta"
+    RELEASE_CANDIDATE = "release-candidate"
 
 
 def get_last_release_version(

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -238,13 +238,13 @@ class ReleaseCommand:
         next_version = (
             next_version
             if next_version is not None
-            else calculator.next_patch_version(release_version)
+            else calculator.next_dev_version(release_version)
         )
 
         self.terminal.info("Updating version after release")
 
         try:
-            updated = command.update_version(next_version, develop=True)
+            updated = command.update_version(next_version)
         except VersionError as e:
             self.terminal.error(
                 f"Error while updating version after release. {e}"

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -77,6 +77,15 @@ class ReleaseCommand:
         if release_type == ReleaseType.MAJOR:
             return calculator.next_major_version(current_version)
 
+        if release_type == ReleaseType.ALPHA:
+            return calculator.next_alpha_version(current_version)
+
+        if release_type == ReleaseType.BETA:
+            return calculator.next_beta_version(current_version)
+
+        if release_type == ReleaseType.RELEASE_CANDIDATE:
+            return calculator.next_release_candidate_version(current_version)
+
         if not release_version:
             raise VersionError(
                 "No release version provided. Either use a different release "

--- a/pontos/version/calculator.py
+++ b/pontos/version/calculator.py
@@ -114,3 +114,111 @@ class VersionCalculator:
             return str(release_version)
         except InvalidVersion as e:
             raise VersionError(e) from None
+
+    def next_dev_version(self, version: str) -> str:
+        try:
+            current_version = Version(version)
+            if current_version.is_devrelease:
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro }.dev{current_version.dev + 1}"
+                )
+            else:
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro + 1 }.dev1"
+                )
+
+            return str(release_version)
+        except InvalidVersion as e:
+            raise VersionError(e) from None
+
+    def next_alpha_version(self, version: str) -> str:
+        try:
+            current_version = Version(version)
+            if current_version.is_devrelease:
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro }a1"
+                )
+            elif (
+                current_version.is_prerelease and current_version.pre[0] == "a"
+            ):
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro }a{current_version.pre[1] + 1}"
+                )
+            else:
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro + 1 }a1"
+                )
+
+            return str(release_version)
+        except InvalidVersion as e:
+            raise VersionError(e) from None
+
+    def next_beta_version(self, version: str) -> str:
+        try:
+            current_version = Version(version)
+            if current_version.is_devrelease or (
+                current_version.is_prerelease and current_version.pre[0] == "a"
+            ):
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro }b1"
+                )
+            elif (
+                current_version.is_prerelease and current_version.pre[0] == "b"
+            ):
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro }b{current_version.pre[1] + 1}"
+                )
+            else:
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro + 1 }b1"
+                )
+
+            return str(release_version)
+        except InvalidVersion as e:
+            raise VersionError(e) from None
+
+    def next_release_candidate_version(self, version: str) -> str:
+        try:
+            current_version = Version(version)
+            if current_version.is_devrelease or (
+                current_version.is_prerelease and current_version.pre[0] != "rc"
+            ):
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro }rc1"
+                )
+            elif (
+                current_version.is_prerelease and current_version.pre[0] == "rc"
+            ):
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro }rc{current_version.pre[1] + 1}"
+                )
+            else:
+                release_version = Version(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.micro + 1 }rc1"
+                )
+
+            return str(release_version)
+        except InvalidVersion as e:
+            raise VersionError(e) from None

--- a/pontos/version/cmake.py
+++ b/pontos/version/cmake.py
@@ -35,7 +35,7 @@ class CMakeVersionCommand(VersionCommand):
     project_file_name = "CMakeLists.txt"
 
     def update_version(
-        self, new_version: str, *, develop: bool = False, force: bool = False
+        self, new_version: str, *, force: bool = False
     ) -> VersionUpdate:
         content = self.project_file_path.read_text(encoding="utf-8")
         cmvp = CMakeVersionParser(content)
@@ -44,7 +44,7 @@ class CMakeVersionCommand(VersionCommand):
         if not force and versions_equal(new_version, previous_version):
             return VersionUpdate(previous=previous_version, new=new_version)
 
-        new_content = cmvp.update_version(new_version, develop=develop)
+        new_content = cmvp.update_version(new_version)
         self.project_file_path.write_text(new_content, encoding="utf-8")
         return VersionUpdate(
             previous=previous_version,
@@ -94,7 +94,7 @@ class CMakeVersionParser:
             return f"{self._current_version}.dev1"
         return self._current_version
 
-    def update_version(self, new_version: str, *, develop: bool = False) -> str:
+    def update_version(self, new_version: str) -> str:
         if not is_version_pep440_compliant(new_version):
             raise VersionError(
                 f"version {new_version} is not pep 440 compliant."
@@ -111,6 +111,8 @@ class CMakeVersionParser:
                     )
                 )
             develop = True
+        else:
+            develop = False
 
         to_update = self._cmake_content_lines[self._version_line_number]
         updated = to_update.replace(self._current_version, new_version)

--- a/pontos/version/go.py
+++ b/pontos/version/go.py
@@ -21,12 +21,7 @@ from pathlib import Path
 from pontos.git import Git, TagSort
 
 from .errors import VersionError
-from .helper import (
-    check_develop,
-    is_version_pep440_compliant,
-    safe_version,
-    versions_equal,
-)
+from .helper import is_version_pep440_compliant, safe_version, versions_equal
 from .version import VersionCommand, VersionUpdate
 
 TEMPLATE = """package main
@@ -88,12 +83,10 @@ class GoVersionCommand(VersionCommand):
             )
 
     def update_version(
-        self, new_version: str, *, develop: bool = False, force: bool = False
+        self, new_version: str, *, force: bool = False
     ) -> VersionUpdate:
         """Update the current version of this project"""
         new_version = safe_version(new_version)
-        if not check_develop(new_version) and develop:
-            new_version = f"{new_version}.dev1"
 
         try:
             current_version = self.get_current_version()

--- a/pontos/version/javascript.py
+++ b/pontos/version/javascript.py
@@ -21,7 +21,6 @@ from pathlib import Path
 from typing import Any
 
 from pontos.version.helper import (
-    check_develop,
     is_version_pep440_compliant,
     safe_version,
     versions_equal,
@@ -125,11 +124,9 @@ class JavaScriptVersionCommand(VersionCommand):
         return True
 
     def update_version(
-        self, new_version: str, *, develop: bool = False, force: bool = False
+        self, new_version: str, *, force: bool = False
     ) -> VersionUpdate:
         new_version = safe_version(new_version)
-        if not check_develop(new_version) and develop:
-            new_version = f"{new_version}.dev1"
 
         package_version = self.get_current_version()
         if not force and versions_equal(new_version, package_version):

--- a/pontos/version/python.py
+++ b/pontos/version/python.py
@@ -22,7 +22,6 @@ import tomlkit
 
 from .errors import VersionError
 from .helper import (
-    check_develop,
     is_version_pep440_compliant,
     safe_version,
     strip_version,
@@ -189,11 +188,9 @@ class PythonVersionCommand(VersionCommand):
                 )
 
     def update_version(
-        self, new_version: str, *, develop: bool = False, force: bool = False
+        self, new_version: str, *, force: bool = False
     ) -> VersionUpdate:
         new_version = safe_version(new_version)
-        if not check_develop(new_version) and develop:
-            new_version = f"{new_version}.dev1"
 
         try:
             current_version = self.get_current_version()

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -50,7 +50,7 @@ class VersionCommand(ABC):
 
     @abstractmethod
     def update_version(
-        self, new_version: str, *, develop: bool = False, force: bool = False
+        self, new_version: str, *, force: bool = False
     ) -> VersionUpdate:
         """Update the current version of this project"""
 

--- a/tests/release/test_parser.py
+++ b/tests/release/test_parser.py
@@ -116,6 +116,28 @@ class ReleaseParseArgsTestCase(unittest.TestCase):
 
         self.assertEqual(args.release_type, ReleaseType.CALENDAR)
 
+        _, _, args = parse_args(["release", "--release-type", "minor"])
+
+        self.assertEqual(args.release_type, ReleaseType.MINOR)
+
+        _, _, args = parse_args(["release", "--release-type", "major"])
+
+        self.assertEqual(args.release_type, ReleaseType.MAJOR)
+
+        _, _, args = parse_args(["release", "--release-type", "alpha"])
+
+        self.assertEqual(args.release_type, ReleaseType.ALPHA)
+
+        _, _, args = parse_args(["release", "--release-type", "beta"])
+
+        self.assertEqual(args.release_type, ReleaseType.BETA)
+
+        _, _, args = parse_args(
+            ["release", "--release-type", "release-candidate"]
+        )
+
+        self.assertEqual(args.release_type, ReleaseType.RELEASE_CANDIDATE)
+
         with self.assertRaises(SystemExit), redirect_stderr(StringIO()):
             parse_args(["release", "--release-type", "foo"])
 

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -99,7 +99,7 @@ class ReleaseTestCase(unittest.TestCase):
         )
 
         version_command_mock.update_version.assert_has_calls(
-            [call("0.0.2"), call("1.0.0.dev1", develop=True)]
+            [call("0.0.2"), call("1.0.0.dev1")]
         )
 
         self.assertEqual(
@@ -161,10 +161,8 @@ class ReleaseTestCase(unittest.TestCase):
             ),
         ]
         version_command_mock.get_current_version.return_value = "0.0.1"
-        version_calculator = MagicMock(spec=VersionCalculator)
-        version_calculator.next_patch_version.return_value = "0.0.2"
         version_command_mock.get_version_calculator.return_value = (
-            version_calculator
+            VersionCalculator()
         )
 
         _, token, args = parse_args(
@@ -194,9 +192,8 @@ class ReleaseTestCase(unittest.TestCase):
                 call(follow_tags=True, remote=None),
             ],
         )
-        version_calculator.next_patch_version.assert_called_once_with("0.0.1")
         version_command_mock.update_version.assert_has_calls(
-            [call("0.0.2"), call("1.0.0.dev1", develop=True)],
+            [call("0.0.2"), call("1.0.0.dev1")],
         )
 
         self.assertEqual(
@@ -295,7 +292,7 @@ class ReleaseTestCase(unittest.TestCase):
             "0.0.1"
         )
         version_command_mock.update_version.assert_has_calls(
-            [call("23.2.0"), call("23.2.1.dev1", develop=True)]
+            [call("23.2.0"), call("23.2.1.dev1")]
         )
 
         self.assertEqual(
@@ -357,10 +354,8 @@ class ReleaseTestCase(unittest.TestCase):
             ),
         ]
         version_command_mock.get_current_version.return_value = "0.0.1"
-        version_calculator = MagicMock(spec=VersionCalculator)
-        version_calculator.next_minor_version.return_value = "0.1.0"
         version_command_mock.get_version_calculator.return_value = (
-            version_calculator
+            VersionCalculator()
         )
 
         _, token, args = parse_args(
@@ -390,9 +385,8 @@ class ReleaseTestCase(unittest.TestCase):
                 call(follow_tags=True, remote=None),
             ],
         )
-        version_calculator.next_minor_version.assert_called_once_with("0.0.1")
         version_command_mock.update_version.assert_has_calls(
-            [call("0.1.0"), call("0.1.1.dev1", develop=True)],
+            [call("0.1.0"), call("0.1.1.dev1")],
         )
 
         self.assertEqual(
@@ -454,10 +448,8 @@ class ReleaseTestCase(unittest.TestCase):
             ),
         ]
         version_command_mock.get_current_version.return_value = "0.0.1"
-        version_calculator = MagicMock(spec=VersionCalculator)
-        version_calculator.next_major_version.return_value = "1.0.0"
         version_command_mock.get_version_calculator.return_value = (
-            version_calculator
+            VersionCalculator()
         )
 
         _, token, args = parse_args(
@@ -487,9 +479,8 @@ class ReleaseTestCase(unittest.TestCase):
                 call(follow_tags=True, remote=None),
             ],
         )
-        version_calculator.next_major_version.assert_called_once_with("0.0.1")
         version_command_mock.update_version.assert_has_calls(
-            [call("1.0.0"), call("1.0.1.dev1", develop=True)],
+            [call("1.0.0"), call("1.0.1.dev1")],
         )
 
         self.assertEqual(
@@ -832,7 +823,7 @@ class ReleaseTestCase(unittest.TestCase):
         )
 
         version_command_mock.update_version.assert_has_calls(
-            [call("0.0.1"), call("0.0.2.dev1", develop=True)]
+            [call("0.0.1"), call("0.0.2.dev1")]
         )
 
         self.assertEqual(
@@ -1127,7 +1118,7 @@ class ReleaseTestCase(unittest.TestCase):
         )
         git_mock.return_value.commit.assert_called_with(
             "Automatic adjustments after release\n\n"
-            "* Update to version 0.0.3\n",
+            "* Update to version 0.0.3.dev1\n",
             verify=False,
             gpg_signing_key="1234",
         )
@@ -1235,7 +1226,7 @@ class ReleaseTestCase(unittest.TestCase):
         )
 
         version_command_mock.update_version.assert_has_calls(
-            [call("0.0.2"), call("1.0.0.dev1", develop=True)]
+            [call("0.0.2"), call("1.0.0.dev1")]
         )
 
         self.assertEqual(

--- a/tests/version/test_calculator.py
+++ b/tests/version/test_calculator.py
@@ -172,3 +172,153 @@ class VersionCalculatorTestCase(unittest.TestCase):
         calculator = VersionCalculator()
         with self.assertRaisesRegex(VersionError, "Invalid version: 'abc'"):
             calculator.next_major_version("abc")
+
+    def test_next_alpha_version(self):
+        calculator = VersionCalculator()
+
+        current_versions = [
+            "0.0.1",
+            "1.2.3",
+            "1.2.3.post1",
+            "1.2.3a1",
+            "1.2.3b1",
+            "1.2.3rc1",
+            "22.4.1",
+            "22.4.1.dev1",
+            "22.4.1.dev3",
+        ]
+        assert_versions = [
+            "0.0.2a1",
+            "1.2.4a1",
+            "1.2.4a1",
+            "1.2.3a2",
+            "1.2.4a1",
+            "1.2.4a1",
+            "22.4.2a1",
+            "22.4.1a1",
+            "22.4.1a1",
+        ]
+
+        for current_version, assert_version in zip(
+            current_versions, assert_versions
+        ):
+            release_version = calculator.next_alpha_version(current_version)
+            self.assertEqual(release_version, assert_version)
+
+    def test_next_alpha_version_error(self):
+        calculator = VersionCalculator()
+        with self.assertRaisesRegex(VersionError, "Invalid version: 'abc'"):
+            calculator.next_alpha_version("abc")
+
+    def test_next_beta_version(self):
+        calculator = VersionCalculator()
+
+        current_versions = [
+            "0.0.1",
+            "1.2.3",
+            "1.2.3.post1",
+            "1.2.3a1",
+            "1.2.3b1",
+            "1.2.3rc1",
+            "22.4.1",
+            "22.4.1.dev1",
+            "22.4.1.dev3",
+        ]
+        assert_versions = [
+            "0.0.2b1",
+            "1.2.4b1",
+            "1.2.4b1",
+            "1.2.3b1",
+            "1.2.3b2",
+            "1.2.4b1",
+            "22.4.2b1",
+            "22.4.1b1",
+            "22.4.1b1",
+        ]
+
+        for current_version, assert_version in zip(
+            current_versions, assert_versions
+        ):
+            release_version = calculator.next_beta_version(current_version)
+            self.assertEqual(release_version, assert_version)
+
+    def test_next_beta_version_error(self):
+        calculator = VersionCalculator()
+        with self.assertRaisesRegex(VersionError, "Invalid version: 'abc'"):
+            calculator.next_beta_version("abc")
+
+    def test_next_release_candidate_version(self):
+        calculator = VersionCalculator()
+
+        current_versions = [
+            "0.0.1",
+            "1.2.3",
+            "1.2.3.post1",
+            "1.2.3a1",
+            "1.2.3b1",
+            "1.2.3rc1",
+            "22.4.1",
+            "22.4.1.dev1",
+            "22.4.1.dev3",
+        ]
+        assert_versions = [
+            "0.0.2rc1",
+            "1.2.4rc1",
+            "1.2.4rc1",
+            "1.2.3rc1",
+            "1.2.3rc1",
+            "1.2.3rc2",
+            "22.4.2rc1",
+            "22.4.1rc1",
+            "22.4.1rc1",
+        ]
+
+        for current_version, assert_version in zip(
+            current_versions, assert_versions
+        ):
+            release_version = calculator.next_release_candidate_version(
+                current_version
+            )
+            self.assertEqual(release_version, assert_version)
+
+    def test_next_release_candidate_version_error(self):
+        calculator = VersionCalculator()
+        with self.assertRaisesRegex(VersionError, "Invalid version: 'abc'"):
+            calculator.next_release_candidate_version("abc")
+
+    def test_next_dev_version(self):
+        calculator = VersionCalculator()
+
+        current_versions = [
+            "0.0.1",
+            "1.2.3",
+            "1.2.3.post1",
+            "1.2.3a1",
+            "1.2.3b1",
+            "1.2.3rc1",
+            "22.4.1",
+            "22.4.1.dev1",
+            "22.4.1.dev3",
+        ]
+        assert_versions = [
+            "0.0.2.dev1",
+            "1.2.4.dev1",
+            "1.2.4.dev1",
+            "1.2.4.dev1",
+            "1.2.4.dev1",
+            "1.2.4.dev1",
+            "22.4.2.dev1",
+            "22.4.1.dev2",
+            "22.4.1.dev4",
+        ]
+
+        for current_version, assert_version in zip(
+            current_versions, assert_versions
+        ):
+            release_version = calculator.next_dev_version(current_version)
+            self.assertEqual(release_version, assert_version)
+
+    def test_next_dev_version_error(self):
+        calculator = VersionCalculator()
+        with self.assertRaisesRegex(VersionError, "Invalid version: 'abc'"):
+            calculator.next_dev_version("abc")

--- a/tests/version/test_cmake_version.py
+++ b/tests/version/test_cmake_version.py
@@ -101,14 +101,14 @@ class UpdateCMakeVersionCommandTestCase(unittest.TestCase):
             change_into=True,
         ) as temp:
             cmake = CMakeVersionCommand()
-            updated = cmake.update_version("22", develop=True)
+            updated = cmake.update_version("22.dev1")
 
             self.assertEqual(
-                "project(VERSION 22)\nset(PROJECT_DEV_VERSION 1)",
+                "project(VERSION 22.0.0)\nset(PROJECT_DEV_VERSION 1)",
                 temp.read_text(encoding="utf8"),
             )
             self.assertEqual(updated.previous, "21")
-            self.assertEqual(updated.new, "22")
+            self.assertEqual(updated.new, "22.dev1")
             self.assertEqual(updated.changed_files, [temp])
 
     def test_no_update(self):
@@ -216,7 +216,7 @@ class CMakeVersionParserTestCase(unittest.TestCase):
 
         self.assertEqual(under_test._project_dev_version_line_number, 7)
         self.assertEqual(under_test._project_dev_version, "1")
-        result = under_test.update_version("41.41.41", develop=False)
+        result = under_test.update_version("41.41.41")
         self.assertEqual(under_test._project_dev_version, "0")
         self.assertEqual(
             result,
@@ -238,7 +238,7 @@ class CMakeVersionParserTestCase(unittest.TestCase):
 
         self.assertEqual(under_test._project_dev_version_line_number, 4)
         self.assertEqual(under_test._project_dev_version, "1")
-        result = under_test.update_version("41.41.41", develop=False)
+        result = under_test.update_version("41.41.41")
         self.assertEqual(under_test._project_dev_version, "0")
         self.assertEqual(
             result,

--- a/tests/version/test_javascript_version.py
+++ b/tests/version/test_javascript_version.py
@@ -84,28 +84,12 @@ class UpdateJavaScriptVersionCommandTestCase(unittest.TestCase):
 
             self.assertEqual(fake_package["version"], "22.4.0")
 
-    def test_update_version_check_develop(self):
-        content = '{"name":"foo", "version":"1.2.3"}'
-
-        with temp_file(content, name="package.json", change_into=True) as temp:
-            cmd = JavaScriptVersionCommand()
-            updated = cmd.update_version("22.4.0.dev1", develop=True)
-
-            self.assertEqual(updated.previous, "1.2.3")
-            self.assertEqual(updated.new, "22.4.0.dev1")
-            self.assertEqual(updated.changed_files, [temp])
-
-            with temp.open(mode="r", encoding="utf-8") as fp:
-                fake_package = json.load(fp)
-
-            self.assertEqual(fake_package["version"], "22.4.0.dev1")
-
     def test_update_version_develop(self):
         content = '{"name":"foo", "version":"1.2.3"}'
 
         with temp_file(content, name="package.json", change_into=True) as temp:
             cmd = JavaScriptVersionCommand()
-            updated = cmd.update_version("22.4.0", develop=True)
+            updated = cmd.update_version("22.4.0.dev1")
 
             self.assertEqual(updated.previous, "1.2.3")
             self.assertEqual(updated.new, "22.4.0.dev1")

--- a/tests/version/test_python_version.py
+++ b/tests/version/test_python_version.py
@@ -227,29 +227,7 @@ class UpdatePythonVersionTestCase(unittest.TestCase):
                 encoding="utf8",
             )
             cmd = PythonVersionCommand()
-            updated = cmd.update_version("22.2", develop=True)
-
-            self.assertEqual(updated.new, "22.2.dev1")
-            self.assertEqual(updated.previous, "1.2.3")
-            self.assertEqual(updated.changed_files, [Path("foo.py"), tmp_file])
-
-            text = tmp_file.read_text(encoding="utf8")
-
-            toml = tomlkit.parse(text)
-
-            self.assertEqual(toml["tool"]["poetry"]["version"], "22.2.dev1")
-
-    def test_not_override_development_version(self):
-        content = "__version__ = '1.2.3'"
-        with temp_python_module(content, name="foo", change_into=True) as temp:
-            tmp_file = temp.parent / "pyproject.toml"
-            tmp_file.write_text(
-                '[tool.poetry]\nversion = "1.2.3"\n'
-                '[tool.pontos.version]\nversion-module-file = "foo.py"',
-                encoding="utf8",
-            )
-            cmd = PythonVersionCommand()
-            updated = cmd.update_version("22.2.dev1", develop=True)
+            updated = cmd.update_version("22.2.dev1")
 
             self.assertEqual(updated.new, "22.2.dev1")
             self.assertEqual(updated.previous, "1.2.3")


### PR DESCRIPTION
## What

Support alpha, beta and release-candidate releases.

The PR introduces `pontos-release release --release-type` with `alpha`, `beta` and `release-candidate`.

## Why

It should be possible to create all kind of pre-releases.

## References

DEVOPS-560

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


