### PR TITLE
Improve version update

### DIFF
--- a/pontos/version/commands/_go.py
+++ b/pontos/version/commands/_go.py
@@ -20,7 +20,6 @@ from pathlib import Path
 from typing import Literal, Union
 
 from ..errors import VersionError
-from ..helper import get_last_release_version
 from ..version import Version, VersionUpdate
 from ._command import VersionCommand
 
@@ -94,9 +93,8 @@ class GoVersionCommand(VersionCommand):
         try:
             current_version = self.get_current_version()
         except VersionError:
-            current_version = get_last_release_version(
-                self.versioning_scheme.parse_version, git_tag_prefix="v"
-            )
+            # likely the initial release
+            current_version = None
 
         if not force and new_version == current_version:
             return VersionUpdate(previous=current_version, new=new_version)

--- a/pontos/version/schemes/_pep440.py
+++ b/pontos/version/schemes/_pep440.py
@@ -184,6 +184,8 @@ class PEP440Version(Version):
         return cls.from_string(str(version))
 
     def __eq__(self, other: Any) -> bool:
+        if other is None:
+            return False
         if isinstance(other, str):
             # allow to compare against "current" for now
             return False
@@ -194,6 +196,8 @@ class PEP440Version(Version):
         return self._version == other._version
 
     def __ne__(self, other: Any) -> bool:
+        if other is None:
+            return True
         if isinstance(other, str):
             # allow to compare against "current" for now
             return True

--- a/pontos/version/schemes/_semantic.py
+++ b/pontos/version/schemes/_semantic.py
@@ -147,6 +147,8 @@ class SemanticVersion(Version):
         return self._version_info.patch
 
     def __eq__(self, other: Any) -> bool:
+        if other is None:
+            return False
         if isinstance(other, str):
             # allow to compare against "current" for now
             return False
@@ -161,6 +163,8 @@ class SemanticVersion(Version):
         )
 
     def __ne__(self, other: Any) -> bool:
+        if other is None:
+            return True
         if isinstance(other, str):
             # allow to compare against "current" for now
             return True

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -152,6 +152,9 @@ class VersionUpdate:
     If previous and new are equal the version was not updated and changed_files
     should be empty.
 
+    If there is no previous version for example in an initial release previous
+    should be None.
+
     Example:
         .. code-block:: python
 
@@ -165,6 +168,10 @@ class VersionUpdate:
             )
     """
 
-    previous: Version
+    previous: Optional[Version]
     new: Version
     changed_files: list[Path] = field(default_factory=list)
+
+    @property
+    def is_update(self) -> bool:
+        return self.previous != self.new

--- a/tests/version/schemes/test_pep440.py
+++ b/tests/version/schemes/test_pep440.py
@@ -123,6 +123,7 @@ class PEP440VersionTestCase(unittest.TestCase):
 
         versions = [
             ("1.0.0", "abc"),
+            ("1.0.0", None),
         ]
         for version1, version2 in versions:
             self.assertFalse(Version.from_string(version1) == version2)
@@ -219,6 +220,7 @@ class PEP440VersionTestCase(unittest.TestCase):
 
         versions = [
             ("1.0.0", "abc"),
+            ("1.0.0", None),
         ]
         for version1, version2 in versions:
             self.assertTrue(Version.from_string(version1) != version2)

--- a/tests/version/schemes/test_semantic.py
+++ b/tests/version/schemes/test_semantic.py
@@ -105,7 +105,7 @@ class SemanticVersionTestCase(unittest.TestCase):
             ("1.0.0", "1.0.0-alpha1"),
             ("1.0.0", "1.0.0-alpha1"),
             ("1.0.0", "1.0.0-beta1"),
-            ("1.0.0+dev1", "1.0.0-dev1"),  # maybe both should be equal
+            ("1.0.0+dev1", "1.0.0-dev1"),
             ("1.0.0+dev1", "1.0.0+dev2"),
             ("1.0.0-alpha1", "1.0.0-beta1"),
             ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
@@ -120,6 +120,9 @@ class SemanticVersionTestCase(unittest.TestCase):
                 Version.from_string(version1) == Version.from_string(version2),
                 f"{version1} equals {version2}",
             )
+
+        other = None
+        self.assertFalse(Version.from_string("1.0.0") == other)
 
         versions = [
             ("1.0.0", object()),
@@ -193,6 +196,7 @@ class SemanticVersionTestCase(unittest.TestCase):
 
         versions = [
             ("1.0.0", "abc"),
+            ("1.0.0", None),
         ]
         for version1, version2 in versions:
             self.assertTrue(Version.from_string(version1) != version2)


### PR DESCRIPTION
## What

Allow to use None as previous version and allow to compare Version instances against None.

## Why

Get rid of get_last_release_version in GoVersionCommand. Using it may result in undefined or unwanted behavior for example when tags for different releases series are available.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


