### PR TITLE
Fix: Allow running pontos-changelog without a changelog config file

### DIFF
--- a/pontos/changelog/main.py
+++ b/pontos/changelog/main.py
@@ -41,7 +41,6 @@ def parse_args(args: Iterable[str] = None) -> ArgumentParser:
     parser.add_argument(
         "--config",
         "-C",
-        default="changelog.toml",
         type=Path,
         help="Conventional commits config file (toml), including conventions.",
     )


### PR DESCRIPTION
## What

Allow running pontos-changelog without a changelog config file

## Why

Don't set a default changelog config file. Otherwise pontos-changelog will error because it can't read the non existing file.
