### PR TITLE
Fix: Fix version scheme, by avoiding version jump on pre-releases

### DIFF
--- a/pontos/version/_calculator.py
+++ b/pontos/version/_calculator.py
@@ -97,7 +97,18 @@ class VersionCalculator(ABC):
             "1.2.3" will return "2.0.0"
             "1.2.3.dev1" will return "2.0.0"
             "1.2.3-alpha1" will return "2.0.0"
+            "0.5.0-a1" will return "0.5.0"
+            "0.5.0.dev1" will return "0.5.0"
         """
+        if (
+            (current_version.is_pre_release or current_version.is_dev_release)
+            and current_version.patch == 0
+            and current_version.minor == 0
+        ):
+            return cls.version_from_string(
+                f"{current_version.major}.{current_version.minor}."
+                f"{current_version.patch}"
+            )
         return cls.version_from_string(f"{current_version.major + 1}.0.0")
 
     @classmethod
@@ -109,7 +120,16 @@ class VersionCalculator(ABC):
             "1.2.3" will return "1.3.0"
             "1.2.3.dev1" will return "1.3.0"
             "1.2.3-alpha1" will return "1.3.0"
+            "1.0.0-a1" will return "1.0.0"
+            "1.0.0.dev1" will return "1.0.0"
         """
+        if (
+            current_version.is_pre_release or current_version.is_dev_release
+        ) and current_version.patch == 0:
+            return cls.version_from_string(
+                f"{current_version.major}.{current_version.minor}."
+                f"{current_version.patch}"
+            )
         return cls.version_from_string(
             f"{current_version.major}.{current_version.minor + 1}.0"
         )

--- a/pontos/version/schemes/_semantic.py
+++ b/pontos/version/schemes/_semantic.py
@@ -89,12 +89,16 @@ class SemanticVersion(Version):
     @property
     def is_alpha_release(self) -> bool:
         """Whether this version is a alpha release."""
-        return self.pre is not None and self.pre[0] == "alpha"
+        return self.pre is not None and (
+            self.pre[0] == "alpha" or self.pre[0] == "a"
+        )
 
     @property
     def is_beta_release(self) -> bool:
         """Whether this version is a beta release."""
-        return self.pre is not None and self.pre[0] == "beta"
+        return self.pre is not None and (
+            self.pre[0] == "beta" or self.pre[0] == "b"
+        )
 
     @property
     def is_release_candidate(self) -> bool:

--- a/tests/version/schemes/test_pep440.py
+++ b/tests/version/schemes/test_pep440.py
@@ -168,6 +168,10 @@ class PEP440VersionCalculatorTestCase(unittest.TestCase):
             "22.4.1",
             "22.4.1.dev1",
             "22.4.1.dev3",
+            "1.0.0a1",
+            "1.1.0a1",
+            "1.0.0.dev1",
+            "1.1.0.dev1",
         ]
         assert_versions = [
             "0.1.0",
@@ -180,6 +184,10 @@ class PEP440VersionCalculatorTestCase(unittest.TestCase):
             "22.5.0",
             "22.5.0",
             "22.5.0",
+            "1.0.0",
+            "1.1.0",
+            "1.0.0",
+            "1.1.0",
         ]
 
         for current_version, assert_version in zip(
@@ -206,6 +214,8 @@ class PEP440VersionCalculatorTestCase(unittest.TestCase):
             "22.4.1",
             "22.4.1.dev1",
             "22.4.1.dev3",
+            "1.0.0a1",
+            "1.0.0.dev1",
         ]
         assert_versions = [
             "1.0.0",
@@ -218,6 +228,8 @@ class PEP440VersionCalculatorTestCase(unittest.TestCase):
             "23.0.0",
             "23.0.0",
             "23.0.0",
+            "1.0.0",
+            "1.0.0",
         ]
 
         for current_version, assert_version in zip(

--- a/tests/version/schemes/test_semantic.py
+++ b/tests/version/schemes/test_semantic.py
@@ -172,6 +172,10 @@ class SemanticVersionCalculatorTestCase(unittest.TestCase):
             "22.4.1",
             "22.4.1-dev1",
             "22.4.1-dev3",
+            "1.0.0-a1",
+            "1.1.0-alpha1",
+            "1.0.0-dev1",
+            "1.1.0-dev1",
         ]
         assert_versions = [
             "0.1.0",
@@ -184,6 +188,10 @@ class SemanticVersionCalculatorTestCase(unittest.TestCase):
             "22.5.0",
             "22.5.0",
             "22.5.0",
+            "1.0.0",
+            "1.1.0",
+            "1.0.0",
+            "1.1.0",
         ]
 
         for current_version, assert_version in zip(
@@ -210,6 +218,9 @@ class SemanticVersionCalculatorTestCase(unittest.TestCase):
             "22.4.1",
             "22.4.1-dev1",
             "22.4.1-dev3",
+            "1.0.0-a1",
+            "1.0.0-beta1",
+            "1.0.0-dev1",
         ]
         assert_versions = [
             "1.0.0",
@@ -222,6 +233,9 @@ class SemanticVersionCalculatorTestCase(unittest.TestCase):
             "23.0.0",
             "23.0.0",
             "23.0.0",
+            "1.0.0",
+            "1.0.0",
+            "1.0.0",
         ]
 
         for current_version, assert_version in zip(


### PR DESCRIPTION
## What

Fixing `next_minor_version()` and `next_major_version()`

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

* Currently when having a zero pre version, e.g. `0.5.0a1` it will be released to `0.6.0` when doing a minor release, same for major releases, e.g. `1.0.0a1` will get `2.0.0` instead of the correct `1.0.0`.

<!-- Describe why are these changes necessary? -->

## References

None.
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


