### PR TITLE
Fix: Use terminal instead of print function in changelog CLI

### DIFF
--- a/pontos/changelog/main.py
+++ b/pontos/changelog/main.py
@@ -140,7 +140,7 @@ def main(args: Iterable[str] = None) -> NoReturn:
                 last_version=last_version,
                 next_version=parsed_args.next_version,
             )
-            print(changelog)
+            term.out(changelog)
     except PontosError as e:
         term.error(str(e))
         sys.exit(1)


### PR DESCRIPTION
## What

Use terminal instead of print function in changelog CLI

## Why

All output should always go through the terminal. It allows for formatting and redirecting the output easily.
