### PR TITLE
Fix printing the versioning scheme in release sign CLI

### DIFF
--- a/pontos/release/sign.py
+++ b/pontos/release/sign.py
@@ -222,9 +222,7 @@ class SignCommand:
             )
             return SignReturnValue.TOKEN_MISSING
 
-        self.terminal.info(
-            f"Using versioning scheme {versioning_scheme.__class__.__name__}"
-        )
+        self.terminal.info(f"Using versioning scheme {versioning_scheme.name}")
 
         try:
             project = (


### PR DESCRIPTION
Don't use the class name which is weird for users. Instead print the dedicated scheme name.

## What

Fix printing the versioning scheme in release sign CLI
## Why

Don't use the class name which is weird for users. Instead print the dedicated scheme name.
