### PR TITLE
Add: Allow to get the conventional commits by type

### DIFF
--- a/pontos/changelog/conventional_commits.py
+++ b/pontos/changelog/conventional_commits.py
@@ -116,8 +116,7 @@ class ChangelogBuilder:
         Returns:
             The created changelog content.
         """
-        commit_list = self._get_git_log(last_version)
-        commit_dict = self._sort_commits(commit_list)
+        commit_dict = self.get_commits(last_version)
         return self._build_changelog(last_version, next_version, commit_dict)
 
     def create_changelog_file(
@@ -142,6 +141,23 @@ class ChangelogBuilder:
             last_version=last_version, next_version=next_version
         )
         self._write_changelog_file(changelog, output)
+
+    def get_commits(
+        self,
+        last_version: Optional[SupportsStr] = None,
+    ) -> Dict[str, List[str]]:
+        """
+        Get all commits by conventional commit type
+
+        Args:
+            last_version: Version of the last release. If None it is considered
+                as the first release.
+
+        Returns:
+            A dict containing the grouped commit messages
+        """
+        commit_list = self._get_git_log(last_version)
+        return self._sort_commits(commit_list)
 
     def _get_first_commit(self) -> str:
         """
@@ -185,7 +201,8 @@ class ChangelogBuilder:
         ```
 
         Returns
-            The dict containing the commit messages"""
+            The dict containing the commit messages
+        """
         # get the commit types from the toml
         commit_types = self.config.get("commit_types")
 

--- a/tests/changelog/test_conventional_commits.py
+++ b/tests/changelog/test_conventional_commits.py
@@ -505,3 +505,32 @@ class ChangelogBuilderTestCase(unittest.TestCase):
         git_mock.return_value.log.assert_called_once_with(
             "v0.0.1..HEAD", oneline=True
         )
+
+    @patch("pontos.changelog.conventional_commits.Git", autospec=True)
+    def test_get_commits(self, git_mock: MagicMock):
+        git_mock.return_value.list_tags.return_value = ["v0.0.1"]
+        git_mock.return_value.log.return_value = [
+            "1234567 Add: foo bar",
+            "8abcdef Add: bar baz",
+            "8abcd3f Add bar baz",
+            "8abcd3d Adding bar baz",
+            "1337abc Change: bar to baz",
+            "42a42a4 Remove: foo bar again",
+            "fedcba8 Test: bar baz testing",
+            "dead901 Refactor: bar baz ref",
+            "fedcba8 Fix: bar baz fixing",
+            "d0c4d0c Doc: bar baz documenting",
+        ]
+
+        changelog_builder = ChangelogBuilder(
+            space="foo",
+            project="bar",
+        )
+        commits = changelog_builder.get_commits(last_version="0.0.1")
+
+        self.assertEqual(len(commits), 4)  # four commit types
+
+        self.assertEqual(len(commits["Added"]), 2)
+        self.assertEqual(len(commits["Changed"]), 1)
+        self.assertEqual(len(commits["Removed"]), 1)
+        self.assertEqual(len(commits["Bug Fixes"]), 1)


### PR DESCRIPTION

## What

Allow to get the conventional commits by type
## Why

This change allows for analyzing the conventional commits of a release and will be used in a GitHub Action in future.

## References

DEVOPS-602

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


