### PR TITLE
Change: Suppress console output while testing error cases

### DIFF
--- a/tests/version/test_main.py
+++ b/tests/version/test_main.py
@@ -160,9 +160,9 @@ class MainTestCase(unittest.TestCase):
         self.assertEqual(cm.exception.code, VersionExitCode.SUCCESS)
 
     def test_next_invalid_current(self):
-        with temp_directory(change_into=True) as temp_dir, self.assertRaises(
-            SystemExit
-        ) as cm:
+        with redirect_stderr(StringIO()), temp_directory(
+            change_into=True
+        ) as temp_dir, self.assertRaises(SystemExit) as cm:
             version_file = temp_dir / "package.json"
             version_file.write_text(
                 '{"name": "foo", "version": "1.2.tt"}',

--- a/tests/version/test_parser.py
+++ b/tests/version/test_parser.py
@@ -16,13 +16,15 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import unittest
+from contextlib import redirect_stderr
+from io import StringIO
 
 from pontos.version.parser import parse_args
 
 
 class ParserTestCase(unittest.TestCase):
     def test_error_while_parsing(self):
-        with self.assertRaises(SystemExit) as cm:
+        with redirect_stderr(StringIO()), self.assertRaises(SystemExit) as cm:
             parse_args(["update", "foo"])
 
         # exception code in argparse


### PR DESCRIPTION
## What

Suppress console output while testing error cases

## Why

Redirect stderror when testing errors to silence the tests.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


