### PR TITLE
Fix: Set accept header back to application/vnd.github+json for steams

### DIFF
--- a/pontos/github/api/client.py
+++ b/pontos/github/api/client.py
@@ -69,7 +69,7 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
     def _request_headers(
         self,
         *,
-        accept: Optional[str] = DEFAULT_ACCEPT_HEADER,
+        accept: Optional[str] = None,
         content_type: Optional[str] = None,
         content_length: Optional[int] = None,
     ) -> Headers:
@@ -77,7 +77,7 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
         Get the default request headers
         """
         headers = {
-            "Accept": accept,
+            "Accept": accept or DEFAULT_ACCEPT_HEADER,
             "X-GitHub-Api-Version": GITHUB_API_VERSION,
         }
         if self.token:
@@ -248,14 +248,21 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
             url, params=params, headers=headers, json=data, content=content
         )
 
-    def stream(self, api: str) -> AsyncContextManager[httpx.Response]:
+    def stream(
+        self,
+        api: str,
+        *,
+        accept: Optional[str] = None,
+    ) -> AsyncContextManager[httpx.Response]:
         """
         Stream data from a GitHub API
 
         Args:
             api: API path to use for the post request
+            accept: Expected content type in the response.
+                Default "application/octet-stream".
         """
-        headers = self._request_headers(accept=ACCEPT_HEADER_OCTET_STREAM)
+        headers = self._request_headers(accept=accept)
         url = self._request_url(api)
         return self._client.stream(
             "GET", url, headers=headers, follow_redirects=True

--- a/tests/github/api/test_client.py
+++ b/tests/github/api/test_client.py
@@ -20,7 +20,6 @@
 from unittest.mock import MagicMock, call, patch
 
 from pontos.github.api.client import (
-    ACCEPT_HEADER_OCTET_STREAM,
     DEFAULT_ACCEPT_HEADER,
     GITHUB_API_VERSION,
     GitHubAsyncRESTClient,
@@ -257,7 +256,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
             "GET",
             f"{DEFAULT_GITHUB_API_URL}/foo/bar",
             headers={
-                "Accept": ACCEPT_HEADER_OCTET_STREAM,
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },
@@ -277,7 +276,7 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
             "GET",
             "https://github.com/foo/bar",
             headers={
-                "Accept": ACCEPT_HEADER_OCTET_STREAM,
+                "Accept": DEFAULT_ACCEPT_HEADER,
                 "Authorization": "token token",
                 "X-GitHub-Api-Version": GITHUB_API_VERSION,
             },


### PR DESCRIPTION
## What

Set accept header back to application/vnd.github+json for steams

Actually revert c3f857c1d878ed1adc63a6984110c88e94604a8c and use application/vnd.github+json as accept header for streaming requests too.

## Why

It seems that GitHub changed their API in this regard and expects application/vnd.github+json again instead of application/octet-stream (at least for the workflow run artifacts).

## References

https://github.com/greenbone/vulnerability-tests/actions/runs/4299657239/jobs/7495093550

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


