### PR TITLE
Add: Allow to set the GPG key for git signing during releases via env

### DIFF
--- a/pontos/release/parser.py
+++ b/pontos/release/parser.py
@@ -128,6 +128,7 @@ def parse_args(args) -> Tuple[str, str, Namespace]:
     release_parser.add_argument(
         "--git-signing-key",
         help="The key to sign the commits and tag for a release",
+        default=os.environ.get("GPG_SIGNING_KEY"),
     )
     release_parser.add_argument(
         "--project",


### PR DESCRIPTION
## What

Allow to set the GPG key for git signing during releases via env

Read the gpg key for git signatures from the environment variable `GPG_SIGNING_KEY`.

## Why

Easier configuration and setting the gpg key in the tests.


