### PR TITLE
Add: Extend conventional commits for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,9 +9,15 @@ updates:
     allow:
       - dependency-type: direct
       - dependency-type: indirect
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
+    commit-message:
+      prefix: "Deps"
+      include: "scope"
 

--- a/pontos/changelog/conventional_commits.py
+++ b/pontos/changelog/conventional_commits.py
@@ -34,6 +34,7 @@ DEFAULT_CHANGELOG_CONFIG = """commit_types = [
     { message = "^remove", group = "Removed"},
     { message = "^change", group = "Changed"},
     { message = "^fix", group = "Bug Fixes"},
+    { message = "^deps", group = "Dependencies"},
 ]
 """
 
@@ -59,8 +60,10 @@ class ChangelogBuilder:
             from pontos.changelog import ChangelogBuilder
 
             builder = ChangelogBuilder(space="my-org", project="my-project)
-            changelog = builder.create_changelog
-                last_version="1.2.3", next_version="2.0.0")
+            changelog = builder.create_changelog(
+                last_version="1.2.3",
+                next_version="2.0.0",
+            )
     """
 
     def __init__(

--- a/tests/changelog/test_conventional_commits.py
+++ b/tests/changelog/test_conventional_commits.py
@@ -38,7 +38,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
     maxDiff = None
 
     @patch("pontos.changelog.conventional_commits.Git", autospec=True)
-    def test_changelog_builder(self, git_mock: MagicMock):
+    def test_changelog_builder_with_config(self, git_mock: MagicMock):
         today = datetime.today().strftime("%Y-%m-%d")
 
         own_path = Path(__file__).absolute().parent
@@ -360,6 +360,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
             "dead901 Refactor: bar baz ref",
             "fedcba8 Fix: bar baz fixing",
             "d0c4d0c Doc: bar baz documenting",
+            "a1c5a0b Deps: Update foo from 1.2.3 to 3.2.1",
         ]
 
         changelog_builder = ChangelogBuilder(
@@ -380,6 +381,9 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 
 ## Bug Fixes
 * bar baz fixing [fedcba8](https://github.com/foo/bar/commit/fedcba8)
+
+## Dependencies
+* Update foo from 1.2.3 to 3.2.1 [a1c5a0b](https://github.com/foo/bar/commit/a1c5a0b)
 
 [0.0.2]: https://github.com/foo/bar/compare/v0.0.1...v0.0.2"""
 


### PR DESCRIPTION


## What

Extend conventional commits for dependency updates

## Why

Allow to include dependency updates in the conventional commits used for generating release changelogs. Commit messages starting with `[Dd]eps` are considered as conventional commits for dependency changes. They will put into a new `Dependencies` section in the generated changelog.

This allows to include updates created by dependabot to be included in the changelog by setting the `prefix` to `Deps` in the `commit-message` setting of the dependabot config.

## References
DEVOPS-669

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


