### PR TITLE
Change: Improve handling git errors during a release

### DIFF
--- a/pontos/release/main.py
+++ b/pontos/release/main.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 from typing import NoReturn
 
+from pontos.git import GitError
 from pontos.release.parser import parse_args
 from pontos.terminal.null import NullTerminal
 from pontos.terminal.rich import RichTerminal
@@ -48,6 +49,11 @@ def main(
             )
             sys.exit(int(retval))
         except KeyboardInterrupt:
+            sys.exit(1)
+        except GitError as e:
+            term.error(f'Could not run git command "{e.cmd}".')
+            error = e.stderr if e.stderr else e.stdout
+            term.print(f"Output was: {error}")
             sys.exit(1)
         except subprocess.CalledProcessError as e:
             if not "--passphrase" in e.cmd:


### PR DESCRIPTION
## What

Improve handling git errors during a release

## Why

Under some circumstances git may fail without issuing an error message to stderror. To improve the situation handle git errors explicitly and print stdout if stderror is empty.


