### PR TITLE
Revert "Change: Much more flexible Conventional Commits support"

### DIFF
--- a/changelog.toml
+++ b/changelog.toml
@@ -1,6 +1,8 @@
 commit_types = [
-    { message = "add", group = "Added"},
-    { message = "remove", group = "Removed"},
-    { message = "change", group = "Changed"},
-    { message = "fix", group = "Bug Fixes"},
+    { message = "^add", group = "Added"},
+    { message = "^remove", group = "Removed"},
+    { message = "^change", group = "Changed"},
+    { message = "^fix", group = "Bug Fixes"},
 ]
+
+changelog_dir = "changelog"

--- a/tests/changelog/changelog.toml
+++ b/tests/changelog/changelog.toml
@@ -1,9 +1,11 @@
 commit_types = [
-    { message = "add", group = "Added"},
-    { message = "remove", group = "Removed"},
-    { message = "change", group = "Changed"},
-    { message = "fix", group = "Bug Fixes"},
-    { message = "doc", group = "Documentation"},
-    { message = "refactor", group = "Refactor"},
-    { message = "test", group = "Testing"},
+    { message = "^add", group = "Added"},
+    { message = "^remove", group = "Removed"},
+    { message = "^change", group = "Changed"},
+    { message = "^fix", group = "Bug Fixes"},
+    { message = "^doc", group = "Documentation"},
+    { message = "^refactor", group = "Refactor"},
+    { message = "^test", group = "Testing"},
 ]
+
+changelog_dir = "changelog"

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -1619,7 +1619,6 @@ class ReleaseTestCase(unittest.TestCase):
 ## Added
 * foo bar [1234567](https://github.com/greenbone/foo/commit/1234567)
 * bar baz [8abcdef](https://github.com/greenbone/foo/commit/8abcdef)
-* bar baz [8abcd3f](https://github.com/greenbone/foo/commit/8abcd3f)
 
 ## Removed
 * foo bar again [42a42a4](https://github.com/greenbone/foo/commit/42a42a4)


### PR DESCRIPTION
Reverts greenbone/pontos#662 because it has not been accepted.