### PR TITLE
Fix: Remove accidentally added print statement in comments method

### DIFF
--- a/pontos/github/api/pull_requests.py
+++ b/pontos/github/api/pull_requests.py
@@ -331,7 +331,6 @@ class GitHubAsyncRESTPullRequests(GitHubAsyncREST):
             response.raise_for_status()
 
             for comment in response.json():
-                print(comment)
                 yield Comment.from_dict(comment)
 
     async def files(


### PR DESCRIPTION


## What

Remove print statement from GitHub pull requests API for getting the list of comments.

## Why

It was committed accidentally.


