### PR TITLE
Use 'license' instead of 'licence'

### DIFF
--- a/docs/tools.md
+++ b/docs/tools.md
@@ -60,7 +60,7 @@ pontos-version next minor
 
 ## pontos-update-header
 
-`pontos-update-header` - Handling Copyright header for various file types and licences
+`pontos-update-header` - Handling Copyright header for various file types and licenses
 
 :::{note}
 We also provide easy-to-use [GitHub Actions](https://github.com/greenbone/actions/#usage), that updates copyright year in header of files and creates a Pull Request.

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -90,7 +90,7 @@ def _find_copyright(
 
 
 def _add_header(
-    suffix: str, license: str, company: str, year: str
+    suffix: str, license_id: str, company: str, year: str
 ) -> Union[str, None]:
     """Tries to add the header to the file.
     Requirements:
@@ -99,7 +99,7 @@ def _add_header(
     """
     if suffix in SUPPORTED_FILE_TYPES:
         root = Path(__file__).parent
-        license_file = root / "templates" / license / f"template{suffix}"
+        license_file = root / "templates" / license_id / f"template{suffix}"
         try:
             return (
                 license_file.read_text(encoding="utf-8")
@@ -149,7 +149,7 @@ def _update_file(
                 try:
                     header = _add_header(
                         file.suffix,
-                        parsed_args.license,
+                        parsed_args.license_id,
                         parsed_args.company,
                         parsed_args.year,
                     )
@@ -169,7 +169,7 @@ def _update_file(
                     )
                 except FileNotFoundError:
                     print(
-                        f"{file}: License file for {parsed_args.license} "
+                        f"{file}: License file for {parsed_args.license_id} "
                         "is not existing."
                     )
                 return 1

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -90,19 +90,19 @@ def _find_copyright(
 
 
 def _add_header(
-    suffix: str, licence: str, company: str, year: str
+    suffix: str, license: str, company: str, year: str
 ) -> Union[str, None]:
     """Tries to add the header to the file.
     Requirements:
       - file type must be supported
-      - licence file must exist
+      - license file must exist
     """
     if suffix in SUPPORTED_FILE_TYPES:
         root = Path(__file__).parent
-        licence_file = root / "templates" / licence / f"template{suffix}"
+        license_file = root / "templates" / license / f"template{suffix}"
         try:
             return (
-                licence_file.read_text(encoding="utf-8")
+                license_file.read_text(encoding="utf-8")
                 .replace("<company>", company)
                 .replace("<year>", year)
             )
@@ -149,7 +149,7 @@ def _update_file(
                 try:
                     header = _add_header(
                         file.suffix,
-                        parsed_args.licence,
+                        parsed_args.license,
                         parsed_args.company,
                         parsed_args.year,
                     )
@@ -160,16 +160,16 @@ def _update_file(
                         fp.write(header)
                         fp.write("\n")
                         fp.write(rest_of_file)
-                        print(f"{file}: Added licence header.")
+                        print(f"{file}: Added license header.")
                         return 0
                 except ValueError:
                     print(
-                        f"{file}: No licence header for the"
+                        f"{file}: No license header for the"
                         f" format {file.suffix} found.",
                     )
                 except FileNotFoundError:
                     print(
-                        f"{file}: Licence file for {parsed_args.licence} "
+                        f"{file}: License file for {parsed_args.license} "
                         "is not existing."
                     )
                 return 1
@@ -196,14 +196,14 @@ def _update_file(
                 # so we truncate the file, just in case!
                 fp.truncate()
                 print(
-                    f"{file}: Changed Licence Header Copyright Year "
+                    f"{file}: Changed License Header Copyright Year "
                     f'{copyright_match["modification_year"]} -> '
                     f"{parsed_args.year}"
                 )
 
                 return 0
             else:
-                print(f"{file}: Licence Header is ok.")
+                print(f"{file}: License Header is ok.")
                 return 0
     except FileNotFoundError as e:
         print(f"{file}: File is not existing.")
@@ -295,10 +295,10 @@ def _parse_args(args=None):
 
     parser.add_argument(
         "-l",
-        "--licence",
+        "--license",
         choices=SUPPORTED_LICENCES,
         default="GPL-3.0-or-later",
-        help=("Use the passed licence type"),
+        help=("Use the passed license type"),
     )
 
     parser.add_argument(
@@ -306,7 +306,7 @@ def _parse_args(args=None):
         default="Greenbone AG",
         help=(
             "If a header will be added to file, "
-            "it will be licenced by company."
+            "it will be licensed by company."
         ),
     )
 

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -157,7 +157,7 @@ class UpdateHeaderTestCase(TestCase):
 
         header = add_header(
             suffix=".py",
-            license="AGPL-3.0-or-later",
+            license_id="AGPL-3.0-or-later",
             company=self.args.company,
             year="2021",
         )
@@ -168,7 +168,7 @@ class UpdateHeaderTestCase(TestCase):
         with self.assertRaises(ValueError):
             add_header(
                 suffix=".prr",
-                license="AGPL-3.0-or-later",
+                license_id="AGPL-3.0-or-later",
                 company=self.args.company,
                 year="2021",
             )
@@ -177,7 +177,7 @@ class UpdateHeaderTestCase(TestCase):
         with self.assertRaises(FileNotFoundError):
             add_header(
                 suffix=".py",
-                license="AAAGPL-3.0-or-later",
+                license_id="AAAGPL-3.0-or-later",
                 company=self.args.company,
                 year="2021",
             )
@@ -186,7 +186,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_file_not_existing(self, mock_stdout):
         self.args.year = "2020"
         self.args.changed = False
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -212,7 +212,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_file_wrong_license(self, mock_stdout):
         self.args.year = "2020"
         self.args.changed = False
-        self.args.license = "AAAGPL-3.0-or-later"
+        self.args.license_id = "AAAGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -237,7 +237,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_file_suffix_invalid(self, mock_stdout):
         self.args.year = "2020"
         self.args.changed = False
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -261,7 +261,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_file_binary_file(self, mock_stdout):
         self.args.year = "2020"
         self.args.changed = False
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -295,7 +295,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_file_changed(self, mock_stdout):
         self.args.year = "1995"
         self.args.changed = True
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -324,7 +324,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_create_header(self, mock_stdout):
         self.args.year = "1995"
         self.args.changed = False
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -350,7 +350,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_header_in_file(self, mock_stdout):
         self.args.year = "2021"
         self.args.changed = False
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -384,7 +384,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_header_ok_in_file(self, mock_stdout):
         self.args.year = "2021"
         self.args.changed = False
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -416,7 +416,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_argparser_files(self):
         self.args.year = "2021"
         self.args.changed = False
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
 
         args = ["-f", "test.py", "-y", "2021", "-l", "AGPL-3.0-or-later"]
 
@@ -425,12 +425,12 @@ class UpdateHeaderTestCase(TestCase):
         self.assertEqual(args.company, self.args.company)
         self.assertEqual(args.files, ["test.py"])
         self.assertEqual(args.year, self.args.year)
-        self.assertEqual(args.license, self.args.license)
+        self.assertEqual(args.license, self.args.license_id)
 
     def test_argparser_dir(self):
         self.args.year = "2020"
         self.args.changed = False
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
 
         args = ["-d", ".", "-c", "-l", "AGPL-3.0-or-later"]
 
@@ -440,7 +440,7 @@ class UpdateHeaderTestCase(TestCase):
         self.assertEqual(args.directories, ["."])
         self.assertTrue(args.changed)
         self.assertEqual(args.year, str(datetime.datetime.now().year))
-        self.assertEqual(args.license, self.args.license)
+        self.assertEqual(args.license, self.args.license_id)
 
     def test_get_exclude_list(self):
         # Try to find the current file from two directories up...
@@ -461,7 +461,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_main(self, argparser_mock):
         self.args.year = "2021"
         self.args.changed = False
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
         self.args.files = ["test.py"]
         self.args.directories = None
         self.args.verbose = 0
@@ -481,7 +481,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_main_never_happen(self, argparser_mock, mock_stdout):
         self.args.year = "2021"
         self.args.changed = False
-        self.args.license = "AGPL-3.0-or-later"
+        self.args.license_id = "AGPL-3.0-or-later"
         self.args.files = None
         self.args.directories = None
         self.args.verbose = 0

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -157,7 +157,7 @@ class UpdateHeaderTestCase(TestCase):
 
         header = add_header(
             suffix=".py",
-            licence="AGPL-3.0-or-later",
+            license="AGPL-3.0-or-later",
             company=self.args.company,
             year="2021",
         )
@@ -168,16 +168,16 @@ class UpdateHeaderTestCase(TestCase):
         with self.assertRaises(ValueError):
             add_header(
                 suffix=".prr",
-                licence="AGPL-3.0-or-later",
+                license="AGPL-3.0-or-later",
                 company=self.args.company,
                 year="2021",
             )
 
-    def test_add_header_licence_not_found(self):
+    def test_add_header_license_not_found(self):
         with self.assertRaises(FileNotFoundError):
             add_header(
                 suffix=".py",
-                licence="AAAGPL-3.0-or-later",
+                license="AAAGPL-3.0-or-later",
                 company=self.args.company,
                 year="2021",
             )
@@ -186,7 +186,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_file_not_existing(self, mock_stdout):
         self.args.year = "2020"
         self.args.changed = False
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -209,10 +209,10 @@ class UpdateHeaderTestCase(TestCase):
         )
 
     @patch("sys.stdout", new_callable=StringIO)
-    def test_update_file_wrong_licence(self, mock_stdout):
+    def test_update_file_wrong_license(self, mock_stdout):
         self.args.year = "2020"
         self.args.changed = False
-        self.args.licence = "AAAGPL-3.0-or-later"
+        self.args.license = "AAAGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -227,7 +227,7 @@ class UpdateHeaderTestCase(TestCase):
         ret = mock_stdout.getvalue()
         self.assertEqual(
             ret,
-            f"{test_file}: Licence file for "
+            f"{test_file}: License file for "
             "AAAGPL-3.0-or-later is not existing.\n",
         )
 
@@ -237,7 +237,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_file_suffix_invalid(self, mock_stdout):
         self.args.year = "2020"
         self.args.changed = False
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -252,7 +252,7 @@ class UpdateHeaderTestCase(TestCase):
         ret = mock_stdout.getvalue()
         self.assertEqual(
             ret,
-            f"{test_file}: No licence header for the format .pppy found.\n",
+            f"{test_file}: No license header for the format .pppy found.\n",
         )
 
         test_file.unlink()
@@ -261,7 +261,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_file_binary_file(self, mock_stdout):
         self.args.year = "2020"
         self.args.changed = False
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -295,7 +295,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_file_changed(self, mock_stdout):
         self.args.year = "1995"
         self.args.changed = True
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -324,7 +324,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_create_header(self, mock_stdout):
         self.args.year = "1995"
         self.args.changed = False
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -339,7 +339,7 @@ class UpdateHeaderTestCase(TestCase):
 
         ret = mock_stdout.getvalue()
         self.assertEqual(
-            f"{test_file}: Added licence header.\n",
+            f"{test_file}: Added license header.\n",
             ret,
         )
         self.assertEqual(code, 0)
@@ -350,7 +350,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_header_in_file(self, mock_stdout):
         self.args.year = "2021"
         self.args.changed = False
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -370,7 +370,7 @@ class UpdateHeaderTestCase(TestCase):
         ret = mock_stdout.getvalue()
         self.assertEqual(
             ret,
-            f"{test_file}: Changed Licence Header "
+            f"{test_file}: Changed License Header "
             "Copyright Year None -> 2021\n",
         )
         self.assertIn(
@@ -384,7 +384,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_update_header_ok_in_file(self, mock_stdout):
         self.args.year = "2021"
         self.args.changed = False
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
 
         term = Terminal()
 
@@ -404,7 +404,7 @@ class UpdateHeaderTestCase(TestCase):
         ret = mock_stdout.getvalue()
         self.assertEqual(
             ret,
-            f"{test_file}: Licence Header is ok.\n",
+            f"{test_file}: License Header is ok.\n",
         )
         self.assertIn(
             "# SPDX-FileCopyrightText: 2021 Greenbone AG",
@@ -416,7 +416,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_argparser_files(self):
         self.args.year = "2021"
         self.args.changed = False
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
 
         args = ["-f", "test.py", "-y", "2021", "-l", "AGPL-3.0-or-later"]
 
@@ -425,12 +425,12 @@ class UpdateHeaderTestCase(TestCase):
         self.assertEqual(args.company, self.args.company)
         self.assertEqual(args.files, ["test.py"])
         self.assertEqual(args.year, self.args.year)
-        self.assertEqual(args.licence, self.args.licence)
+        self.assertEqual(args.license, self.args.license)
 
     def test_argparser_dir(self):
         self.args.year = "2020"
         self.args.changed = False
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
 
         args = ["-d", ".", "-c", "-l", "AGPL-3.0-or-later"]
 
@@ -440,7 +440,7 @@ class UpdateHeaderTestCase(TestCase):
         self.assertEqual(args.directories, ["."])
         self.assertTrue(args.changed)
         self.assertEqual(args.year, str(datetime.datetime.now().year))
-        self.assertEqual(args.licence, self.args.licence)
+        self.assertEqual(args.license, self.args.license)
 
     def test_get_exclude_list(self):
         # Try to find the current file from two directories up...
@@ -461,7 +461,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_main(self, argparser_mock):
         self.args.year = "2021"
         self.args.changed = False
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
         self.args.files = ["test.py"]
         self.args.directories = None
         self.args.verbose = 0
@@ -481,7 +481,7 @@ class UpdateHeaderTestCase(TestCase):
     def test_main_never_happen(self, argparser_mock, mock_stdout):
         self.args.year = "2021"
         self.args.changed = False
-        self.args.licence = "AGPL-3.0-or-later"
+        self.args.license = "AGPL-3.0-or-later"
         self.args.files = None
         self.args.directories = None
         self.args.verbose = 0


### PR DESCRIPTION
## What

Use the spelling _license_ (American English) instead of _licence_ (British English) for consistency.

## Why

The variety of the language used should be consistent.
