### PR TITLE
Change: Remove scope from dependabot commit message config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,7 +11,6 @@ updates:
       - dependency-type: indirect
     commit-message:
       prefix: "Deps"
-      include: "scope"
 
   - package-ecosystem: "github-actions"
     directory: "/"
@@ -19,5 +18,4 @@ updates:
       interval: "weekly"
     commit-message:
       prefix: "Deps"
-      include: "scope"
 


### PR DESCRIPTION
## What

Remove scope from dependabot commit message config

## Why

It seems this includes `(deps)` after the desired `Deps` and results in an invalid conventional commits entry.