### PR TITLE
Improve updating python project versions

### DIFF
--- a/pontos/version/commands/_python.py
+++ b/pontos/version/commands/_python.py
@@ -50,7 +50,9 @@ class PythonVersionCommand(VersionCommand):
             and "poetry" in self.pyproject_toml["tool"]  # type: ignore
             and "version" in self.pyproject_toml["tool"]["poetry"]  # type: ignore # pylint: disable=line-too-long
         ):
-            return self.versioning_scheme.parse_version(self.pyproject_toml["tool"]["poetry"]["version"])  # type: ignore # pylint: disable=line-too-long
+            return PEP440VersioningScheme.parse_version(
+                self.pyproject_toml["tool"]["poetry"]["version"]
+            )  # type: ignore
 
         raise VersionError(
             "Version information not found in "

--- a/pontos/version/commands/_python.py
+++ b/pontos/version/commands/_python.py
@@ -202,9 +202,21 @@ class PythonVersionCommand(VersionCommand):
                 previous=current_converted_version, new=new_version
             )
 
-        self._update_pyproject_version(new_version=new_pep440_version)
+        try:
+            self._update_pyproject_version(new_version=new_pep440_version)
+        except OSError as e:
+            raise VersionError(
+                "Unable to update version in "
+                f"{self.project_file_path.absolute()}. Error was {e}"
+            ) from e
 
-        self._update_version_file(new_version=new_pep440_version)
+        try:
+            self._update_version_file(new_version=new_pep440_version)
+        except OSError as e:
+            raise VersionError(
+                "Unable to update version in "
+                f"{self.version_file_path.absolute()}. Error was {e}"
+            ) from e
 
         return VersionUpdate(
             previous=current_converted_version,


### PR DESCRIPTION
## What

Improve updating python project versions

## Why

Ensure versions from python project files are always parsed as PEP 440 and provide better error messages if something goes wrong.

## References

https://github.com/greenbone/asset-management-backend/actions/runs/4794364062/jobs/8527667584

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


