### PR TITLE
Change: Fix and improve (dev) versioning

### DIFF
--- a/pontos/version/_calculator.py
+++ b/pontos/version/_calculator.py
@@ -95,10 +95,13 @@ class VersionCalculator(ABC):
 
         Examples:
             "1.2.3" will return "2.0.0"
-            "1.2.3.dev1" will return "2.0.0"
-            "1.2.3-alpha1" will return "2.0.0"
-            "0.5.0-a1" will return "0.5.0"
-            "0.5.0.dev1" will return "0.5.0"
+            "1.2.3.dev1" will return "1.2.3"
+            "1.2.3-alpha1" will return "1.2.3"
+            "1.0.0" will return "2.0.0"
+            "1.0.0-a1" will return "1.0.0"
+            "1.0.0.dev1" will return "1.0.0"
+            "0.5.0-a1" will return "1.0.0"
+            "0.5.0.dev1" will return "1.0.0"
         """
         if (
             (current_version.is_pre_release or current_version.is_dev_release)
@@ -120,8 +123,11 @@ class VersionCalculator(ABC):
             "1.2.3" will return "1.3.0"
             "1.2.3.dev1" will return "1.3.0"
             "1.2.3-alpha1" will return "1.3.0"
+            "1.0.0" will return "1.1.0"
             "1.0.0-a1" will return "1.0.0"
             "1.0.0.dev1" will return "1.0.0"
+            "0.5.0-a1" will return "0.5.0"
+            "0.5.0.dev1" will return "0.5.0"
         """
         if (
             current_version.is_pre_release or current_version.is_dev_release
@@ -141,12 +147,20 @@ class VersionCalculator(ABC):
 
         Examples:
             "1.2.3" will return "1.2.4"
-            "1.2.3.dev1" will return "1.2.4"
-            "1.2.3-alpha1" will return "1.2.4"
+            "1.2.3.dev1" will return "1.2.3"
+            "1.2.3-dev1" will return "1.2.3"
+            "1.2.3+dev1" will return "1.2.4"
+            "1.2.3-alpha1" will return "1.2.3"
+            "1.0.0" will return "1.0.1"
+            "1.0.0-a1" will return "1.0.0"
+            "1.0.0.dev1" will return "1.0.0"
+            "0.5.0-a1" will return "0.5.0"
+            "0.5.0.dev1" will return "0.5.0"
         """
         if not current_version:
             raise VersionError("No current version passed.")
-        if current_version.is_pre_release:
+
+        if current_version.is_dev_release or current_version.is_pre_release:
             next_version = cls.version_from_string(
                 f"{current_version.major}."
                 f"{current_version.minor}."
@@ -166,6 +180,18 @@ class VersionCalculator(ABC):
     def next_dev_version(current_version: Version) -> Version:
         """
         Get the next development version from a valid version
+
+        Examples:
+            "1.2.3" will return "1.2.4-dev1"
+            "1.2.3.dev1" will return "1.2.3.dev2"
+            "1.2.3-dev1" will return "1.2.3-dev2"
+            "1.2.3+dev1" will return "1.2.4-dev1"
+            "1.2.3-alpha1" will return "1.2.3-alpha2-dev1"
+            "1.0.0" will return "1.0.1-dev1"
+            "1.0.0-a1" will return "1.0.0-a2-dev1"
+            "1.0.0.dev1" will return "1.0.0.dev2"
+            "0.5.0-a1" will return "0.5.0-a2-dev1"
+            "0.5.0.dev1" will return "0.5.0.dev2"
         """
 
     @staticmethod
@@ -173,6 +199,18 @@ class VersionCalculator(ABC):
     def next_alpha_version(current_version: Version) -> Version:
         """
         Get the next alpha version from a valid version
+
+        Examples:
+            "1.2.3" will return "1.2.4-alpha1"
+            "1.2.3.dev1" will return "1.2.3-alpha1"
+            "1.2.3-dev1" will return "1.2.3-alpha1"
+            "1.2.3+dev1" will return "1.2.4-alpha1"
+            "1.2.3-alpha1" will return "1.2.3-alpha2"
+            "1.0.0" will return "1.0.1-alpha1"
+            "1.0.0-a1" will return "1.0.1-alpha1"
+            "1.0.0.dev1" will return "1.0.0-alpha1"
+            "0.5.0-a1" will return "0.5.1-alpha1"
+            "0.5.0.dev1" will return "0.5.0-alpha1"
         """
 
     @staticmethod
@@ -180,6 +218,18 @@ class VersionCalculator(ABC):
     def next_beta_version(current_version: Version) -> Version:
         """
         Get the next beta version from a valid version
+
+        Examples:
+            "1.2.3" will return "1.2.4-beta1"
+            "1.2.3.dev1" will return "1.2.3-beta1"
+            "1.2.3-dev1" will return "1.2.3-beta1"
+            "1.2.3+dev1" will return "1.2.4-beta1"
+            "1.2.3-alpha1" will return "1.2.3-beta1"
+            "1.0.0" will return "1.0.1-beta1"
+            "1.0.0-a1" will return "1.0.1-beta1"
+            "1.0.0.dev1" will return "1.0.0-beta1"
+            "0.5.0-a1" will return "0.5.1-beta1"
+            "0.5.0.dev1" will return "0.5.0-beta1"
         """
 
     @staticmethod
@@ -187,4 +237,16 @@ class VersionCalculator(ABC):
     def next_release_candidate_version(current_version: Version) -> Version:
         """
         Get the next release candidate version from a valid version
+
+        Examples:
+            "1.2.3" will return "1.2.4-rc1"
+            "1.2.3.dev1" will return "1.2.3-rc1"
+            "1.2.3-dev1" will return "1.2.3-rc1"
+            "1.2.3+dev1" will return "1.2.4-rc1"
+            "1.2.3-alpha1" will return "1.2.3-rc1"
+            "1.0.0" will return "1.0.1-rc1"
+            "1.0.0-a1" will return "1.0.1-rc1"
+            "1.0.0.dev1" will return "1.0.0-rc1"
+            "0.5.0-a1" will return "0.5.1-rc1"
+            "0.5.0.dev1" will return "0.5.0-rc"
         """

--- a/pontos/version/schemes/_semantic.py
+++ b/pontos/version/schemes/_semantic.py
@@ -28,7 +28,8 @@ from ._scheme import VersioningScheme
 # Note: This regex currently support any kind of
 # word-number combination for pre releases
 _PRE_RELEASE_REGEXP = re.compile(
-    r"^(?P<name>[a-zA-Z]+)(?P<version>0|[1-9][0-9]*)$"
+    r"^(?P<name>[a-zA-Z]+)(?P<version>0|[1-9][0-9]*)"
+    r"(?:-(?P<extra>[a-zA-Z]+)(?P<extra_version>0|[1-9][0-9]*))?$"
 )
 
 
@@ -43,9 +44,13 @@ class SemanticVersion(Version):
         version: str,
     ) -> None:
         self._version_info = VersionInfo.parse(version)
+        self._parse_build()
         self._parse_pre_release()
 
     def _parse_pre_release(self) -> None:
+        self._dev = None
+        self._pre_release = None
+
         if self._version_info.prerelease:
             match = _PRE_RELEASE_REGEXP.match(self._version_info.prerelease)
             if not match:
@@ -54,12 +59,35 @@ class SemanticVersion(Version):
                     f"{self._version_info}"
                 )
 
-            self._pre_release = (
-                match.group("name"),
-                int(match.group("version")),
-            )
-        else:
-            self._pre_release = None
+            name = match.group("name")
+            version = int(match.group("version"))
+
+            if name == "dev":
+                self._dev = version
+            else:
+                self._pre_release = (
+                    name,
+                    version,
+                )
+
+            extra = match.group("extra")
+            if extra == "dev":
+                if name == "dev":
+                    raise VersionError(
+                        f"Invalid prerelease {self._version_info.prerelease} "
+                        f"in {self._version_info}"
+                    )
+                self._dev = int(match.group("extra_version"))
+
+    def _parse_build(self) -> None:
+        self._build = None
+        if self._version_info.build:
+            match = _PRE_RELEASE_REGEXP.match(self._version_info.build)
+            if match:
+                self._build = (
+                    match.group("name"),
+                    int(match.group("version")),
+                )
 
     @property
     def pre(self) -> Optional[Tuple[str, int]]:
@@ -69,41 +97,39 @@ class SemanticVersion(Version):
     @property
     def dev(self) -> Optional[int]:
         """The development number of the version."""
-        return self.pre[1] if self.is_dev_release else None
+        return self._dev
 
     @property
-    def local(self) -> Optional[str]:
+    def local(self) -> Optional[Tuple[str, int]]:
         """The local version segment of the version."""
-        return self._version_info.build
+        return self._build
 
     @property
     def is_pre_release(self) -> bool:
-        """Whether this version is a pre-release."""
-        return self.pre is not None
+        """
+        Whether this version is a pre-release (alpha, beta, release candidate).
+        """
+        return self._pre_release is not None
 
     @property
     def is_dev_release(self) -> bool:
         """Whether this version is a development release."""
-        return self.pre and self.pre[0] == "dev"
+        return self._dev is not None
 
     @property
     def is_alpha_release(self) -> bool:
         """Whether this version is a alpha release."""
-        return self.pre is not None and (
-            self.pre[0] == "alpha" or self.pre[0] == "a"
-        )
+        return self.is_pre_release and self.pre[0] == "alpha"
 
     @property
     def is_beta_release(self) -> bool:
         """Whether this version is a beta release."""
-        return self.pre is not None and (
-            self.pre[0] == "beta" or self.pre[0] == "b"
-        )
+        return self.is_pre_release and self.pre[0] == "beta"
 
     @property
     def is_release_candidate(self) -> bool:
         """Whether this version is a release candidate."""
-        return self.pre is not None and self.pre[0] == "rc"
+        return self.is_pre_release and self.pre[0] == "rc"
 
     @property
     def major(self) -> int:
@@ -129,7 +155,10 @@ class SemanticVersion(Version):
         if not isinstance(other, type(self)):
             other = self.from_version(other)
 
-        return self._version_info == other._version_info
+        return (
+            self._version_info == other._version_info
+            and self._version_info.build == other._version_info.build
+        )
 
     def __ne__(self, other: Any) -> bool:
         if isinstance(other, str):
@@ -140,7 +169,10 @@ class SemanticVersion(Version):
         if not isinstance(other, type(self)):
             other = self.from_version(other)
 
-        return self._version_info != other._version_info
+        return (
+            self._version_info != other._version_info
+            or self._version_info.build != other._version_info.build
+        )
 
     def __str__(self) -> str:
         """A string representation of the version"""
@@ -177,13 +209,41 @@ class SemanticVersion(Version):
         if isinstance(version, cls):
             return version
 
+        version_local = (
+            f"+{version.local[0]}{version.local[1]}" if version.local else ""
+        )
         if version.is_dev_release:
+            if not version.pre:
+                return cls.from_string(
+                    f"{version.major}."
+                    f"{version.minor}."
+                    f"{version.patch}"
+                    f"-dev{version.dev}"
+                    f"{version_local}"
+                )
+
             return cls.from_string(
                 f"{version.major}."
                 f"{version.minor}."
                 f"{version.patch}"
+                f"-{version.pre[0]}{version.pre[1]}"
                 f"-dev{version.dev}"
-                f"{'+' + version.local if version.local else ''}"
+            )
+        if version.is_alpha_release:
+            return cls.from_string(
+                f"{version.major}."
+                f"{version.minor}."
+                f"{version.patch}"
+                f"-alpha{version.pre[1]}"
+                f"{version_local}"
+            )
+        if version.is_beta_release:
+            return cls.from_string(
+                f"{version.major}."
+                f"{version.minor}."
+                f"{version.patch}"
+                f"-beta{version.pre[1]}"
+                f"{version_local}"
             )
         if version.is_pre_release:
             return cls.from_string(
@@ -191,7 +251,7 @@ class SemanticVersion(Version):
                 f"{version.minor}."
                 f"{version.patch}"
                 f"-{version.pre[0]}{version.pre[1]}"
-                f"{'+' + version.local if version.local else ''}"
+                f"{version_local}"
             )
 
         return cls.from_string(str(version))
@@ -207,11 +267,19 @@ class SemanticVersionCalculator(VersionCalculator):
         Get the next development version from a valid version
         """
         if current_version.is_dev_release:
+            if current_version.pre:
+                return cls.version_from_string(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.patch}"
+                    f"-{current_version.pre[0]}{current_version.pre[1]}"
+                    f"-dev{current_version.dev + 1}"
+                )
             return cls.version_from_string(
                 f"{current_version.major}."
                 f"{current_version.minor}."
                 f"{current_version.patch}"
-                f"-dev{current_version.pre[1] + 1}"
+                f"-dev{current_version.dev + 1}"
             )
 
         if current_version.is_pre_release:
