### PR TITLE
Change: Much more flexible Conventional Commits support

### DIFF
--- a/changelog.toml
+++ b/changelog.toml
@@ -1,8 +1,6 @@
 commit_types = [
-    { message = "^add", group = "Added"},
-    { message = "^remove", group = "Removed"},
-    { message = "^change", group = "Changed"},
-    { message = "^fix", group = "Bug Fixes"},
+    { message = "add", group = "Added"},
+    { message = "remove", group = "Removed"},
+    { message = "change", group = "Changed"},
+    { message = "fix", group = "Bug Fixes"},
 ]
-
-changelog_dir = "changelog"

--- a/pontos/changelog/conventional_commits.py
+++ b/pontos/changelog/conventional_commits.py
@@ -29,12 +29,14 @@ from pontos.git import Git
 ADDRESS = "https://github.com/"
 
 DEFAULT_CHANGELOG_CONFIG = """commit_types = [
-    { message = "^add", group = "Added"},
-    { message = "^remove", group = "Removed"},
-    { message = "^change", group = "Changed"},
-    { message = "^fix", group = "Bug Fixes"},
+    { message = "add", group = "Added"},
+    { message = "remove", group = "Removed"},
+    { message = "change", group = "Changed"},
+    { message = "fix", group = "Bug Fixes"},
 ]
 """
+
+JIRA_ID = r"(\s?/?\[?[A-Z0-9]+[\- ][0-9]{1,5}\]?\s?/?)?"
 
 
 class ChangelogBuilder:
@@ -162,14 +164,15 @@ class ChangelogBuilder:
         commit_link = f"{ADDRESS}{self.space}/{self.project}/commit/"
 
         commit_dict = {}
+
+        self._prepare_regexs([t["message"] for t in commit_types])
         if commits and len(commits) > 0:
             for commit in commits:
                 commit = commit.split(" ", maxsplit=1)
                 for commit_type in commit_types:
-                    reg = re.compile(
-                        rf'{commit_type["message"]}\s?[:|-]', flags=re.I
+                    match = self._check_for_conventional_commit(
+                        commit_type["message"], commit[1]
                     )
-                    match = reg.match(commit[1])
                     if match:
                         if commit_type["group"] not in commit_dict:
                             commit_dict[commit_type["group"]] = []
@@ -184,6 +187,19 @@ class ChangelogBuilder:
                         )
 
         return commit_dict
