### PR TITLE
Fix: Argument naming in pontos-update-header

### DIFF
--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -296,6 +296,7 @@ def _parse_args(args=None):
     parser.add_argument(
         "-l",
         "--license",
+        dest="license_id",
         choices=SUPPORTED_LICENCES,
         default="GPL-3.0-or-later",
         help=("Use the passed license type"),

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -425,7 +425,7 @@ class UpdateHeaderTestCase(TestCase):
         self.assertEqual(args.company, self.args.company)
         self.assertEqual(args.files, ["test.py"])
         self.assertEqual(args.year, self.args.year)
-        self.assertEqual(args.license, self.args.license_id)
+        self.assertEqual(args.license_id, self.args.license_id)
 
     def test_argparser_dir(self):
         self.args.year = "2020"
@@ -440,7 +440,7 @@ class UpdateHeaderTestCase(TestCase):
         self.assertEqual(args.directories, ["."])
         self.assertTrue(args.changed)
         self.assertEqual(args.year, str(datetime.datetime.now().year))
-        self.assertEqual(args.license, self.args.license_id)
+        self.assertEqual(args.license_id, self.args.license_id)
 
     def test_get_exclude_list(self):
         # Try to find the current file from two directories up...


### PR DESCRIPTION
## What
This PR fixes the naming of the license argument. It is wrongfully accessed via `license_id`, so I specified a `dest` to store the license argument in.
An alternative approach would be to rename all occurrences to `license`. This however interferes with the built-in `license()` and hence makes pylint sad.

## Why
To fix:
```
➜  pontos git:(main) poetry run pontos-update-header -d /tmp/test -l GPL-2.0-only    
 ℹ pontos-update-header
Traceback (most recent call last):
  File "<string>", line 1, in <module>
  File "/home/nthumann/Greenbone/pontos/pontos/updateheader/updateheader.py", line 388, in main
    _update_file(
  File "/home/nthumann/Greenbone/pontos/pontos/updateheader/updateheader.py", line 152, in _update_file
    parsed_args.license_id,
AttributeError: 'Namespace' object has no attribute 'license_id'. Did you mean: 'license'?
```

With this patch applied:
```
➜  pontos git:(fix_updateheader) poetry run pontos-update-header -d /tmp/test -l GPL-2.0-only
 ℹ pontos-update-header
/tmp/test/mgasa-2023-0001.nasl: Added license header.
```
## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


