### PR TITLE
Change: Add contents read permissions for conventional commits workflow

### DIFF
--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -5,6 +5,7 @@ on:
 
 permissions:
   pull-requests: write
+  contents: read
 
 jobs:
   conventional-commits:


### PR DESCRIPTION
## What

Add contents read permissions for conventional commits workflow

## Why

The workflow to check the conventional commits usage requires read permissions on the repo contents.