+
+    def _prepare_regexs(self, commit_types: List[str]) -> None:
+        # only compile these regexes once
+        self.cc_regexes: Dict[str, re.Pattern] = {}
+        for commit_type in commit_types:
+            self.cc_regexes[commit_type] = re.compile(
+                rf"{JIRA_ID}{commit_type}{JIRA_ID}\s??[:|-]?\s", flags=re.I
+            )
+
+    def _check_for_conventional_commit(
+        self, commit_type: str, commit_msg: str
+    ) -> Optional[re.Match]:
+        return self.cc_regexes[commit_type].match(commit_msg)
 
     def _build_changelog(
         self,

--- a/tests/changelog/changelog.toml
+++ b/tests/changelog/changelog.toml
@@ -1,11 +1,9 @@
 commit_types = [
-    { message = "^add", group = "Added"},
-    { message = "^remove", group = "Removed"},
-    { message = "^change", group = "Changed"},
-    { message = "^fix", group = "Bug Fixes"},
-    { message = "^doc", group = "Documentation"},
-    { message = "^refactor", group = "Refactor"},
-    { message = "^test", group = "Testing"},
+    { message = "add", group = "Added"},
+    { message = "remove", group = "Removed"},
+    { message = "change", group = "Changed"},
+    { message = "fix", group = "Bug Fixes"},
+    { message = "doc", group = "Documentation"},
+    { message = "refactor", group = "Refactor"},
+    { message = "test", group = "Testing"},
 ]
-
-changelog_dir = "changelog"

--- a/tests/changelog/test_conventional_commits.py
+++ b/tests/changelog/test_conventional_commits.py
@@ -16,6 +16,9 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
+# pylint: disable=protected-access
+
+import re
 import unittest
 from dataclasses import dataclass
 from datetime import datetime
@@ -63,6 +66,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 ## Added
 * foo bar [1234567](https://github.com/foo/bar/commit/1234567)
 * bar baz [8abcdef](https://github.com/foo/bar/commit/8abcdef)
+* bar baz [8abcd3f](https://github.com/foo/bar/commit/8abcd3f)
 
 ## Removed
 * foo bar again [42a42a4](https://github.com/foo/bar/commit/42a42a4)
@@ -152,6 +156,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 ## Added
 * foo bar [1234567](https://github.com/foo/bar/commit/1234567)
 * bar baz [8abcdef](https://github.com/foo/bar/commit/8abcdef)
+* bar baz [8abcd3f](https://github.com/foo/bar/commit/8abcd3f)
 
 ## Removed
 * foo bar again [42a42a4](https://github.com/foo/bar/commit/42a42a4)
@@ -208,6 +213,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 ## Added
 * foo bar [1234567](https://github.com/foo/bar/commit/1234567)
 * bar baz [8abcdef](https://github.com/foo/bar/commit/8abcdef)
+* bar baz [8abcd3f](https://github.com/foo/bar/commit/8abcd3f)
 
 ## Removed
 * foo bar again [42a42a4](https://github.com/foo/bar/commit/42a42a4)
@@ -268,6 +274,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 ## Added
 * foo bar [1234567](https://github.com/foo/bar/commit/1234567)
 * bar baz [8abcdef](https://github.com/foo/bar/commit/8abcdef)
+* bar baz [8abcd3f](https://github.com/foo/bar/commit/8abcd3f)
 
 ## Removed
 * foo bar again [42a42a4](https://github.com/foo/bar/commit/42a42a4)
@@ -371,6 +378,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 ## Added
 * foo bar [1234567](https://github.com/foo/bar/commit/1234567)
 * bar baz [8abcdef](https://github.com/foo/bar/commit/8abcdef)
+* bar baz [8abcd3f](https://github.com/foo/bar/commit/8abcd3f)
 
 ## Removed
 * foo bar again [42a42a4](https://github.com/foo/bar/commit/42a42a4)
@@ -421,6 +429,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 ## Added
 * foo bar [1234567](https://github.com/foo/bar/commit/1234567)
 * bar baz [8abcdef](https://github.com/foo/bar/commit/8abcdef)
+* bar baz [8abcd3f](https://github.com/foo/bar/commit/8abcd3f)
 
 ## Removed
 * foo bar again [42a42a4](https://github.com/foo/bar/commit/42a42a4)
@@ -451,9 +460,9 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 
         git_mock.return_value.list_tags.return_value = ["v0.0.1"]
         git_mock.return_value.log.return_value = [
-            "1234567 Add: foo bar",
-            "8abcdef Add: bar baz",
-            "8abcd3f Add bar baz",
+            "1234567 TXT-123 Add: foo bar",
+            "8abcdef [XC-33] Add: bar baz",
+            "8abcd3f Add/TT 55 bar baz",
             "8abcd3d Adding bar baz",
             "1337abc Change: bar to baz",
             "42a42a4 Remove: foo bar again",
@@ -468,6 +477,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 ## Added
 * foo bar [1234567](https://github.com/foo/bar/commit/1234567)
 * bar baz [8abcdef](https://github.com/foo/bar/commit/8abcdef)
+* bar baz [8abcd3f](https://github.com/foo/bar/commit/8abcd3f)
 
 ## Removed
 * foo bar again [42a42a4](https://github.com/foo/bar/commit/42a42a4)
@@ -505,3 +515,43 @@ class ChangelogBuilderTestCase(unittest.TestCase):
         git_mock.return_value.log.assert_called_once_with(
             "v0.0.1..HEAD", oneline=True
         )
+
+    def test_regex(self):
+        own_path = Path(__file__).absolute().parent
+        config_toml = own_path / "changelog.toml"
+
+        changelog_builder = ChangelogBuilder(
+            space="foo", project="bar", config=config_toml
+        )
+        commit_types = changelog_builder.config.get("commit_types")
+        changelog_builder._prepare_regexs([t["message"] for t in commit_types])
+
+        commit_messages = [
+            "TEST-3 Add: blah",
+            "BLUBB-123 Change: blah",
+            "TEST 123 Add: blah",
+            "Add/TEST-123: blah",
+            "TEST 123 Fix blah",
+            "TE5T-23 Fix blah",
+            "Fix - blah",
+            "Fix : blah",
+            "Fix: blah",
+            "Fix| blah",
+            "[TEST-123] Add: blah",
+            "TEST-123/Add blah",
+        ]
+        matches = len(commit_messages)
+        found = 0
+
+        for commit_message in commit_messages:
+            for commit_type in ["add", "fix", "change"]:
+                match = changelog_builder._check_for_conventional_commit(
+                    commit_type=commit_type, commit_msg=commit_message
+                )
+                if match:
+                    self.assertIsInstance(match, re.Match)
+                    matched = True
+                    found = found + 1
+            self.assertTrue(matched)
+            matched = False
+        self.assertEqual(matches, found)

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -1619,6 +1619,7 @@ class ReleaseTestCase(unittest.TestCase):
 ## Added
 * foo bar [1234567](https://github.com/greenbone/foo/commit/1234567)
 * bar baz [8abcdef](https://github.com/greenbone/foo/commit/8abcdef)
+* bar baz [8abcd3f](https://github.com/greenbone/foo/commit/8abcd3f)
 
 ## Removed
 * foo bar again [42a42a4](https://github.com/greenbone/foo/commit/42a42a4)


### PR DESCRIPTION
## What

Catch more Conventional Commits, by improving the RegEx.
Supports:
* `Add: foo`, `Change: foo`, ..
* `[JIRA-123] Add: foo`, ...
* `JIRA-123 Add: foo`,
* `JIRA 123 Add: foo`,
* `JIRA-123/Add: foo`,
* `Add/JIRA-123: foo`,
All catches also without the `:`, e.g. `JIRA-123 Add blubb`
Also is still case insensitive


<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

* Don't force other teams into using a single type of commit messages

<!-- Describe why are these changes necessary? -->

## References

DEVOPS-593

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


