### PR TITLE
Sign last tag as release version

### DIFF
--- a/pontos/git/git.py
+++ b/pontos/git/git.py
@@ -21,8 +21,10 @@ from os import PathLike, fspath
 from pathlib import Path
 from typing import List, Optional, Union
 
+from pontos.errors import PontosError
 
-class GitError(subprocess.CalledProcessError):
+
+class GitError(subprocess.CalledProcessError, PontosError):
     """
     Error raised while executing a git command
     """

--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -19,6 +19,7 @@ from enum import Enum
 from typing import Optional
 
 from pontos.git import Git, GitError
+from pontos.git.git import TagSort
 from pontos.terminal import Terminal
 
 DEFAULT_TIMEOUT = 1000
@@ -47,7 +48,7 @@ def get_last_release_version(
     """
 
     git_interface = Git()
-    tag_list = git_interface.list_tags()
+    tag_list = git_interface.list_tags(sort=TagSort.VERSION)
 
     if not tag_list:
         return None

--- a/pontos/release/sign.py
+++ b/pontos/release/sign.py
@@ -33,9 +33,8 @@ from pontos.github.api import GitHubAsyncRESTApi
 from pontos.helper import AsyncDownloadProgressIterable
 from pontos.terminal import Terminal
 from pontos.terminal.rich import RichTerminal
-from pontos.version.commands import gather_project
 
-from .helper import get_git_repository_name
+from .helper import get_git_repository_name, get_last_release_version
 
 
 class SignReturnValue(IntEnum):
@@ -65,13 +64,6 @@ async def cmd_runner(*args: Iterable[str]) -> Process:
 class SignCommand:
     def __init__(self, terminal: RichTerminal) -> None:
         self.terminal = terminal
-
-    def _get_current_version(self) -> str:
-        """
-        Get the current Version for the current project
-        """
-
-        return gather_project().get_current_version()
 
     async def _async_download_progress(
         self,
@@ -205,10 +197,10 @@ class SignCommand:
             release_version = (
                 release_version
                 if release_version is not None
-                else self._get_current_version()
+                else get_last_release_version(git_tag_prefix)
             )
         except PontosError as e:
-            self.terminal.error(f"Could not determine current version. {e}")
+            self.terminal.error(f"Could not determine release version. {e}")
             return SignReturnValue.NO_RELEASE_VERSION
 
         if not release_version:

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -71,7 +71,28 @@ class SignTestCase(unittest.TestCase):
 
             self.assertEqual(result, SignReturnValue.NO_PROJECT)
 
-    def test_no_project_setup(self):
+    def test_no_release_error(self):
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                    "--project",
+                    "foo",
+                ]
+            )
+
+            result = sign(
+                terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
+
+            self.assertEqual(result, SignReturnValue.NO_RELEASE_VERSION)
+
+    @patch("pontos.release.sign.get_last_release_version", autospec=True)
+    def test_no_release_version(self, get_last_release_version_mock: MagicMock):
+        get_last_release_version_mock.return_value = None
+
         with temp_directory(change_into=True):
             _, token, args = parse_args(
                 [
@@ -156,6 +177,114 @@ class SignTestCase(unittest.TestCase):
                     "foo",
                     "--release-version",
                     "1.2.3",
+                ]
+            )
+
+            result = sign(
+                terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
+
+            self.assertEqual(result, SignReturnValue.SUCCESS)
+
+            cmd_runner_mock.assert_has_calls(
+                [
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        zip_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        tar_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        some_asset,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        other_asset,
+                    ),
+                ]
+            )
+
+            github_releases_mock.upload_release_assets.assert_called_once_with(
+                "greenbone/foo",
+                "v1.2.3",
+                [
+                    (Path("file.zip.asc"), "application/pgp-signature"),
+                    (Path("file.tar.asc"), "application/pgp-signature"),
+                    (Path("file1.asc"), "application/pgp-signature"),
+                    (Path("file2.asc"), "application/pgp-signature"),
+                ],
+            )
+
+    @patch("pontos.release.helper.Git", autospec=True)
+    @patch("pontos.release.sign.cmd_runner", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_asset", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_tar", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_zip", autospec=True)
+    @patch("pontos.release.sign.GitHubAsyncRESTApi.releases", autospec=True)
+    def test_sign_success_determine_release_version(
+        self,
+        github_releases_mock: AsyncMock,
+        download_zip_mock: AsyncMock,
+        download_tar_mock: AsyncMock,
+        download_asset_mock: AsyncMock,
+        cmd_runner_mock: AsyncMock,
+        git_mock: MagicMock,
+    ):
+        tar_file = Path("file.tar")
+        zip_file = Path("file.zip")
+        some_asset = Path("file1")
+        other_asset = Path("file2")
+        download_tar_mock.return_value = tar_file
+        download_zip_mock.return_value = zip_file
+        download_asset_mock.side_effect = [some_asset, other_asset]
+        github_releases_mock.exists = AsyncMock(return_value=True)
+        github_releases_mock.download_release_assets.return_value = (
+            AsyncIteratorMock(
+                [
+                    (
+                        "foo",
+                        MagicMock(),
+                    ),
+                    ("bar", MagicMock()),
+                ]
+            )
+        )
+        process = AsyncMock(spec=Process, returncode=0)
+        process.communicate.return_value = ("", "")
+        cmd_runner_mock.return_value = process
+        git_mock.return_value.list_tags.return_value = ["v1.0.0", "v1.2.3"]
+
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                    "--project",
+                    "foo",
                 ]
             )
 


### PR DESCRIPTION
## What

Use last tag as release version in `pontos-release sign`.

## Why

Allow to use sign in the CI after creating the release.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


