### PR TITLE
When updating a version ignore the current version in case of erros

### DIFF
--- a/pontos/version/commands/_cargo.py
+++ b/pontos/version/commands/_cargo.py
@@ -1,11 +1,11 @@
 from pathlib import Path
-from typing import Iterator, Tuple, Union, Literal
+from typing import Iterator, Literal, Tuple, Union
 
 import tomlkit
 
+from ..errors import VersionError
 from ..version import Version, VersionUpdate
 from ._command import VersionCommand
-from ..errors import VersionError
 
 
 class CargoVersionCommand(VersionCommand):
@@ -40,10 +40,14 @@ class CargoVersionCommand(VersionCommand):
     def update_version(
         self, new_version: Version, *, force: bool = False
     ) -> VersionUpdate:
-        previous_version = self.get_current_version()
+        try:
+            previous_version = self.get_current_version()
 
-        if not force and new_version == previous_version:
-            return VersionUpdate(previous=previous_version, new=new_version)
+            if not force and new_version == previous_version:
+                return VersionUpdate(previous=previous_version, new=new_version)
+        except VersionError:
+            # just ignore current version and override it
+            previous_version = None
 
         changed_files = []
         for project_path, project in self.__as_project_document(

--- a/pontos/version/commands/_cmake.py
+++ b/pontos/version/commands/_cmake.py
@@ -33,10 +33,15 @@ class CMakeVersionCommand(VersionCommand):
     ) -> VersionUpdate:
         content = self.project_file_path.read_text(encoding="utf-8")
         cmake_version_parser = CMakeVersionParser(content)
-        previous_version = self.get_current_version()
 
-        if not force and new_version == previous_version:
-            return VersionUpdate(previous=previous_version, new=new_version)
+        try:
+            previous_version = self.get_current_version()
+
+            if not force and new_version == previous_version:
+                return VersionUpdate(previous=previous_version, new=new_version)
+        except VersionError:
+            # just ignore current version and override it
+            previous_version = None
 
         new_content = cmake_version_parser.update_version(new_version)
         self.project_file_path.write_text(new_content, encoding="utf-8")

--- a/pontos/version/commands/_go.py
+++ b/pontos/version/commands/_go.py
@@ -92,12 +92,11 @@ class GoVersionCommand(VersionCommand):
         """Update the current version of this project"""
         try:
             current_version = self.get_current_version()
+            if not force and new_version == current_version:
+                return VersionUpdate(previous=current_version, new=new_version)
         except VersionError:
-            # likely the initial release
+            # just ignore current version and override it
             current_version = None
-
-        if not force and new_version == current_version:
-            return VersionUpdate(previous=current_version, new=new_version)
 
         self._update_version_file(new_version=new_version)
 

--- a/pontos/version/commands/_java.py
+++ b/pontos/version/commands/_java.py
@@ -36,7 +36,7 @@ __version__ = "{}"\n"""
 def find_file(
     filename: Path, search_path: str, search_glob: str
 ) -> Optional[Path]:
-    """Find a file somewherre within an directory tree
+    """Find a file somewhere within an directory tree
     Arguments:
         filename (Path)     The file to look up
         search_path (str)   The path to look for the file
@@ -180,9 +180,13 @@ class JavaVersionCommand(VersionCommand):
     def update_version(
         self, new_version: Version, *, force: bool = False
     ) -> VersionUpdate:
-        package_version = self.get_current_version()
-        if not force and new_version == package_version:
-            return VersionUpdate(previous=package_version, new=new_version)
+        try:
+            package_version = self.get_current_version()
+            if not force and new_version == package_version:
+                return VersionUpdate(previous=package_version, new=new_version)
+        except VersionError:
+            # just ignore current version and override it
+            package_version = None
 
         changed_files = [self.project_file_path]
         self._update_pom_version(new_version=new_version)

--- a/pontos/version/commands/_javascript.py
+++ b/pontos/version/commands/_javascript.py
@@ -153,9 +153,13 @@ class JavaScriptVersionCommand(VersionCommand):
     def update_version(
         self, new_version: Version, *, force: bool = False
     ) -> VersionUpdate:
-        package_version = self.get_current_version()
-        if not force and new_version == package_version:
-            return VersionUpdate(previous=package_version, new=new_version)
+        try:
+            package_version = self.get_current_version()
+            if not force and new_version == package_version:
+                return VersionUpdate(previous=package_version, new=new_version)
+        except VersionError:
+            # just ignore current version and override it
+            package_version = None
 
         changed_files = [self.project_file_path]
         self._update_package_json(new_version=new_version)

--- a/pontos/version/commands/_python.py
+++ b/pontos/version/commands/_python.py
@@ -185,22 +185,27 @@ class PythonVersionCommand(VersionCommand):
     def update_version(
         self, new_version: Version, *, force: bool = False
     ) -> VersionUpdate:
-        try:
-            current_version = self.get_current_version()
-        except VersionError:
-            # maybe no version module exists yet. fallback to version from
-            # pyproject.toml
-            current_version = self._get_version_from_pyproject_toml()
-
         new_pep440_version = PEP440VersioningScheme.from_version(new_version)
-        current_converted_version = self.versioning_scheme.from_version(
-            current_version
-        )
 
-        if not force and new_pep440_version == current_version:
-            return VersionUpdate(
-                previous=current_converted_version, new=new_version
+        try:
+            try:
+                current_version = self.get_current_version()
+            except VersionError:
+                # maybe no version module exists yet. fallback to version from
+                # pyproject.toml
+                current_version = self._get_version_from_pyproject_toml()
+
+            current_converted_version = self.versioning_scheme.from_version(
+                current_version
             )
+
+            if not force and new_pep440_version == current_version:
+                return VersionUpdate(
+                    previous=current_converted_version, new=new_version
+                )
+        except VersionError:
+            # just ignore current version and override it
+            current_converted_version = None
 
         try:
             self._update_pyproject_version(new_version=new_pep440_version)

--- a/tests/version/commands/test_python.py
+++ b/tests/version/commands/test_python.py
@@ -155,7 +155,7 @@ class UpdatePythonVersionTestCase(unittest.TestCase):
             "", name="pyproject.toml", change_into=True
         ), self.assertRaisesRegex(
             VersionError,
-            r"Version information not found in .*pyproject\.toml file\.",
+            r"\[tool.pontos.version\] section missing in .*pyproject\.toml\.",
         ):
             cmd = PythonVersionCommand(PEP440VersioningScheme)
             new_version = PEP440VersioningScheme.parse_version("22.1.2")
@@ -166,7 +166,7 @@ class UpdatePythonVersionTestCase(unittest.TestCase):
             "[tool]", name="pyproject.toml", change_into=True
         ), self.assertRaisesRegex(
             VersionError,
-            r"Version information not found in .*pyproject\.toml file\.",
+            r"\[tool.pontos.version\] section missing in .*pyproject\.toml\.",
         ):
             cmd = PythonVersionCommand(PEP440VersioningScheme)
             new_version = PEP440VersioningScheme.parse_version("22.1.2")


### PR DESCRIPTION
## What

When updating a version ignore the current version in case of erros

## Why


During a version update the project's current version is parsed. This may result in VersionErrors if for example the versioning scheme is changed and the new versioning scheme doesn't recognize the current version format (PEP440 based 22.4.1.dev1 can't be parsed as semver).

The current version is just parsed during the update to check if it is a real update or if the same version is set. Therefore ignore the VersionErrors during the version update and just set the new version.