### PR TITLE
Fix: Show correct versioning scheme information during a release

### DIFF
--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -198,9 +198,7 @@ class ReleaseCommand:
         )
         self.space = space
 
-        self.terminal.info(
-            f"Using versioning scheme {versioning_scheme.__class__.__name__}"
-        )
+        self.terminal.info(f"Using versioning scheme {versioning_scheme.name}")
 
         try:
             last_release_version = get_last_release_version(

--- a/pontos/version/schemes/_pep440.py
+++ b/pontos/version/schemes/_pep440.py
@@ -402,3 +402,4 @@ class PEP440VersioningScheme(VersioningScheme):
 
     version_calculator_cls = PEP440VersionCalculator
     version_cls = PEP440Version
+    name = "PEP440"

--- a/pontos/version/schemes/_scheme.py
+++ b/pontos/version/schemes/_scheme.py
@@ -40,6 +40,7 @@ class VersioningScheme(ABC):
 
     version_cls: Type[Version]
     version_calculator_cls: Type[VersionCalculator]
+    name: str
 
     @classmethod
     def parse_version(cls, version: str) -> Version:

--- a/pontos/version/schemes/_semantic.py
+++ b/pontos/version/schemes/_semantic.py
@@ -467,3 +467,4 @@ class SemanticVersionCalculator(VersionCalculator):
 class SemanticVersioningScheme(VersioningScheme):
     version_cls = SemanticVersion
     version_calculator_cls = SemanticVersionCalculator
+    name = "SemVer"


### PR DESCRIPTION
## What

Show correct versioning scheme information during a release

## Why

Ensure that the shown versioning scheme is user readable.

