### PR TITLE
Change: Resolve deprecation warnings in GitHub workflows

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -22,7 +22,7 @@ jobs:
         uses: greenbone/actions/lint-python@v2
         with:
           packages: pontos tests scripts
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
           cache: "true"
 
   test:
@@ -39,7 +39,7 @@ jobs:
       - name: Install python, poetry and dependencies
         uses: greenbone/actions/poetry@v2
         with:
-          version: ${{ matrix.python-version }}
+          python-version: ${{ matrix.python-version }}
           cache: "true"
           cache-poetry-installation: "true"
       - name: Run unit tests
@@ -54,7 +54,7 @@ jobs:
       - name: Install and calculate and upload coverage to codecov.io
         uses: greenbone/actions/coverage-python@v2
         with:
-          version: "3.10"
+          python-version: "3.10"
           cache: "true"
           token: ${{ secrets.CODECOV_TOKEN }}
 

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -12,7 +12,7 @@ jobs:
       - name: Set up Python
         uses: greenbone/actions/poetry@v2
         with:
-          version: "3.10"
+          python-version: "3.10"
           install-dependencies: "false"
           cache-poetry-installation: "true"
       - name: Build and publish

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Install poetry and dependencies
         uses: greenbone/actions/poetry@v2
         with:
-          version: "3.10"
+          python-version: "3.10"
           cache: "true"
           cache-poetry-installation: "true"
       - name: Build Documentation


### PR DESCRIPTION


## What

Use python-version input instead of version
## Why

Resolve deprecation warnings in GitHub workflows


