### PR TITLE
Update header templates

### DIFF
--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.bash
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.bash
@@ -2,16 +2,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.bash
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.c
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.c
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.c
@@ -1,17 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.cmake
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.cmake
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.cmake
@@ -1,16 +1,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.go
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.go
@@ -1,4 +1,4 @@
-// Copyright (C) <year> <company>
+// SPDX-FileCopyrightText: <year> <company>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 //

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.go
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.go
@@ -1,16 +1,3 @@
 // SPDX-FileCopyrightText: <year> <company>
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU Affero General Public License as
-// published by the Free Software Foundation, either version 3 of the
-// License, or (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
-//
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.h
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.h
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.h
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.h
@@ -1,17 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.js
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.js
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.js
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.js
@@ -1,17 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: AGPL-3.0-or-later
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU Affero General Public License as
- * published by the Free Software Foundation, either version 3 of the
- * License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU Affero General Public License for more details.
- *
- * You should have received a copy of the GNU Affero General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.nasl
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.nasl
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 # Some text descriptions might be excerpted from (a) referenced
 # source(s), and are Copyright (C) by the respective right holder(s).
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.nasl
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.nasl
@@ -3,16 +3,3 @@
 # source(s), and are Copyright (C) by the respective right holder(s).
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.po
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.po
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.po
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.po
@@ -1,16 +1,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.py
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.py
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.py
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.py
@@ -1,16 +1,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.sh
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.sh
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.sh
@@ -2,16 +2,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.txt
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.txt
@@ -1,16 +1,3 @@
 SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.txt
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.txt
@@ -1,4 +1,4 @@
-Copyright (C) <year> <company>
+SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.xml
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (C) <year> <company>
+SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.xml
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.xml
@@ -4,17 +4,4 @@
 SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (C) <year> <company>
+SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
 

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.xsl
@@ -4,17 +4,4 @@
 SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: AGPL-3.0-or-later
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU Affero General Public License as
-published by the Free Software Foundation, either version 3 of the
-License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU Affero General Public License for more details.
-
-You should have received a copy of the GNU Affero General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->

--- a/pontos/updateheader/templates/GPL-2.0-only/template.c
+++ b/pontos/updateheader/templates/GPL-2.0-only/template.c
@@ -1,17 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-only
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */

--- a/pontos/updateheader/templates/GPL-2.0-only/template.c
+++ b/pontos/updateheader/templates/GPL-2.0-only/template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *

--- a/pontos/updateheader/templates/GPL-2.0-only/template.h
+++ b/pontos/updateheader/templates/GPL-2.0-only/template.h
@@ -1,17 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-only
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * version 2 as published by the Free Software Foundation.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */

--- a/pontos/updateheader/templates/GPL-2.0-only/template.h
+++ b/pontos/updateheader/templates/GPL-2.0-only/template.h
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-only
  *

