### PR TITLE
Add: Cargo support

### DIFF
--- a/pontos/version/commands/__init__.py
+++ b/pontos/version/commands/__init__.py
@@ -22,6 +22,7 @@ from ._command import VersionCommand
 from ._go import GoVersionCommand
 from ._javascript import JavaScriptVersionCommand
 from ._python import PythonVersionCommand
+from ._cargo import CargoVersionCommand
 
 __all__ = (
     "VersionCommand",
@@ -29,6 +30,7 @@ __all__ = (
     "GoVersionCommand",
     "JavaScriptVersionCommand",
     "PythonVersionCommand",
+    "CargoVersionCommand",
     "get_commands",
 )
 
@@ -37,6 +39,7 @@ __COMMANDS: Tuple[Type[VersionCommand]] = (
     GoVersionCommand,
     JavaScriptVersionCommand,
     PythonVersionCommand,
+    CargoVersionCommand,
 )
 
 

--- a/pontos/version/commands/_cargo.py
+++ b/pontos/version/commands/_cargo.py
@@ -1,0 +1,84 @@
+from pathlib import Path
+from typing import Generator, Tuple, Union, Literal
+
+import tomlkit
+
+from ..version import Version, VersionUpdate
+from ._command import VersionCommand
+from ..errors import VersionError
+
+
+class CargoVersionCommand(VersionCommand):
+    project_file_name = "Cargo.toml"
+
+    def __as_project_document(
+        self, origin: Path
+    ) -> Generator[
+        Tuple[Path, tomlkit.TOMLDocument],
+        Tuple[Path, tomlkit.TOMLDocument],
+        None,
+    ]:
+        """
+        Parse the given origin and yields a tuple of path to a
+        cargo toml that contains a version
+
+        If the origin is invalid toml than it will raise a VersionError.
+        """
+        content = origin.read_text(encoding="utf-8")
+        content = tomlkit.parse(content)
+        package = content.get("package")
+        if package:
+            version = package.get("version")
+            if version:
+                yield (origin, content)
+        else:
+            workspace = content.get("workspace")
+            if workspace:
+                members = workspace.get("members")
+                for member in members:
+                    yield from self.__as_project_document(
+                        origin.parent / member / self.project_file_name
+                    )
+        return None
+
+    def update_version(
+        self, new_version: Version, *, force: bool = False
+    ) -> VersionUpdate:
+        previous_version = self.get_current_version()
+
+        if not force and new_version == previous_version:
+            return VersionUpdate(previous=previous_version, new=new_version)
+
+        changed_files = []
+        for project_path, project in self.__as_project_document(
+            self.project_file_path
+        ):
+            project["package"]["version"] = str(new_version)
+            project_path.write_text(tomlkit.dumps(project))
+            changed_files.append(project_path)
+        return VersionUpdate(
+            previous=previous_version,
+            new=new_version,
+            changed_files=changed_files,
+        )
+
+    def get_current_version(self) -> Version:
+        (_, document) = next(self.__as_project_document(self.project_file_path))
+        current_version = self.versioning_scheme.parse_version(
+            document["package"]["version"]
+        )
+        return self.versioning_scheme.from_version(current_version)
+
+    def verify_version(
+        self, version: Union[Literal["current"], Version, None]
+    ) -> None:
+        current_version = self.get_current_version()
+
+        if not version or version == "current":
+            return
+
+        if current_version != version:
+            raise VersionError(
+                f"Provided version {version} does not match the "
+                f"current version {current_version}."
+            )

--- a/pontos/version/commands/_cargo.py
+++ b/pontos/version/commands/_cargo.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Generator, Tuple, Union, Literal
+from typing import Iterator, Tuple, Union, Literal
 
 import tomlkit
 
@@ -13,11 +13,7 @@ class CargoVersionCommand(VersionCommand):
 
     def __as_project_document(
         self, origin: Path
-    ) -> Generator[
-        Tuple[Path, tomlkit.TOMLDocument],
-        Tuple[Path, tomlkit.TOMLDocument],
-        None,
-    ]:
+    ) -> Iterator[Tuple[Path, tomlkit.TOMLDocument],]:
         """
         Parse the given origin and yields a tuple of path to a
         cargo toml that contains a version

--- a/tests/version/commands/test_cargo.py
+++ b/tests/version/commands/test_cargo.py
@@ -1,0 +1,115 @@
+from typing import Generator
+import unittest
+
+from contextlib import contextmanager
+from pathlib import Path
+import tomlkit
+
+from pontos.testing import temp_directory, temp_file
+from pontos.version import VersionError
+from pontos.version.schemes import PEP440VersioningScheme
+
+from pontos.version.commands._cargo import CargoVersionCommand
+
+
+VERSION_EXAMPLE = """
+[package]
+name = "nasl-syntax"
+version = "0.1.0"
+edition = "2021"
+license = "GPL-2.0-or-later"
+"""
+WORKSPACE_EXAMPLE = """
+[workspace]
+members = [
+  "nasl-syntax",
+  "nasl-interpreter",
+  "nasl-cli",
+  "storage",
+  "redis-storage",
+  "json-storage",
+  "feed",
+  "feed-verifier",
+]
+"""
+
+
+class VerifyCargoUpdateCommandTestCase(unittest.TestCase):
+    @contextmanager
+    def __create_cargo_layout(self) -> Generator[Path, Path, None]:
+        with temp_directory(change_into=True) as temporary_dir:
+            workspace = temporary_dir / "Cargo.toml"
+            workspace.write_text(WORKSPACE_EXAMPLE)
+            members = tomlkit.parse(WORKSPACE_EXAMPLE)["workspace"]["members"]
+            for cargo_workspace_member in members:
+                npath = temporary_dir / f"{cargo_workspace_member}"
+                npath.mkdir()
+                pf = npath / "Cargo.toml"
+                pf.write_text(
+                    VERSION_EXAMPLE.replace(
+                        "nasl-syntax", cargo_workspace_member
+                    )
+                )
+            yield temporary_dir
+        return None
+
+    def test_update(self):
+        def expected_changed_files(temporary_dir_with_cargo_toml):
+            members = tomlkit.parse(WORKSPACE_EXAMPLE)["workspace"]["members"]
+            return [
+                (temporary_dir_with_cargo_toml / m / "Cargo.toml").resolve()
+                for m in members
+            ]
+
+        with self.__create_cargo_layout() as temporary_dir_with_cargo_toml:
+            cargo = CargoVersionCommand(PEP440VersioningScheme)
+            previous = PEP440VersioningScheme.parse_version("0.1.0")
+            new_version = PEP440VersioningScheme.parse_version("23.4.1")
+            updated = cargo.update_version(new_version)
+            self.assertEqual(updated.previous, previous)
+            self.assertEqual(updated.new, new_version)
+            self.assertEqual(
+                updated.changed_files,
+                expected_changed_files(temporary_dir_with_cargo_toml),
+            )
+
+    def test_update_fail(self):
+        with self.__create_cargo_layout():
+            cargo = CargoVersionCommand(PEP440VersioningScheme)
+            previous = PEP440VersioningScheme.parse_version("0.1.0")
+            new_version = PEP440VersioningScheme.parse_version("0.1.0")
+            updated = cargo.update_version(new_version)
+            self.assertEqual(updated.previous, previous)
+            self.assertEqual(updated.new, new_version)
+            self.assertEqual(
+                updated.changed_files,
+                [],
+            )
+
+
+class VerifyCargoVersionCommandTestCase(unittest.TestCase):
+    def test_verify_failure(self):
+        with temp_file(
+            VERSION_EXAMPLE,
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            version = PEP440VersioningScheme.parse_version("2.3.4")
+            cargo = CargoVersionCommand(PEP440VersioningScheme)
+
+            with self.assertRaisesRegex(
+                VersionError,
+                "Provided version 2.3.4 does not match the "
+                "current version 0.1.0.",
+            ):
+                cargo.verify_version(version)
+
+    def test_success(self):
+        with temp_file(
+            VERSION_EXAMPLE,
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            version = PEP440VersioningScheme.parse_version("0.1.0")
+            cargo = CargoVersionCommand(PEP440VersioningScheme)
+            cargo.verify_version(version)

--- a/tests/version/commands/test_cargo.py
+++ b/tests/version/commands/test_cargo.py
@@ -1,4 +1,4 @@
-from typing import Generator
+from typing import Iterator
 import unittest
 
 from contextlib import contextmanager
@@ -36,7 +36,7 @@ members = [
 
 class VerifyCargoUpdateCommandTestCase(unittest.TestCase):
     @contextmanager
-    def __create_cargo_layout(self) -> Generator[Path, Path, None]:
+    def __create_cargo_layout(self) -> Iterator[Path]:
         with temp_directory(change_into=True) as temporary_dir:
             workspace = temporary_dir / "Cargo.toml"
             workspace.write_text(WORKSPACE_EXAMPLE)

--- a/tests/version/test_commands.py
+++ b/tests/version/test_commands.py
@@ -22,4 +22,4 @@ from pontos.version.commands import get_commands
 
 class GetCommandsTestCase(unittest.TestCase):
     def test_available_commands(self):
-        self.assertEqual(len(get_commands()), 4)
+        self.assertEqual(len(get_commands()), 5)


### PR DESCRIPTION
Adds cargo support for changing the version for cargo projects.

It assumes that each cargo version within a workspace setup has the same
version.

As an example if you have workspace setup like
- Cargo.toml - workspace [1, 2, 3]
- 1/Cargo.toml - version: 0.1.0
- 2/Cargo.toml - version: 0.1.0
- 3/Cargo.toml - version: 0.1.0

on `pontos-release update 23.0.0` each version of those definitions will
be set to `23.0.0`.