@@ -219,7 +287,7 @@ class SemanticVersionCalculator(VersionCalculator):
                 f"{current_version.major}."
                 f"{current_version.minor}."
                 f"{current_version.patch}-"
-                f"{current_version.pre[0]}{current_version.pre[1]}+dev1"
+                f"{current_version.pre[0]}{current_version.pre[1] + 1}-dev1"
             )
 
         return cls.version_from_string(
@@ -235,11 +303,23 @@ class SemanticVersionCalculator(VersionCalculator):
         Get the next alpha version from a valid version
         """
         if current_version.is_dev_release:
+            if current_version.pre:
+                if current_version.pre[0] == "alpha":
+                    return cls.version_from_string(
+                        f"{current_version.major}."
+                        f"{current_version.minor}."
+                        f"{current_version.patch}"
+                        f"-alpha{current_version.pre[1] + 1}"
+                    )
+                return cls.version_from_string(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.patch + 1}-alpha1"
+                )
             return cls.version_from_string(
                 f"{current_version.major}."
                 f"{current_version.minor}."
-                f"{current_version.patch}"
-                "-alpha1"
+                f"{current_version.patch}-alpha1"
             )
         if current_version.is_alpha_release:
             return cls.version_from_string(
@@ -260,6 +340,20 @@ class SemanticVersionCalculator(VersionCalculator):
         """
         Get the next alpha version from a valid version
         """
+        if current_version.is_dev_release and current_version.pre:
+            if current_version.pre[0] == "beta":
+                return cls.version_from_string(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.patch}"
+                    f"-beta{current_version.pre[1] + 1}"
+                )
+            if current_version.pre[0] == "rc":
+                return cls.version_from_string(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.patch + 1}-beta1"
+                )
         if current_version.is_dev_release or current_version.is_alpha_release:
             return cls.version_from_string(
                 f"{current_version.major}."
@@ -286,18 +380,26 @@ class SemanticVersionCalculator(VersionCalculator):
         cls, current_version: Version
     ) -> Version:
         """
-        Get the next alpha version from a valid version
+        Get the next release candidate version from a valid version
         """
-        if (
-            current_version.is_dev_release
-            or current_version.is_alpha_release
-            or current_version.is_beta_release
-        ):
+        if current_version.is_dev_release:
+            if current_version.pre and current_version.pre[0] == "rc":
+                return cls.version_from_string(
+                    f"{current_version.major}."
+                    f"{current_version.minor}."
+                    f"{current_version.patch}"
+                    f"-rc{current_version.pre[1] + 1}"
+                )
             return cls.version_from_string(
                 f"{current_version.major}."
                 f"{current_version.minor}."
-                f"{current_version.patch}"
-                "-rc1"
+                f"{current_version.patch}-rc1"
+            )
+        if current_version.is_alpha_release or current_version.is_beta_release:
+            return cls.version_from_string(
+                f"{current_version.major}."
+                f"{current_version.minor}."
+                f"{current_version.patch}-rc1"
             )
         if current_version.is_release_candidate:
             return cls.version_from_string(

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -24,6 +24,21 @@ from typing import Any, Callable, Optional, Tuple
 class Version(ABC):
     """
     An abstract base class for version information
+
+    A version implementation must consider the following constraints:
+
+    * Version strings containing `-dev`, and `.dev` are considered development
+      versions.
+    * Version strings containing `+dev` are not considered as development
+      versions.
+    * Development versions are are also pre releases. The following version
+      string is a development version and a pre release: `1.2.3-alpha1-dev1`
+    * A version must return a pre for development versions for version strings
+      containing a pre release version like `1.2.3-alpha1-dev1`
+    * A development version has no local part
+    * Alpha, Beta, Release Candidate and Development versions are pre releases
+    * Alpha, Beta and Release Candidate versions pre must return the following
+      names for the first value in the tuple: `alpha`, `beta`, `rc` and `dev`
     """
 
     @property
@@ -53,13 +68,15 @@ class Version(ABC):
 
     @property
     @abstractmethod
-    def local(self) -> Optional[str]:
+    def local(self) -> Optional[Tuple[str, int]]:
         """The local version segment of the version."""
 
     @property
     @abstractmethod
     def is_pre_release(self) -> bool:
-        """Whether this version is a pre-release."""
+        """
+        Whether this version is a pre-release (alpha, beta, release candidate).
+        """
 
     @property
     @abstractmethod

--- a/tests/release/test_release.py
+++ b/tests/release/test_release.py
@@ -554,7 +554,7 @@ class ReleaseTestCase(unittest.TestCase):
     ):
         current_version = PEP440Version("0.0.1")
         release_version = PEP440Version("0.0.2a1")
-        next_version = PEP440Version("0.0.2a1+dev1")
+        next_version = PEP440Version("0.0.2a2.dev1")
         command_mock = MagicMock(spec=GoVersionCommand)
         gather_commands_mock.return_value = [command_mock]
         create_changelog_mock.return_value = "A Changelog"
@@ -621,7 +621,7 @@ class ReleaseTestCase(unittest.TestCase):
                 ),
                 call(
                     "Automatic adjustments after release\n\n"
-                    "* Update to version 0.0.2a1+dev1\n",
+                    "* Update to version 0.0.2a2.dev1\n",
                     verify=False,
                     gpg_signing_key="123",
                 ),
@@ -651,7 +651,7 @@ class ReleaseTestCase(unittest.TestCase):
     ):
         current_version = PEP440Version("0.0.1")
         release_version = PEP440Version("0.0.2b1")
-        next_version = PEP440Version("0.0.2b1+dev1")
+        next_version = PEP440Version("0.0.2b2.dev1")
         command_mock = MagicMock(spec=GoVersionCommand)
         gather_commands_mock.return_value = [command_mock]
         create_changelog_mock.return_value = "A Changelog"
@@ -718,7 +718,7 @@ class ReleaseTestCase(unittest.TestCase):
                 ),
                 call(
                     "Automatic adjustments after release\n\n"
-                    "* Update to version 0.0.2b1+dev1\n",
+                    "* Update to version 0.0.2b2.dev1\n",
                     verify=False,
                     gpg_signing_key="123",
                 ),
@@ -748,7 +748,7 @@ class ReleaseTestCase(unittest.TestCase):
     ):
         current_version = PEP440Version("0.0.1")
         release_version = PEP440Version("0.0.2rc1")
-        next_version = PEP440Version("0.0.2rc1+dev1")
+        next_version = PEP440Version("0.0.2rc2.dev1")
         command_mock = MagicMock(spec=GoVersionCommand)
         gather_commands_mock.return_value = [command_mock]
         create_changelog_mock.return_value = "A Changelog"
@@ -815,7 +815,7 @@ class ReleaseTestCase(unittest.TestCase):
                 ),
                 call(
                     "Automatic adjustments after release\n\n"
-                    "* Update to version 0.0.2rc1+dev1\n",
+                    "* Update to version 0.0.2rc2.dev1\n",
                     verify=False,
                     gpg_signing_key="123",
                 ),

--- a/tests/version/schemes/test_pep440.py
+++ b/tests/version/schemes/test_pep440.py
@@ -23,6 +23,7 @@ from pontos.version.schemes._pep440 import PEP440Version as Version
 from pontos.version.schemes._pep440 import (
     PEP440VersionCalculator as VersionCalculator,
 )
+from pontos.version.schemes._semantic import SemanticVersion
 
 
 class PEP440VersionTestCase(unittest.TestCase):
@@ -35,6 +36,7 @@ class PEP440VersionTestCase(unittest.TestCase):
             "1.2.3b1",
             "1.2.3rc1",
             "1.2.3a1+dev1",
+            "1.2.3a1.dev1",
             "22.4.1",
             "22.4.1.dev1",
             "22.4.1.dev3",
@@ -51,6 +53,7 @@ class PEP440VersionTestCase(unittest.TestCase):
             "1.2.3-b1",
             "1.2.3-rc1",
             "1.2.3-a1+dev1",
+            "1.2.3-a1-dev1",
             "1.4.1",
             "2.4.1-dev1",
             "2.4.1-dev3",
@@ -70,45 +73,354 @@ class PEP440VersionTestCase(unittest.TestCase):
             ):
                 Version.from_string(version)
 
+    def test_equal(self):
+        versions = [
+            ("1.0.0", "1.0.0"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0.dev1", "1.0.0.dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0a1", "1.0.0-alpha1"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1.dev1", "1.0.0-alpha1.dev1"),
+            ("1.0.0a1.dev1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0b1", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+            ("1.0.0rc1", "1.0.0-rc1"),
+        ]
+        for version1, version2 in versions:
+            self.assertTrue(
+                Version.from_string(version1) == Version.from_string(version2),
+                f"{version1} does not equal {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "1.0.1"),
+            ("1.0.0", "1.0.0+dev1"),
+            ("1.0.0", "1.0.0.dev1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-beta1"),
+            ("1.0.0.dev1", "1.0.0.dev2"),
+            ("1.0.0+dev1", "1.0.0+dev2"),
+            ("1.0.0-alpha1", "1.0.0-beta1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-alpha1-dev1", "1.0.0-alpha1-dev2"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev2"),
+            ("1.0.0-beta1", "1.0.0-beta1+dev1"),
+            ("1.0.0-beta1-dev1", "1.0.0-beta1-dev2"),
+            ("1.0.0-beta1+dev1", "1.0.0-beta1+dev2"),
+            ("1.0.0-rc1", "1.0.0-rc1+dev1"),
+            ("1.0.0-rc1-dev1", "1.0.0-rc1-dev2"),
+            ("1.0.0-rc1+dev1", "1.0.0-rc1+dev2"),
+        ]
+        for version1, version2 in versions:
+            self.assertFalse(
+                Version.from_string(version1) == Version.from_string(version2),
+                f"{version1} equals {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "abc"),
+        ]
+        for version1, version2 in versions:
+            self.assertFalse(Version.from_string(version1) == version2)
+
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) == version2)
+
+    def test_equal_with_semantic_version(self):
+        versions = [
+            ("1.0.0", "1.0.0"),
+            ("1.0.0.dev1", "1.0.0-dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-a1", "1.0.0-alpha1"),
+            ("1.0.0-alpha1.dev1", "1.0.0-alpha1-dev1"),
+            ("1.0.0a1.dev1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-b1", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+            ("1.0.0a1", "1.0.0-alpha1"),
+            ("1.0.0b1", "1.0.0-beta1"),
+            ("1.0.0rc1", "1.0.0-rc1"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0a1+dev1", "1.0.0-alpha1+dev1"),
+            ("1.0.0b1+dev1", "1.0.0-beta1+dev1"),
+            ("1.0.0rc1+dev1", "1.0.0-rc1+dev1"),
+        ]
+        for version1, version2 in versions:
+            pep440 = Version.from_string(version1)
+            semver = SemanticVersion.from_string(version2)
+            self.assertTrue(
+                pep440 == semver,
+                f"{pep440!r} {version1} does not equal {semver!r} {version2}",
+            )
+
+        versions = []
+        for version1, version2 in versions:
+            pep440 = Version.from_string(version1)
+            semver = SemanticVersion.from_string(version2)
+            self.assertFalse(
+                pep440 == semver,
+                f"{pep440!r} {version1} equals {semver!r} {version2}",
+            )
+
+    def test_not_equal(self):
+        versions = [
+            ("1.0.0", "1.0.0"),
+            ("1.0.0.dev1", "1.0.0.dev1"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-alpha1.dev1", "1.0.0-alpha1.dev1"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+        ]
+        for version1, version2 in versions:
+            self.assertFalse(
+                Version.from_string(version1) != Version.from_string(version2),
+                f"{version1} does not equal {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "1.0.1"),
+            ("1.0.0", "1.0.0+dev1"),
+            ("1.0.0", "1.0.0.dev1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-beta1"),
+            ("1.0.0.dev1", "1.0.0.dev2"),
+            ("1.0.0+dev1", "1.0.0+dev2"),
+            ("1.0.0-alpha1", "1.0.0-beta1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1.dev1"),
+            ("1.0.0-alpha1.dev1", "1.0.0-alpha1.dev2"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev2"),
+            ("1.0.0-beta1", "1.0.0-beta1+dev1"),
+            ("1.0.0-beta1", "1.0.0-beta1.dev1"),
+            ("1.0.0-beta1.dev1", "1.0.0-beta1.dev2"),
+            ("1.0.0-beta1+dev1", "1.0.0-beta1+dev2"),
+            ("1.0.0-rc1", "1.0.0-rc1+dev1"),
+            ("1.0.0-rc1", "1.0.0-rc1.dev1"),
+            ("1.0.0-rc1.dev1", "1.0.0-rc1.dev2"),
+            ("1.0.0-rc1+dev1", "1.0.0-rc1+dev2"),
+        ]
+        for version1, version2 in versions:
+            self.assertTrue(
+                Version.from_string(version1) != Version.from_string(version2),
+                f"{version1} equals {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "abc"),
+        ]
+        for version1, version2 in versions:
+            self.assertTrue(Version.from_string(version1) != version2)
+
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) != version2)
+
+    def test_is_dev_release(self):
+        versions = [
+            "1.0.0.dev1",
+            "1.0.0dev1",
+            "1.0.0-alpha1.dev1",
+            "1.0.0-beta1.dev1",
+            "1.0.0-rc1.dev1",
+        ]
+        for version in versions:
+            self.assertTrue(
+                Version.from_string(version).is_dev_release,
+                f"{version} is not a dev release",
+            )
+
+        versions = [
+            "1.0.0",
+            "1.0.0+dev1",
+            "1.0.0a1",
+            "1.0.0b1",
+            "1.0.0rc1",
+            "1.0.0-alpha1",
+            "1.0.0-beta1",
+            "1.0.0-rc1",
+            "1.0.0a1+dev1",
+            "1.0.0b1+dev1",
+            "1.0.0rc1+dev1",
+        ]
+        for version in versions:
+            self.assertFalse(
+                Version.from_string(version).is_dev_release,
+                f"{version} is a dev release",
+            )
+
+    def test_is_alpha_release(self):
+        versions = [
+            "1.0.0-alpha1",
+            "1.0.0-a1",
+            "1.0.0a1",
+            "1.0.0a1+foo",
+            "1.0.0a1.dev1",
+        ]
+        for version in versions:
+            self.assertTrue(
+                Version.from_string(version).is_alpha_release,
+                f"{version} is not an alpha release",
+            )
+
+        versions = [
+            "1.0.0",
+            "1.0.0.dev1",
+            "1.0.0b1",
+            "1.0.0rc1",
+        ]
+        for version in versions:
+            self.assertFalse(
+                Version.from_string(version).is_alpha_release,
+                f"{version} is an alpha release",
+            )
+
+    def test_is_beta_release(self):
+        versions = [
+            "1.0.0-beta1",
+            "1.0.0-b1",
+            "1.0.0b1",
+            "1.0.0b1+foo",
+            "1.0.0b1.dev1",
+        ]
+        for version in versions:
+            self.assertTrue(
+                Version.from_string(version).is_beta_release,
+                f"{version} is not a beta release",
+            )
+
+        versions = [
+            "1.0.0",
+            "1.0.0.dev1",
+            "1.0.0a1",
+            "1.0.0rc1",
+        ]
+        for version in versions:
+            self.assertFalse(
+                Version.from_string(version).is_beta_release,
+                f"{version} is a beta release",
+            )
+
+    def test_is_release_candidate(self):
+        versions = [
+            "1.0.0-rc1",
+            "1.0.0rc1",
+            "1.0.0rc1+foo",
+            "1.0.0rc1.dev1",
+        ]
+        for version in versions:
+            self.assertTrue(
+                Version.from_string(version).is_release_candidate,
+                f"{version} is not a release candidate",
+            )
+
+        versions = [
+            "1.0.0",
+            "1.0.0.dev1",
+            "1.0.0a1",
+            "1.0.0b1",
+        ]
+        for version in versions:
+            self.assertFalse(
+                Version.from_string(version).is_release_candidate,
+                f"{version} is a release candidate",
+            )
+
+    def test_pre(self):
+        versions = [
+            ("1.0.0", None),
+            ("1.0.0.dev1", None),
+            ("1.0.0-dev1", None),
+            ("1.0.0a1", ("alpha", 1)),
+            ("1.0.0-alpha1", ("alpha", 1)),
+            ("1.0.0b1", ("beta", 1)),
+            ("1.0.0-beta1", ("beta", 1)),
+            ("1.0.0rc1", ("rc", 1)),
+            ("1.0.0-rc1", ("rc", 1)),
+            ("1.0.0rc1+foo1", ("rc", 1)),
+            ("1.0.0a1.dev1", ("alpha", 1)),
+            ("1.0.0a1.dev1", ("alpha", 1)),
+            ("1.0.0b1.dev1", ("beta", 1)),
+            ("1.0.0rc1.dev1", ("rc", 1)),
+        ]
+
+        for version, expected in versions:
+            self.assertEqual(Version.from_string(version).pre, expected)
+
+    def test_local(self):
+        versions = [
+            ("1.0.0", None),
+            ("1.0.0+dev1", ("dev", 1)),
+            ("1.0.0-dev1", None),
+            ("1.0.0.dev1", None),
+            ("1.0.0a1", None),
+            ("1.0.0-alpha1", None),
+            ("1.0.0b1", None),
+            ("1.0.0-beta1", None),
+            ("1.0.0rc1", None),
+            ("1.0.0-rc1", None),
+            ("1.0.0rc1+foo1", ("foo", 1)),
+            ("1.0.0rc1+dev1", ("dev", 1)),
+            ("1.0.01.dev1", None),
+            ("1.0.0b1.dev1", None),
+            ("1.0.0rc1.dev1", None),
+        ]
+
+        for version, expected in versions:
+            version_local = Version.from_string(version).local
+            self.assertEqual(
+                version_local,
+                expected,
+                f"{version_local} does not match {expected} for version "
+                f"{version}",
+            )
+
 
 class PEP440VersionCalculatorTestCase(unittest.TestCase):
     def test_next_patch_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3.post1",
-            "1.2.3a1",
-            "1.2.3b1",
-            "1.2.3rc1",
-            "1.2.3a1+dev1",
-            "22.4.1",
-            "22.4.1.dev1",
-            "22.4.1.dev3",
-        ]
-        assert_versions = [
-            "0.0.2",
-            "1.2.4",
-            "1.2.4",
-            "1.2.3",
-            "1.2.3",
-            "1.2.3",
-            "1.2.3",
-            "22.4.2",
-            "22.4.1",
-            "22.4.1",
+        versions = [
+            ("0.0.1", "0.0.2"),
+            ("1.2.3", "1.2.4"),
+            ("1.2.3.post1", "1.2.4"),
+            ("1.2.3a1", "1.2.3"),
+            ("1.2.3b1", "1.2.3"),
+            ("1.2.3rc1", "1.2.3"),
+            ("1.2.3a1.dev1", "1.2.3"),
+            ("1.2.3b1.dev1", "1.2.3"),
+            ("1.2.3rc1.dev1", "1.2.3"),
+            ("22.4.1", "22.4.2"),
+            ("22.4.1.dev1", "22.4.1"),
+            ("22.4.1.dev3", "22.4.1"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_patch_version(
                 Version.from_string(current_version)
             )
 
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next patch version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_calendar_versions(self):
@@ -157,239 +469,196 @@ class PEP440VersionCalculatorTestCase(unittest.TestCase):
     def test_next_minor_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3.post1",
-            "1.2.3a1",
-            "1.2.3b1",
-            "1.2.3rc1",
-            "1.2.3a1+dev1",
-            "22.4.1",
-            "22.4.1.dev1",
-            "22.4.1.dev3",
-            "1.0.0a1",
-            "1.1.0a1",
-            "1.0.0.dev1",
-            "1.1.0.dev1",
-        ]
-        assert_versions = [
-            "0.1.0",
-            "1.3.0",
-            "1.3.0",
-            "1.3.0",
-            "1.3.0",
-            "1.3.0",
-            "1.3.0",
-            "22.5.0",
-            "22.5.0",
-            "22.5.0",
-            "1.0.0",
-            "1.1.0",
-            "1.0.0",
-            "1.1.0",
+        versions = [
+            ("0.0.1", "0.1.0"),
+            ("1.2.3", "1.3.0"),
+            ("1.2.3.post1", "1.3.0"),
+            ("1.2.3a1", "1.3.0"),
+            ("1.2.3b1", "1.3.0"),
+            ("1.2.3rc1", "1.3.0"),
+            ("1.2.3a1.dev1", "1.3.0"),
+            ("1.2.3b1.dev1", "1.3.0"),
+            ("1.2.3rc1.dev1", "1.3.0"),
+            ("22.4.1", "22.5.0"),
+            ("22.4.1.dev1", "22.5.0"),
+            ("22.4.1.dev3", "22.5.0"),
+            ("1.0.0a1", "1.0.0"),
+            ("1.1.0a1", "1.1.0"),
+            ("1.0.0.dev1", "1.0.0"),
+            ("1.1.0.dev1", "1.1.0"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_minor_version(
-                Version.from_string(current_version)
+                Version.from_string(current_version),
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next minor version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_major_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3.post1",
-            "1.2.3a1",
-            "1.2.3b1",
-            "1.2.3rc1",
-            "1.2.3a1+dev1",
-            "22.4.1",
-            "22.4.1.dev1",
-            "22.4.1.dev3",
-            "1.0.0a1",
-            "1.0.0.dev1",
+        versions = [
+            ("0.0.1", "1.0.0"),
+            ("1.2.3", "2.0.0"),
+            ("1.2.3.post1", "2.0.0"),
+            ("1.2.3a1", "2.0.0"),
+            ("1.2.3b1", "2.0.0"),
+            ("1.2.3rc1", "2.0.0"),
+            ("1.2.3a1.dev1", "2.0.0"),
+            ("1.2.3b1.dev1", "2.0.0"),
+            ("1.2.3rc1.dev1", "2.0.0"),
+            ("22.4.1", "23.0.0"),
+            ("22.4.1.dev1", "23.0.0"),
+            ("22.4.1.dev3", "23.0.0"),
+            ("1.0.0a1", "1.0.0"),
+            ("1.1.0a1", "2.0.0"),
+            ("1.0.0.dev1", "1.0.0"),
+            ("1.1.0.dev1", "2.0.0"),
         ]
-        assert_versions = [
-            "1.0.0",
-            "2.0.0",
-            "2.0.0",
-            "2.0.0",
-            "2.0.0",
-            "2.0.0",
-            "2.0.0",
-            "23.0.0",
-            "23.0.0",
-            "23.0.0",
-            "1.0.0",
-            "1.0.0",
-        ]
-
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_major_version(
-                Version.from_string(current_version)
+                Version.from_string(current_version),
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next major version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_alpha_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3.post1",
-            "1.2.3a1",
-            "1.2.3b1",
-            "1.2.3rc1",
-            "1.2.3a1+dev1",
-            "22.4.1",
-            "22.4.1.dev1",
-            "22.4.1.dev3",
+        versions = [
+            ("0.0.1", "0.0.2a1"),
+            ("1.2.3", "1.2.4a1"),
+            ("1.2.3.post1", "1.2.4a1"),
+            ("1.2.3a1", "1.2.3a2"),
+            ("1.2.3b1", "1.2.4a1"),
+            ("1.2.3rc1", "1.2.4a1"),
+            ("1.2.3a1.dev1", "1.2.3a2"),
+            ("1.2.3b1.dev1", "1.2.4a1"),
+            ("1.2.3rc1.dev1", "1.2.4a1"),
+            ("22.4.1", "22.4.2a1"),
+            ("22.4.1.dev1", "22.4.1a1"),
+            ("22.4.1.dev3", "22.4.1a1"),
+            ("1.0.0a1", "1.0.0a2"),
+            ("1.1.0a1", "1.1.0a2"),
+            ("1.0.0.dev1", "1.0.0a1"),
+            ("1.1.0.dev1", "1.1.0a1"),
         ]
-        assert_versions = [
-            "0.0.2a1",
-            "1.2.4a1",
-            "1.2.4a1",
-            "1.2.3a2",
-            "1.2.4a1",
-            "1.2.4a1",
-            "1.2.3a2",
-            "22.4.2a1",
-            "22.4.1a1",
-            "22.4.1a1",
-        ]
-
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_alpha_version(
                 Version.from_string(current_version)
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next alpha version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_beta_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3.post1",
-            "1.2.3a1",
-            "1.2.3b1",
-            "1.2.3rc1",
-            "1.2.3a1+dev1",
-            "22.4.1",
-            "22.4.1.dev1",
-            "22.4.1.dev3",
-        ]
-        assert_versions = [
-            "0.0.2b1",
-            "1.2.4b1",
-            "1.2.4b1",
-            "1.2.3b1",
-            "1.2.3b2",
-            "1.2.4b1",
-            "1.2.3b1",
-            "22.4.2b1",
-            "22.4.1b1",
-            "22.4.1b1",
+        versions = [
+            ("0.0.1", "0.0.2b1"),
+            ("1.2.3", "1.2.4b1"),
+            ("1.2.3.post1", "1.2.4b1"),
+            ("1.2.3a1", "1.2.3b1"),
+            ("1.2.3b1", "1.2.3b2"),
+            ("1.2.3rc1", "1.2.4b1"),
+            ("1.2.3a1.dev1", "1.2.3b1"),
+            ("1.2.3b1.dev1", "1.2.3b2"),
+            ("1.2.3rc1.dev1", "1.2.4b1"),
+            ("22.4.1", "22.4.2b1"),
+            ("22.4.1.dev1", "22.4.1b1"),
+            ("22.4.1.dev3", "22.4.1b1"),
+            ("1.0.0a1", "1.0.0b1"),
+            ("1.1.0a1", "1.1.0b1"),
+            ("1.0.0.dev1", "1.0.0b1"),
+            ("1.1.0.dev1", "1.1.0b1"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_beta_version(
                 Version.from_string(current_version)
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next beta version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_release_candidate_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3.post1",
-            "1.2.3a1",
-            "1.2.3b1",
-            "1.2.3rc1",
-            "1.2.3a1+dev1",
-            "22.4.1",
-            "22.4.1.dev1",
-            "22.4.1.dev3",
-        ]
-        assert_versions = [
-            "0.0.2rc1",
-            "1.2.4rc1",
-            "1.2.4rc1",
-            "1.2.3rc1",
-            "1.2.3rc1",
-            "1.2.3rc2",
-            "1.2.3rc1",
-            "22.4.2rc1",
-            "22.4.1rc1",
-            "22.4.1rc1",
+        versions = [
+            ("0.0.1", "0.0.2rc1"),
+            ("1.2.3", "1.2.4rc1"),
+            ("1.2.3.post1", "1.2.4rc1"),
+            ("1.2.3a1", "1.2.3rc1"),
+            ("1.2.3b1", "1.2.3rc1"),
+            ("1.2.3rc1", "1.2.3rc2"),
+            ("1.2.3a1.dev1", "1.2.3rc1"),
+            ("1.2.3b1.dev1", "1.2.3rc1"),
+            ("1.2.3rc1.dev1", "1.2.3rc2"),
+            ("22.4.1", "22.4.2rc1"),
+            ("22.4.1.dev1", "22.4.1rc1"),
+            ("22.4.1.dev3", "22.4.1rc1"),
+            ("1.0.0a1", "1.0.0rc1"),
+            ("1.1.0a1", "1.1.0rc1"),
+            ("1.0.0.dev1", "1.0.0rc1"),
+            ("1.1.0.dev1", "1.1.0rc1"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_release_candidate_version(
                 Version.from_string(current_version)
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next rc version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_dev_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3.post1",
-            "1.2.3a1",
-            "1.2.3b1",
-            "1.2.3rc1",
-            "1.2.3a1+dev1",
-            "22.4.1",
-            "22.4.1.dev1",
-            "22.4.1.dev3",
-        ]
-        assert_versions = [
-            "0.0.2.dev1",
-            "1.2.4.dev1",
-            "1.2.4.dev1",
-            "1.2.3a1+dev1",
-            "1.2.3b1+dev1",
-            "1.2.3rc1+dev1",
-            "1.2.3a1+dev1",
-            "22.4.2.dev1",
-            "22.4.1.dev2",
-            "22.4.1.dev4",
+        versions = [
+            ("0.0.1", "0.0.2.dev1"),
+            ("1.2.3", "1.2.4.dev1"),
+            ("1.2.3.dev1", "1.2.3.dev2"),
+            ("1.2.3.post1", "1.2.4.dev1"),
+            ("1.2.3a1", "1.2.3a2.dev1"),
+            ("1.2.3b1", "1.2.3b2.dev1"),
+            ("1.2.3rc1", "1.2.3rc2.dev1"),
+            ("1.2.3a1.dev1", "1.2.3a1.dev2"),
+            ("1.2.3b1.dev1", "1.2.3b1.dev2"),
+            ("1.2.3rc1.dev1", "1.2.3rc1.dev2"),
+            ("22.4.1", "22.4.2.dev1"),
+            ("22.4.1.dev1", "22.4.1.dev2"),
+            ("22.4.1.dev3", "22.4.1.dev4"),
+            ("1.0.0a1", "1.0.0a2.dev1"),
+            ("1.1.0a1", "1.1.0a2.dev1"),
+            ("1.0.0.dev1", "1.0.0.dev2"),
+            ("1.1.0.dev1", "1.1.0.dev2"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_dev_version(
                 Version.from_string(current_version)
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the next expected dev version "
+                f"{assert_version} for {current_version}",
             )

--- a/tests/version/schemes/test_semantic.py
+++ b/tests/version/schemes/test_semantic.py
@@ -19,6 +19,7 @@ import unittest
 from datetime import datetime
 
 from pontos.version.errors import VersionError
+from pontos.version.schemes._pep440 import PEP440Version
 from pontos.version.schemes._semantic import SemanticVersion as Version
 from pontos.version.schemes._semantic import (
     SemanticVersionCalculator as VersionCalculator,
@@ -30,13 +31,17 @@ class SemanticVersionTestCase(unittest.TestCase):
         versions = [
             "0.0.1",
             "1.2.3",
-            "1.2.3-post1",
+            "1.2.3-foo1",
             "1.2.3-a1",
             "1.2.3-alpha1",
+            "1.2.3-alpha1-dev1",
             "1.2.3-b1",
             "1.2.3-beta1",
+            "1.2.3-beta1-dev1",
             "1.2.3-rc1",
-            "1.2.3-a1+dev1",
+            "1.2.3-rc1-dev1",
+            "1.2.3-dev1",
+            "1.2.3+foo1",
             "22.4.1",
             "22.4.1-dev1",
             "22.4.1-dev3",
@@ -66,53 +71,343 @@ class SemanticVersionTestCase(unittest.TestCase):
     def test_parse_prerelease_error(self):
         versions = [
             "1.2.3-pos1t1",
+            "1.2.3-dev1-dev1",
         ]
 
         for version in versions:
             with self.assertRaisesRegex(
-                VersionError, f"^Invalid prerelease [a-zA-Z0-9]* in {version}"
+                VersionError, f"^Invalid prerelease .* in {version}"
             ):
                 Version.from_string(version)
+
+    def test_equal(self):
+        versions = [
+            ("1.0.0", "1.0.0"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0-dev1", "1.0.0-dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1-dev1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-beta1-dev1", "1.0.0-beta1-dev1"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+            ("1.0.0-rc1-dev1", "1.0.0-rc1-dev1"),
+        ]
+        for version1, version2 in versions:
+            self.assertTrue(
+                Version.from_string(version1) == Version.from_string(version2),
+                f"{version1} does not equal {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "1.0.1"),
+            ("1.0.0", "1.0.0+dev1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-beta1"),
+            ("1.0.0+dev1", "1.0.0-dev1"),  # maybe both should be equal
+            ("1.0.0+dev1", "1.0.0+dev2"),
+            ("1.0.0-alpha1", "1.0.0-beta1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev2"),
+            ("1.0.0-beta1", "1.0.0-beta1+dev1"),
+            ("1.0.0-beta1+dev1", "1.0.0-beta1+dev2"),
+            ("1.0.0-rc1", "1.0.0-rc1+dev1"),
+            ("1.0.0-rc1+dev1", "1.0.0-rc1+dev2"),
+        ]
+        for version1, version2 in versions:
+            self.assertFalse(
+                Version.from_string(version1) == Version.from_string(version2),
+                f"{version1} equals {version2}",
+            )
+
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) == version2)
+
+    def test_equal_pep440_version(self):
+        versions = [
+            ("1.0.0", "1.0.0"),
+            ("1.0.0-dev1", "1.0.0-dev1"),
+            ("1.0.0-dev1", "1.0.0.dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-alpha1", "1.0.0a1"),
+            ("1.0.0-alpha1-dev1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-alpha1-dev1", "1.0.0a1.dev1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-beta1", "1.0.0b1"),
+            ("1.0.0-beta1-dev1", "1.0.0-beta1-dev1"),
+            ("1.0.0-beta1-dev1", "1.0.0b1.dev1"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+            ("1.0.0-rc1-dev1", "1.0.0-rc1.dev1"),
+            ("1.0.0-rc1-dev1", "1.0.0rc1.dev1"),
+        ]
+        for version1, version2 in versions:
+            semver = Version.from_string(version1)
+            pep440 = PEP440Version.from_string(version2)
+            self.assertTrue(
+                semver == pep440,
+                f"{semver!r} {version1} does not equal {pep440!r} {version2}",
+            )
+
+    def test_not_equal(self):
+        versions = [
+            ("1.0.0", "1.0.0"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+        ]
+        for version1, version2 in versions:
+            self.assertFalse(
+                Version.from_string(version1) != Version.from_string(version2),
+                f"{version1} does not equal {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "1.0.1"),
+            ("1.0.0", "1.0.0+dev1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-beta1"),
+            ("1.0.0+dev1", "1.0.0+dev2"),
+            ("1.0.0-alpha1", "1.0.0-beta1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev2"),
+            ("1.0.0-beta1", "1.0.0-beta1+dev1"),
+            ("1.0.0-beta1+dev1", "1.0.0-beta1+dev2"),
+            ("1.0.0-rc1", "1.0.0-rc1+dev1"),
+            ("1.0.0-rc1+dev1", "1.0.0-rc1+dev2"),
+        ]
+        for version1, version2 in versions:
+            self.assertTrue(
+                Version.from_string(version1) != Version.from_string(version2),
+                f"{version1} equals {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "abc"),
+        ]
+        for version1, version2 in versions:
+            self.assertTrue(Version.from_string(version1) != version2)
+
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) != version2)
+
+    def test_is_dev_release(self):
+        versions = [
+            "1.0.0-dev1",
+            "1.0.0-alpha1-dev1",
+            "1.0.0-beta1-dev1",
+            "1.0.0-rc1-dev1",
+        ]
+        for version in versions:
+            self.assertTrue(
+                Version.from_string(version).is_dev_release,
+                f"{version} is not a dev release",
+            )
+
+        versions = [
+            "1.0.0",
+            "1.0.0+foo1",
+            "1.0.0+dev1",
+            "1.0.0-alpha1",
+            "1.0.0-beta1",
+            "1.0.0-rc1",
+            "1.0.0-alpha1+dev1",
+            "1.0.0-beta1+dev1",
+            "1.0.0-rc1+dev1",
+        ]
+        for version in versions:
+            self.assertFalse(
+                Version.from_string(version).is_dev_release,
+                f"{version} is a dev release",
+            )
+
+    def test_is_alpha_release(self):
+        versions = [
+            "1.0.0-alpha1",
+            "1.0.0-alpha1+foo1",
+            "1.0.0-alpha1-foo1",
+            "1.0.0-alpha1+dev1",
+            "1.0.0-alpha1-dev1",
+        ]
+        for version in versions:
+            self.assertTrue(
+                Version.from_string(version).is_alpha_release,
+                f"{version} is not an alpha release",
+            )
+
+        versions = [
+            "1.0.0",
+            "1.0.0+dev1",
+            "1.0.0-dev1",
+            "1.0.0-a1",
+            "1.0.0-b1",
+            "1.0.0-rc1",
+        ]
+        for version in versions:
+            self.assertFalse(
+                Version.from_string(version).is_alpha_release,
+                f"{version} is an alpha release",
+            )
+
+    def test_is_beta_release(self):
+        versions = [
+            "1.0.0-beta1",
+            "1.0.0-beta1+foo1",
+            "1.0.0-beta1-foo1",
+            "1.0.0-beta1+dev1",
+            "1.0.0-beta1-dev1",
+        ]
+        for version in versions:
+            self.assertTrue(
+                Version.from_string(version).is_beta_release,
+                f"{version} is not a beta release",
+            )
+
+        versions = [
+            "1.0.0",
+            "1.0.0-dev1",
+            "1.0.0+dev1",
+            "1.0.0-alpha1",
+            "1.0.0-b1",
+            "1.0.0-rc1",
+        ]
+        for version in versions:
+            self.assertFalse(
+                Version.from_string(version).is_beta_release,
+                f"{version} is a beta release",
+            )
+
+    def test_is_release_candidate(self):
+        versions = [
+            "1.0.0-rc1",
+            "1.0.0-rc1+foo1",
+            "1.0.0-rc1-foo1",
+            "1.0.0-rc1+dev1",
+            "1.0.0-rc1-dev1",
+        ]
+        for version in versions:
+            self.assertTrue(
+                Version.from_string(version).is_release_candidate,
+                f"{version} is not a release candidate",
+            )
+
+        versions = [
+            "1.0.0",
+            "1.0.0+dev1",
+            "1.0.0-dev1",
+            "1.0.0-alpha1",
+            "1.0.0-beta1",
+        ]
+        for version in versions:
+            self.assertFalse(
+                Version.from_string(version).is_release_candidate,
+                f"{version} is a release candidate",
+            )
+
+    def test_pre(self):
+        versions = [
+            ("1.0.0", None),
+            ("1.0.0+dev1", None),
+            ("1.0.0-dev1", None),
+            ("1.0.0-alpha1", ("alpha", 1)),
+            ("1.0.0-beta1", ("beta", 1)),
+            ("1.0.0-rc1", ("rc", 1)),
+            ("1.0.0-rc1+foo1", ("rc", 1)),
+            ("1.0.0-alpha1+dev1", ("alpha", 1)),
+            ("1.0.0-beta1+dev1", ("beta", 1)),
+            ("1.0.0-rc1+dev1", ("rc", 1)),
+            ("1.0.0-alpha1-dev1", ("alpha", 1)),
+            ("1.0.0-beta1-dev1", ("beta", 1)),
+            ("1.0.0-rc1-dev1", ("rc", 1)),
+        ]
+
+        for version, expected in versions:
+            self.assertEqual(Version.from_string(version).pre, expected)
+
+    def test_local(self):
+        versions = [
+            ("1.0.0", None),
+            ("1.0.0+foo1", ("foo", 1)),
+            ("1.0.0+dev1", ("dev", 1)),
+            ("1.0.0-dev1", None),
+            ("1.0.0-alpha1", None),
+            ("1.0.0-beta1", None),
+            ("1.0.0-rc1", None),
+            ("1.0.0-rc1+foo1", ("foo", 1)),
+            ("1.0.0-alpha1+dev1", ("dev", 1)),
+            ("1.0.0-beta1+dev1", ("dev", 1)),
+            ("1.0.0-rc1+dev1", ("dev", 1)),
+            ("1.0.0-alpha1-dev1", None),
+            ("1.0.0-beta1-dev1", None),
+            ("1.0.0-rc1-dev1", None),
+        ]
+
+        for version, expected in versions:
+            local = Version.from_string(version).local
+            self.assertEqual(
+                local,
+                expected,
+                f"{version} has not the expected local {expected}. Instead it "
+                f"is {local}",
+            )
 
 
 class SemanticVersionCalculatorTestCase(unittest.TestCase):
     def test_next_patch_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3-post1",
-            "1.2.3-alpha1",
-            "1.2.3-beta1",
-            "1.2.3-rc1",
-            "1.2.3-alpha1+dev1",
-            "22.4.1",
-            "22.4.1-dev1",
-            "22.4.1-dev3",
-        ]
-        assert_versions = [
-            "0.0.2",
-            "1.2.4",
-            "1.2.3",
-            "1.2.3",
-            "1.2.3",
-            "1.2.3",
-            "1.2.3",
-            "22.4.2",
-            "22.4.1",
-            "22.4.1",
+        versions = [
+            ("0.0.1", "0.0.2"),
+            ("1.2.3", "1.2.4"),
+            ("1.2.3+dev1", "1.2.4"),
+            ("1.2.3-dev1", "1.2.3"),
+            ("1.2.3-foo1", "1.2.3"),
+            ("1.2.3-alpha1", "1.2.3"),
+            ("1.2.3-beta1", "1.2.3"),
+            ("1.2.3-rc1", "1.2.3"),
+            ("1.2.3-alpha1+dev1", "1.2.3"),
+            ("1.2.3-beta1+dev1", "1.2.3"),
+            ("1.2.3-rc1+dev1", "1.2.3"),
+            ("1.2.3-alpha1-dev1", "1.2.3"),
+            ("1.2.3-beta1-dev1", "1.2.3"),
+            ("1.2.3-rc1-dev1", "1.2.3"),
+            ("22.4.1", "22.4.2"),
+            ("22.4.1+dev3", "22.4.2"),
+            ("22.4.1-dev1", "22.4.1"),
+            ("22.4.1-dev3", "22.4.1"),
+            ("1.0.0-a1", "1.0.0"),
+            ("1.1.0-alpha1", "1.1.0"),
+            ("1.0.0+dev1", "1.0.1"),
+            ("1.1.0+dev1", "1.1.1"),
+            ("1.0.0-dev1", "1.0.0"),
+            ("1.1.0-dev1", "1.1.0"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_patch_version(
                 Version.from_string(current_version)
             )
 
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next patch version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_calendar_versions(self):
@@ -161,239 +456,248 @@ class SemanticVersionCalculatorTestCase(unittest.TestCase):
     def test_next_minor_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3-post1",
-            "1.2.3-alpha1",
-            "1.2.3-beta1",
-            "1.2.3-rc1",
-            "1.2.3-alpha1+dev1",
-            "22.4.1",
-            "22.4.1-dev1",
-            "22.4.1-dev3",
-            "1.0.0-a1",
-            "1.1.0-alpha1",
-            "1.0.0-dev1",
-            "1.1.0-dev1",
+        versions = [
+            ("0.0.1", "0.1.0"),
+            ("1.2.3", "1.3.0"),
+            ("1.2.3+dev1", "1.3.0"),
+            ("1.2.3-dev1", "1.3.0"),
+            ("1.2.3-foo1", "1.3.0"),
+            ("1.2.3-alpha1", "1.3.0"),
+            ("1.2.3-beta1", "1.3.0"),
+            ("1.2.3-rc1", "1.3.0"),
+            ("1.2.3-alpha1+dev1", "1.3.0"),
+            ("1.2.3-beta1+dev1", "1.3.0"),
+            ("1.2.3-rc1+dev1", "1.3.0"),
+            ("22.4.1", "22.5.0"),
+            ("22.4.1+dev3", "22.5.0"),
+            ("22.4.1-dev1", "22.5.0"),
+            ("22.4.1-dev3", "22.5.0"),
+            ("1.0.0-a1", "1.0.0"),
+            ("1.1.0-alpha1", "1.1.0"),
+            ("1.0.0+dev1", "1.1.0"),
+            ("1.1.0+dev1", "1.2.0"),
+            ("1.0.0-dev1", "1.0.0"),
+            ("1.1.0-dev1", "1.1.0"),
         ]
-        assert_versions = [
-            "0.1.0",
-            "1.3.0",
-            "1.3.0",
-            "1.3.0",
-            "1.3.0",
-            "1.3.0",
-            "1.3.0",
-            "22.5.0",
-            "22.5.0",
-            "22.5.0",
-            "1.0.0",
-            "1.1.0",
-            "1.0.0",
-            "1.1.0",
-        ]
-
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_minor_version(
                 Version.from_string(current_version)
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next minor version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_major_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3-post1",
-            "1.2.3-alpha1",
-            "1.2.3-beta1",
-            "1.2.3-rc1",
-            "1.2.3-alpha1+dev1",
-            "22.4.1",
-            "22.4.1-dev1",
-            "22.4.1-dev3",
-            "1.0.0-a1",
-            "1.0.0-beta1",
-            "1.0.0-dev1",
-        ]
-        assert_versions = [
-            "1.0.0",
-            "2.0.0",
-            "2.0.0",
-            "2.0.0",
-            "2.0.0",
-            "2.0.0",
-            "2.0.0",
-            "23.0.0",
-            "23.0.0",
-            "23.0.0",
-            "1.0.0",
-            "1.0.0",
-            "1.0.0",
+        versions = [
+            ("0.0.1", "1.0.0"),
+            ("1.2.3", "2.0.0"),
+            ("1.2.3+dev1", "2.0.0"),
+            ("1.2.3-dev1", "2.0.0"),
+            ("1.2.3-foo1", "2.0.0"),
+            ("1.2.3-alpha1", "2.0.0"),
+            ("1.2.3-beta1", "2.0.0"),
+            ("1.2.3-rc1", "2.0.0"),
+            ("1.2.3-alpha1+dev1", "2.0.0"),
+            ("1.2.3-beta1+dev1", "2.0.0"),
+            ("1.2.3-rc1+dev1", "2.0.0"),
+            ("1.2.3-alpha1-dev1", "2.0.0"),
+            ("1.2.3-beta1-dev1", "2.0.0"),
+            ("1.2.3-rc1-dev1", "2.0.0"),
+            ("22.4.1", "23.0.0"),
+            ("22.4.1+dev3", "23.0.0"),
+            ("22.4.1-dev1", "23.0.0"),
+            ("22.4.1-dev3", "23.0.0"),
+            ("1.0.0-a1", "1.0.0"),
+            ("1.0.0-beta1", "1.0.0"),
+            ("1.1.0-alpha1", "2.0.0"),
+            ("1.0.0+dev1", "2.0.0"),
+            ("1.1.0+dev1", "2.0.0"),
+            ("1.0.0-dev1", "1.0.0"),
+            ("1.1.0-dev1", "2.0.0"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_major_version(
                 Version.from_string(current_version)
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next major version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_alpha_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3-post1",
-            "1.2.3-alpha1",
-            "1.2.3-beta1",
-            "1.2.3-rc1",
-            "1.2.3-alpha1+dev1",
-            "22.4.1",
-            "22.4.1-dev1",
-            "22.4.1-dev3",
-        ]
-        assert_versions = [
-            "0.0.2-alpha1",
-            "1.2.4-alpha1",
-            "1.2.4-alpha1",
-            "1.2.3-alpha2",
-            "1.2.4-alpha1",
-            "1.2.4-alpha1",
-            "1.2.3-alpha2",
-            "22.4.2-alpha1",
-            "22.4.1-alpha1",
-            "22.4.1-alpha1",
+        versions = [
+            ("0.0.1", "0.0.2-alpha1"),
+            ("1.2.3", "1.2.4-alpha1"),
+            ("1.2.3+dev1", "1.2.4-alpha1"),
+            ("1.2.3-dev1", "1.2.3-alpha1"),
+            ("1.2.3-post1", "1.2.4-alpha1"),
+            ("1.2.3-alpha1", "1.2.3-alpha2"),
+            ("1.2.3-beta1", "1.2.4-alpha1"),
+            ("1.2.3-rc1", "1.2.4-alpha1"),
+            ("1.2.3-alpha1+dev1", "1.2.3-alpha2"),
+            ("1.2.3-beta1+dev1", "1.2.4-alpha1"),
+            ("1.2.3-rc1+dev1", "1.2.4-alpha1"),
+            ("1.2.3-alpha1-dev1", "1.2.3-alpha2"),
+            ("1.2.3-beta1-dev1", "1.2.4-alpha1"),
+            ("1.2.3-beta1-dev1", "1.2.4-alpha1"),
+            ("22.4.1", "22.4.2-alpha1"),
+            ("22.4.1+dev3", "22.4.2-alpha1"),
+            ("22.4.1-dev1", "22.4.1-alpha1"),
+            ("22.4.1-dev3", "22.4.1-alpha1"),
+            ("1.0.0-a1", "1.0.1-alpha1"),
+            ("1.0.0-beta1", "1.0.1-alpha1"),
+            ("1.1.0-alpha1", "1.1.0-alpha2"),
+            ("1.0.0+dev1", "1.0.1-alpha1"),
+            ("1.1.0+dev1", "1.1.1-alpha1"),
+            ("1.0.0-dev1", "1.0.0-alpha1"),
+            ("1.1.0-dev1", "1.1.0-alpha1"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_alpha_version(
                 Version.from_string(current_version)
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next alpha version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_beta_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3-post1",
-            "1.2.3-alpha1",
-            "1.2.3-beta1",
-            "1.2.3-rc1",
-            "1.2.3-alpha1+dev1",
-            "22.4.1",
-            "22.4.1-dev1",
-            "22.4.1-dev3",
-        ]
-        assert_versions = [
-            "0.0.2-beta1",
-            "1.2.4-beta1",
-            "1.2.4-beta1",
-            "1.2.3-beta1",
-            "1.2.3-beta2",
-            "1.2.4-beta1",
-            "1.2.3-beta1",
-            "22.4.2-beta1",
-            "22.4.1-beta1",
-            "22.4.1-beta1",
+        versions = [
+            ("0.0.1", "0.0.2-beta1"),
+            ("1.2.3", "1.2.4-beta1"),
+            ("1.2.3+dev1", "1.2.4-beta1"),
+            ("1.2.3-dev1", "1.2.3-beta1"),
+            ("1.2.3-foo1", "1.2.4-beta1"),
+            ("1.2.3-alpha1", "1.2.3-beta1"),
+            ("1.2.3-beta1", "1.2.3-beta2"),
+            ("1.2.3-rc1", "1.2.4-beta1"),
+            ("1.2.3-alpha1+dev1", "1.2.3-beta1"),
+            ("1.2.3-beta1+dev1", "1.2.3-beta2"),
+            ("1.2.3-rc1+dev1", "1.2.4-beta1"),
+            ("1.2.3-alpha1-dev1", "1.2.3-beta1"),
+            ("1.2.3-beta1-dev1", "1.2.3-beta2"),
+            ("1.2.3-rc1-dev1", "1.2.4-beta1"),
+            ("22.4.1", "22.4.2-beta1"),
+            ("22.4.1+dev3", "22.4.2-beta1"),
+            ("22.4.1-dev1", "22.4.1-beta1"),
+            ("22.4.1-dev3", "22.4.1-beta1"),
+            # actually 1.0.0-beta1 would also be ok, but it would require to
+            # to add extra code for not used versioning
+            ("1.0.0-a1", "1.0.1-beta1"),
+            ("1.0.0-beta1", "1.0.0-beta2"),
+            ("1.1.0-alpha1", "1.1.0-beta1"),
+            ("1.0.0+dev1", "1.0.1-beta1"),
+            ("1.1.0+dev1", "1.1.1-beta1"),
+            ("1.0.0-dev1", "1.0.0-beta1"),
+            ("1.1.0-dev1", "1.1.0-beta1"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_beta_version(
                 Version.from_string(current_version)
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next beta version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_release_candidate_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3-post1",
-            "1.2.3-alpha1",
-            "1.2.3-beta1",
-            "1.2.3-rc1",
-            "1.2.3-alpha1+dev1",
-            "22.4.1",
-            "22.4.1-dev1",
-            "22.4.1-dev3",
-        ]
-        assert_versions = [
-            "0.0.2-rc1",
-            "1.2.4-rc1",
-            "1.2.4-rc1",
-            "1.2.3-rc1",
-            "1.2.3-rc1",
-            "1.2.3-rc2",
-            "1.2.3-rc1",
-            "22.4.2-rc1",
-            "22.4.1-rc1",
-            "22.4.1-rc1",
+        versions = [
+            ("0.0.1", "0.0.2-rc1"),
+            ("1.2.3", "1.2.4-rc1"),
+            ("1.2.3+dev1", "1.2.4-rc1"),
+            ("1.2.3-dev1", "1.2.3-rc1"),
+            ("1.2.3-foo1", "1.2.4-rc1"),
+            ("1.2.3-alpha1", "1.2.3-rc1"),
+            ("1.2.3-beta1", "1.2.3-rc1"),
+            ("1.2.3-rc1", "1.2.3-rc2"),
+            ("1.2.3-alpha1+dev1", "1.2.3-rc1"),
+            ("1.2.3-beta1+dev1", "1.2.3-rc1"),
+            ("1.2.3-rc1+dev1", "1.2.3-rc2"),
+            ("1.2.3-alpha1-dev1", "1.2.3-rc1"),
+            ("1.2.3-beta1-dev1", "1.2.3-rc1"),
+            ("1.2.3-rc1-dev1", "1.2.3-rc2"),
+            ("22.4.1", "22.4.2-rc1"),
+            ("22.4.1+dev3", "22.4.2-rc1"),
+            ("22.4.1-dev1", "22.4.1-rc1"),
+            ("22.4.1-dev3", "22.4.1-rc1"),
+            ("1.0.0-a1", "1.0.1-rc1"),
+            ("1.0.0-beta1", "1.0.0-rc1"),
+            ("1.1.0-alpha1", "1.1.0-rc1"),
+            ("1.0.0+dev1", "1.0.1-rc1"),
+            ("1.1.0+dev1", "1.1.1-rc1"),
+            ("1.0.0-dev1", "1.0.0-rc1"),
+            ("1.1.0-dev1", "1.1.0-rc1"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_release_candidate_version(
                 Version.from_string(current_version)
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next rc version "
+                f"{assert_version} for {current_version}",
             )
 
     def test_next_dev_version(self):
         calculator = VersionCalculator()
 
-        current_versions = [
-            "0.0.1",
-            "1.2.3",
-            "1.2.3-alpha1",
-            "1.2.3-beta1",
-            "1.2.3-rc1",
-            # "1.2.3-alpha1+dev1",
-            "22.4.1",
-            "22.4.1-dev1",
-            "22.4.1-dev3",
-        ]
-        assert_versions = [
-            "0.0.2-dev1",
-            "1.2.4-dev1",
-            "1.2.3-alpha1+dev1",
-            "1.2.3-beta1+dev1",
-            "1.2.3-rc1+dev1",
-            # "1.2.3-alpha1+dev1",
-            "22.4.2-dev1",
-            "22.4.1-dev2",
-            "22.4.1-dev4",
+        versions = [
+            ("0.0.1", "0.0.2-dev1"),
+            ("1.2.3", "1.2.4-dev1"),
+            ("1.2.3+dev1", "1.2.4-dev1"),
+            ("1.2.3-dev1", "1.2.3-dev2"),
+            ("1.2.3-foo1", "1.2.3-foo2-dev1"),
+            ("1.2.3-alpha1", "1.2.3-alpha2-dev1"),
+            ("1.2.3-beta1", "1.2.3-beta2-dev1"),
+            ("1.2.3-rc1", "1.2.3-rc2-dev1"),
+            ("1.2.3-alpha1+dev1", "1.2.3-alpha2-dev1"),
+            ("1.2.3-beta1+dev1", "1.2.3-beta2-dev1"),
+            ("1.2.3-rc1+dev1", "1.2.3-rc2-dev1"),
+            ("1.2.3-alpha1-dev1", "1.2.3-alpha1-dev2"),
+            ("1.2.3-beta1-dev1", "1.2.3-beta1-dev2"),
+            ("1.2.3-rc1-dev1", "1.2.3-rc1-dev2"),
+            ("22.4.1", "22.4.2-dev1"),
+            ("22.4.1+dev3", "22.4.2-dev1"),
+            ("22.4.1-dev1", "22.4.1-dev2"),
+            ("22.4.1-dev3", "22.4.1-dev4"),
+            ("1.0.0-a1", "1.0.0-a2-dev1"),
+            ("1.0.0-beta1", "1.0.0-beta2-dev1"),
+            ("1.1.0-alpha1", "1.1.0-alpha2-dev1"),
+            ("1.0.0+dev1", "1.0.1-dev1"),
+            ("1.1.0+dev1", "1.1.1-dev1"),
+            ("1.0.0-dev1", "1.0.0-dev2"),
+            ("1.1.0-dev1", "1.1.0-dev2"),
         ]
 
-        for current_version, assert_version in zip(
-            current_versions, assert_versions
-        ):
+        for current_version, assert_version in versions:
             release_version = calculator.next_dev_version(
                 Version.from_string(current_version)
             )
             self.assertEqual(
-                release_version, Version.from_string(assert_version)
+                release_version,
+                Version.from_string(assert_version),
+                f"{release_version} is not the expected next development "
+                f"version {assert_version} for {current_version}",
             )


### PR DESCRIPTION
## What

Ensure version calculation, comparison and parsing with tests. With the change the following calculations are implemented:

| Version | Next  | Semver | PEP 440 |
|---------|-------|--------|---------|
| 1.0.0   | Major | 2.0.0  | 2.0.0   |
| 1.0.0   | Minor | 1.1.0  | 1.1.0   |
| 1.0.0   | Patch | 1.0.1  | 1.0.1   |
| 1.0.0   | Alpha | 1.0.1-alpha1 | 1.0.1a1    |
| 1.0.0   | Beta  | 1.0.1-beta1  | 1.0.1b1    |
| 1.0.0   | RC    | 1.0.1-rc1    | 1.0.1rc1   |
| 1.0.0   | Dev   | 1.0.1-dev1   | 1.0.1.dev1 |
| 1.0.0-alpha1 | Dev   | 1.0.0-alpha2-dev1 | 1.0.0a2.dev1  |
| 1.0.0-alpha1 | Alpha | 1.0.0-alpha2      | 1.0.0a2       |
| 1.0.0-alpha1 | Beta  | 1.0.0-beta1       | 1.0.0b1       |
| 1.0.0-alpha1 | RC    | 1.0.0-rc1         | 1.0.0rc1      |
| 1.0.0-beta1  | Dev   | 1.0.0-beta2-dev1  | 1.0.0b2.dev1  |
| 1.0.0-beta1  | Alpha | 1.0.1-alpha1      | 1.0.1a1       |
| 1.0.0-beta1  | Beta  | 1.0.0-beta2       | 1.0.0b2       |
| 1.0.0-beta1  | RC    | 1.0.0-rc1         | 1.0.0rc1      |
| 1.0.0-rc1    | Dev   | 1.0.0-rc2-dev1    | 1.0.0rc2.dev1 |
| 1.0.0-rc1    | Alpha | 1.0.1-alpha1      | 1.0.1a1       |
| 1.0.0-rc1    | Beta  | 1.0.1-beta1       | 1.0.1b1       |
| 1.0.0-rc1    | RC    | 1.0.0-rc2         | 1.0.0rc2      |


## Why

Fix creating releases with semver where comparison was broken.

## References

DEVOPS-613

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