--- a/pontos/updateheader/templates/GPL-2.0-only/template.nasl
+++ b/pontos/updateheader/templates/GPL-2.0-only/template.nasl
@@ -1,0 +1,5 @@
+# SPDX-FileCopyrightText: <year> <company>
+# Some text descriptions might be excerpted from (a) referenced
+# source(s), and are Copyright (C) by the respective right holder(s).
+#
+# SPDX-License-Identifier: GPL-2.0-only

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.bash
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.bash
@@ -2,17 +2,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.bash
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.c
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.c
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.c
@@ -1,18 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.cmake
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.cmake
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.cmake
@@ -1,17 +1,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.h
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.h
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.h
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.h
@@ -1,18 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.js
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.js
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.js
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.js
@@ -1,18 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-2.0-or-later
- *
- * This program is free software; you can redistribute it and/or
- * modify it under the terms of the GNU General Public License
- * as published by the Free Software Foundation; either version 2
- * of the License, or (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program; if not, write to the Free Software
- * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
  */

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.nasl
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.nasl
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 # Some text descriptions might be excerpted from (a) referenced
 # source(s), and are Copyright (C) by the respective right holder(s).
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.nasl
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.nasl
@@ -3,17 +3,3 @@
 # source(s), and are Copyright (C) by the respective right holder(s).
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.po
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.po
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.po
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.po
@@ -1,17 +1,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.py
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.py
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.py
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.py
@@ -1,17 +1,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.sh
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.sh
@@ -2,17 +2,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
-#
-# This program is free software; you can redistribute it and/or
-# modify it under the terms of the GNU General Public License
-# as published by the Free Software Foundation; either version 2
-# of the License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program; if not, write to the Free Software
-# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.sh
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.txt
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.txt
@@ -1,17 +1,3 @@
 SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.txt
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.txt
@@ -1,4 +1,4 @@
-Copyright (C) <year> <company>
+SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.xml
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.xml
@@ -4,18 +4,4 @@
 SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 -->

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.xml
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (C) <year> <company>
+SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.xsl
@@ -4,18 +4,4 @@
 SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-2.0-or-later
-
-This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public License
-as published by the Free Software Foundation; either version 2
-of the License, or (at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program; if not, write to the Free Software
-Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
 -->

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (C) <year> <company>
+SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-2.0-or-later
 

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.bash
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.bash
@@ -2,16 +2,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.bash
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.bash
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.c
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.c
@@ -1,17 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.c
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.c
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.cmake
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.cmake
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.cmake
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.cmake
@@ -1,16 +1,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.go
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.go
@@ -1,16 +1,3 @@
 // SPDX-FileCopyrightText: <year> <company>
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
-//
-// This program is free software: you can redistribute it and/or modify
-// it under the terms of the GNU General Public License as published by
-// the Free Software Foundation, either version 3 of the License, or
-// (at your option) any later version.
-//
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU General Public License for more details.
-//
-// You should have received a copy of the GNU General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.go
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.go
@@ -1,4 +1,4 @@
-// Copyright (C) <year> <company>
+// SPDX-FileCopyrightText: <year> <company>
 //
 // SPDX-License-Identifier: GPL-3.0-or-later
 //

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.h
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.h
@@ -1,17 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.h
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.h
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.js
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.js
@@ -1,17 +1,4 @@
 /* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
- *
- * This program is free software: you can redistribute it and/or modify
- * it under the terms of the GNU General Public License as published by
- * the Free Software Foundation, either version 3 of the License, or
- * (at your option) any later version.
- *
- * This program is distributed in the hope that it will be useful,
- * but WITHOUT ANY WARRANTY; without even the implied warranty of
- * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
- * GNU General Public License for more details.
- *
- * You should have received a copy of the GNU General Public License
- * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.js
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.js
@@ -1,4 +1,4 @@
-/* Copyright (C) <year> <company>
+/* SPDX-FileCopyrightText: <year> <company>
  *
  * SPDX-License-Identifier: GPL-3.0-or-later
  *

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.nasl
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.nasl
@@ -3,16 +3,3 @@
 # source(s), and are Copyright (C) by the respective right holder(s).
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.nasl
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.nasl
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 # Some text descriptions might be excerpted from (a) referenced
 # source(s), and are Copyright (C) by the respective right holder(s).
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.po
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.po
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.po
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.po
@@ -1,16 +1,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.py
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.py
@@ -1,4 +1,4 @@
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.py
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.py
@@ -1,16 +1,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.sh
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.sh
@@ -2,16 +2,3 @@
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU General Public License as published by
-# the Free Software Foundation, either version 3 of the License, or
-# (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
-#
-# You should have received a copy of the GNU General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.sh
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Copyright (C) <year> <company>
+# SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.txt
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.txt
@@ -1,4 +1,4 @@
-Copyright (C) <year> <company>
+SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.txt
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.txt
@@ -1,16 +1,3 @@
 SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-3.0-or-later
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.xml
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.xml
@@ -4,17 +4,4 @@
 SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-3.0-or-later
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.xml
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (C) 2020 Greenbone AG
+SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.xsl
@@ -4,17 +4,4 @@
 SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-3.0-or-later
-
-This program is free software: you can redistribute it and/or modify
-it under the terms of the GNU General Public License as published by
-the Free Software Foundation, either version 3 of the License, or
-(at your option) any later version.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-GNU General Public License for more details.
-
-You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
 -->

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.xsl
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 
 <!--
-Copyright (C) 2020 Greenbone AG
+SPDX-FileCopyrightText: <year> <company>
 
 SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -181,7 +181,8 @@ def _update_file(
                 and copyright_match["modification_year"] < parsed_args.year
             ):
                 copyright_term = (
-                    f'Copyright (C) {copyright_match["creation_year"]}'
+                    f"SPDX-FileCopyrightText: "
+                    f'{copyright_match["creation_year"]}'
                     f'-{parsed_args.year} {copyright_match["company"]}'
                 )
                 new_line = re.sub(regex, copyright_term, line)

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -81,9 +81,9 @@ def _find_copyright(
         return (
             True,
             {
-                "creation_year": copyright_match.group(1),
-                "modification_year": copyright_match.group(2),
-                "company": copyright_match.group(3),
+                "creation_year": copyright_match.group(2),
+                "modification_year": copyright_match.group(3),
+                "company": copyright_match.group(4),
             },
         )
     return False, None

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -376,7 +376,7 @@ def main() -> None:
         sys.exit(1)
 
     regex = re.compile(
-        "[Cc]opyright.*?(19[0-9]{2}|20[0-9]{2}) "
+        "(SPDX-FileCopyrightText:|[Cc]opyright).*?(19[0-9]{2}|20[0-9]{2}) "
         f"?-? ?(19[0-9]{{2}}|20[0-9]{{2}})? ({parsed_args.company})"
     )
 

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -39,22 +39,9 @@ from pontos.updateheader.updateheader import _parse_args as parse_args
 from pontos.updateheader.updateheader import _update_file as update_file
 from pontos.updateheader.updateheader import main
 
-HEADER = """# Copyright (C) {date} Greenbone AG
+HEADER = """# SPDX-FileCopyrightText: {date} Greenbone AG
 #
-# SPDX-License-Identifier: AGPL-3.0-or-later
-#
-# This program is free software: you can redistribute it and/or modify
-# it under the terms of the GNU Affero General Public License as
-# published by the Free Software Foundation, either version 3 of the
-# License, or (at your option) any later version.
-#
-# This program is distributed in the hope that it will be useful,
-# but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU Affero General Public License for more details.
-#
-# You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>."""
+# SPDX-License-Identifier: AGPL-3.0-or-later"""
 
 
 class Terminal(ConsoleTerminal):
@@ -358,7 +345,7 @@ class UpdateHeaderTestCase(TestCase):
             "Copyright Year None -> 2021\n",
         )
         self.assertIn(
-            "# Copyright (C) 2020-2021 Greenbone AG",
+            "# SPDX-FileCopyrightText: 2020-2021 Greenbone AG",
             test_file.read_text(encoding="utf-8"),
         )
 
@@ -391,7 +378,7 @@ class UpdateHeaderTestCase(TestCase):
             f"{test_file}: Licence Header is ok.\n",
         )
         self.assertIn(
-            "# Copyright (C) 2021 Greenbone AG",
+            "# SPDX-FileCopyrightText: 2021 Greenbone AG",
             test_file.read_text(encoding="utf-8"),
         )
 

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -71,7 +71,7 @@ class UpdateHeaderTestCase(TestCase):
         self.path = Path(__file__).parent
 
         self.regex = re.compile(
-            "[Cc]opyright.*?(19[0-9]{2}|20[0-9]{2}) "
+            "(SPDX-FileCopyrightText:|[Cc]opyright).*?(19[0-9]{2}|20[0-9]{2}) "
             f"?-? ?(19[0-9]{{2}}|20[0-9]{{2}})? ({self.args.company})"
         )
 

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -123,6 +123,35 @@ class UpdateHeaderTestCase(TestCase):
         self.assertFalse(found)
         self.assertIsNone(match)
 
+    def test_find_spdx_copyright(self):
+        test_line = "# SPDX-FileCopyrightText: 1995-2021 Greenbone AG"
+        test2_line = "# SPDX-FileCopyrightText: 1995 Greenbone AG"
+        invalid_line = (
+            "# This program is free software: "
+            "you can redistribute it and/or modify"
+        )
+
+        # Full match
+        found, match = find_copyright(regex=self.regex, line=test_line)
+        self.assertTrue(found)
+        self.assertIsNotNone(match)
+        self.assertEqual(match["creation_year"], "1995")
+        self.assertEqual(match["modification_year"], "2021")
+        self.assertEqual(match["company"], self.args.company)
+
+        # No modification Date
+        found, match = find_copyright(regex=self.regex, line=test2_line)
+        self.assertTrue(found)
+        self.assertIsNotNone(match)
+        self.assertEqual(match["creation_year"], "1995")
+        self.assertEqual(match["modification_year"], None)
+        self.assertEqual(match["company"], self.args.company)
+
+        # No match
+        found, match = find_copyright(regex=self.regex, line=invalid_line)
+        self.assertFalse(found)
+        self.assertIsNone(match)
+
     def test_add_header(self):
         expected_header = HEADER.format(date="2021") + "\n"
 


### PR DESCRIPTION
## What

This PR updates the header templates to use the `SPDX-FileCopyrightText` prefix for copyright information to aid automated processing of this information.

It also removes all "boilerplate" license text from the templates. The `SPDX-License-Identifier` is the authoritative statement for the license applicable for this file.

Additionally, issues with the templates for the `GPL-3.0-or-later` license for the `XML` and `XSL` formats were identified and fixed and a template for the `GPL-2.0-only` license for the `NASL` language was added.

## Why

The changes are necessary to aid automated processing of license and copyright information.