### PR TITLE
Change: Rework release process by using tags for last release version

### DIFF
--- a/pontos/release/parser.py
+++ b/pontos/release/parser.py
@@ -107,6 +107,12 @@ def parse_args(args) -> Tuple[str, str, Namespace]:
         ),
         action=ReleaseVersionAction,
     )
+    release_parser.add_argument(
+        "--release-series",
+        help="Create a release for a release series. Setting a release series "
+        "is required if the latest tag version is newer then the to be "
+        'released version. Examples: "1.2", "2", "22.4"',
+    )
 
     release_parser.add_argument(
         "--next-version",
@@ -171,6 +177,12 @@ def parse_args(args) -> Tuple[str, str, Namespace]:
     sign_parser.add_argument(
         "--release-version",
         help="Will release changelog as version. Must be PEP 440 compliant.",
+    )
+    sign_parser.add_argument(
+        "--release-series",
+        help="Sign release files for a release series. Setting a release "
+        "series is required if the latest tag version is newer then the to be "
+        'signed version. Examples: "1.2", "2", "22.4"',
     )
     sign_parser.add_argument(
         "--git-tag-prefix",

--- a/tests/release/test_parser.py
+++ b/tests/release/test_parser.py
@@ -212,6 +212,13 @@ class ReleaseParseArgsTestCase(unittest.TestCase):
 
         self.assertEqual(args.cc_config, Path("foo.toml"))
 
+    def test_release_series(self):
+        _, _, args = parse_args(
+            ["release", "--release-type", "patch", "--release-series", "22.4"]
+        )
+
+        self.assertEqual(args.release_series, "22.4")
+
 
 class SignParseArgsTestCase(unittest.TestCase):
     def test_sign_func(self):
@@ -255,3 +262,8 @@ class SignParseArgsTestCase(unittest.TestCase):
         _, _, args = parse_args(["sign", "--passphrase", "123"])
 
         self.assertEqual(args.passphrase, "123")
+
+    def test_release_series(self):
+        _, _, args = parse_args(["sign", "--release-series", "22.4"])
+
+        self.assertEqual(args.release_series, "22.4")

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -120,7 +120,7 @@ class SignTestCase(unittest.TestCase):
                     "sign",
                     "--project",
                     "foo",
-                    "--release",
+                    "--release-version",
                     "1.2.3",
                 ]
             )
@@ -340,6 +340,112 @@ class SignTestCase(unittest.TestCase):
             github_releases_mock.upload_release_assets.assert_called_once_with(
                 "greenbone/foo",
                 "v1.2.3",
+                [
+                    (Path("file.zip.asc"), "application/pgp-signature"),
+                    (Path("file.tar.asc"), "application/pgp-signature"),
+                    (Path("file1.asc"), "application/pgp-signature"),
+                    (Path("file2.asc"), "application/pgp-signature"),
+                ],
+            )
+
+    @patch("pontos.version.helper.Git", autospec=True)
+    @patch("pontos.release.sign.cmd_runner", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_asset", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_tar", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_zip", autospec=True)
+    @patch("pontos.release.sign.GitHubAsyncRESTApi.releases", autospec=True)
+    def test_sign_success_determine_release_version_with_release_series(
+        self,
+        github_releases_mock: AsyncMock,
+        download_zip_mock: AsyncMock,
+        download_tar_mock: AsyncMock,
+        download_asset_mock: AsyncMock,
+        cmd_runner_mock: AsyncMock,
+        git_mock: MagicMock,
+    ):
+        tar_file = Path("file.tar")
+        zip_file = Path("file.zip")
+        some_asset = Path("file1")
+        other_asset = Path("file2")
+        download_tar_mock.return_value = tar_file
+        download_zip_mock.return_value = zip_file
+        download_asset_mock.side_effect = [some_asset, other_asset]
+        github_releases_mock.exists = AsyncMock(return_value=True)
+        github_releases_mock.download_release_assets.return_value = (
+            AsyncIteratorMock(
+                [
+                    (
+                        "foo",
+                        MagicMock(),
+                    ),
+                    ("bar", MagicMock()),
+                ]
+            )
+        )
+        process = AsyncMock(spec=Process, returncode=0)
+        process.communicate.return_value = ("", "")
+        cmd_runner_mock.return_value = process
+        git_mock.return_value.list_tags.return_value = [
+            "v2.0.1",
+        ]
+
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                ["sign", "--project", "foo", "--release-series", "2"]
+            )
+
+            result = sign(
+                terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
+
+            self.assertEqual(result, SignReturnValue.SUCCESS)
+
+            cmd_runner_mock.assert_has_calls(
+                [
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        zip_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        tar_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        some_asset,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        other_asset,
+                    ),
+                ]
+            )
+
+            github_releases_mock.upload_release_assets.assert_called_once_with(
+                "greenbone/foo",
+                "v2.0.1",
                 [
                     (Path("file.zip.asc"), "application/pgp-signature"),
                     (Path("file.tar.asc"), "application/pgp-signature"),


### PR DESCRIPTION
## What

Before this change the current release version was derived from the project settings. Additionally the last release version was determined from the git tags in a complicated way keeping the current release version in mind to support different release series. The last release version was used only to create the changelog for the release.

With this change getting the current version from the project settings is dropped and only the last release version is used. Determining the last release version from the git tags is simplified by just using the latest tag (sorted by versions) and optionally a release series.

If a release series is provided the last tag fitting to the series is used as last release version. A release series can be something like "1.0", "2.0", "20.4" or even just "1".

## Why

Simplify determining the last release version and make the release process independent of the versions in the code of the project. Support for mono (multi-project) repos.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


