### PR TITLE
Fix: Fix updating JS versions with single quotes

### DIFF
--- a/pontos/version/commands/_javascript.py
+++ b/pontos/version/commands/_javascript.py
@@ -139,11 +139,14 @@ class JavaScriptVersionCommand(VersionCommand):
             return False
 
         content = version_file.read_text(encoding="utf-8")
-        content = re.sub(
-            pattern=r'VERSION = "(?P<version>.*)"',
-            repl=f'VERSION = "{new_version}"',
+        match = re.search(
+            pattern=r'VERSION = (?P<quote>[\'"])(?P<version>.*)(?P=quote)',
             string=content,
         )
+        if not match:
+            return False
+
+        content = content.replace(match.group("version"), str(new_version))
         version_file.write_text(content, encoding="utf-8")
         return True
 


### PR DESCRIPTION


## What

Fix updating JS versions with single quotes

## Why

When updating a version in a version.js file support single and double quotes. GSA uses single quotes and updating the version during a release failed.