### PR TITLE
Add: Allow to create releases for projects without project files

### DIFF
--- a/pontos/release/parser.py
+++ b/pontos/release/parser.py
@@ -17,7 +17,12 @@
 
 import argparse
 import os
-from argparse import ArgumentParser, ArgumentTypeError, Namespace
+from argparse import (
+    ArgumentParser,
+    ArgumentTypeError,
+    BooleanOptionalAction,
+    Namespace,
+)
 from enum import Enum
 from pathlib import Path
 from typing import Callable, Tuple, Type
@@ -157,6 +162,13 @@ def parse_args(args) -> Tuple[str, str, Namespace]:
         type=Path,
         help="Conventional commits config file (toml), including conventions."
         " If not set defaults are used.",
+    )
+    release_parser.add_argument(
+        "--update-project",
+        help="Update version in project files like pyproject.toml. By default "
+        "project files are updated.",
+        action=BooleanOptionalAction,
+        default=True,
     )
 
     sign_parser = subparsers.add_parser("sign")

--- a/tests/release/test_parser.py
+++ b/tests/release/test_parser.py
@@ -219,6 +219,23 @@ class ReleaseParseArgsTestCase(unittest.TestCase):
 
         self.assertEqual(args.release_series, "22.4")
 
+    def test_update_project(self):
+        _, _, args = parse_args(["release", "--release-type", "patch"])
+
+        self.assertTrue(args.update_project)
+
+        _, _, args = parse_args(
+            ["release", "--release-type", "patch", "--update-project"]
+        )
+
+        self.assertTrue(args.update_project)
+
+        _, _, args = parse_args(
+            ["release", "--release-type", "patch", "--no-update-project"]
+        )
+
+        self.assertFalse(args.update_project)
+
 
 class SignParseArgsTestCase(unittest.TestCase):
     def test_sign_func(self):


### PR DESCRIPTION
## What

Allow to create releases for projects without project files

## Why

If a project has no project files like pyproject.toml allow to create releases by setting the `--no-update-project` argument.

## References

[DEVOPS-652](https://jira.greenbone.net/browse/DEVOPS-652)

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


