### PR TITLE
Change: Run no signing key test only on CI

### DIFF
--- a/tests/release/test_helper.py
+++ b/tests/release/test_helper.py
@@ -16,6 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import contextlib
+import os
 import subprocess
 import unittest
 from pathlib import Path
@@ -61,6 +62,7 @@ class FindSigningKeyTestCase(unittest.TestCase):
                 signing_key, "1234567890ABCEDEF1234567890ABCEDEF123456"
             )
 
+    @unittest.skipUnless(os.environ.get("CI"), "only run on CI")
     def test_find_no_signing_key(self):
         terminal = MagicMock()
         saved_key = None


### PR DESCRIPTION

## What

Run no signing key test only on CI

## Why

The test changes the user's git config if a signing key has been set. To avoid changing the git config run the test only on CI.


