### PR TITLE
Change: Don't use upper limits for dependencies

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -412,13 +412,13 @@ graph = ["objgraph (>=1.7.2)"]
 
 [[package]]
 name = "docutils"
-version = "0.19"
+version = "0.20.1"
 description = "Docutils -- Python Documentation Utilities"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "docutils-0.19-py3-none-any.whl", hash = "sha256:5e1de4d849fee02c63b040a4a3fd567f4ab104defd8a5511fbbc24a8a017efbc"},
-    {file = "docutils-0.19.tar.gz", hash = "sha256:33995a6753c30b7f577febfc2c50411fec6aac7f7ffeb7c4cfe5991072dcf9e6"},
+    {file = "docutils-0.20.1-py3-none-any.whl", hash = "sha256:96f387a2c5562db4476f09f13bbab2192e764cac08ebbf3a34a95d9b1e4a59d6"},
+    {file = "docutils-0.20.1.tar.gz", hash = "sha256:f08a4e276c3a1583a86dce3e34aba3fe04d02bba2dd51ed16106244e8a923e3b"},
 ]
 
 [[package]]
@@ -569,13 +569,13 @@ files = [
 
 [[package]]
 name = "importlib-metadata"
-version = "6.6.0"
+version = "6.7.0"
 description = "Read metadata from Python packages"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "importlib_metadata-6.6.0-py3-none-any.whl", hash = "sha256:43dd286a2cd8995d5eaef7fee2066340423b818ed3fd70adf0bad5f1fac53fed"},
-    {file = "importlib_metadata-6.6.0.tar.gz", hash = "sha256:92501cdf9cc66ebd3e612f1b4f0c0765dfa42f0fa38ffb319b6bd84dd675d705"},
+    {file = "importlib_metadata-6.7.0-py3-none-any.whl", hash = "sha256:cb52082e659e97afc5dac71e79de97d8681de3aa07ff18578330904a9d18e5b5"},
+    {file = "importlib_metadata-6.7.0.tar.gz", hash = "sha256:1aaf550d4f73e5d6783e7acb77aec43d49da8017410afae93822cc9cca98c4d4"},
 ]
 
 [package.dependencies]
@@ -584,7 +584,7 @@ zipp = ">=0.5"
 [package.extras]
 docs = ["furo", "jaraco.packaging (>=9)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 perf = ["ipython"]
-testing = ["flake8 (<5)", "flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-flake8", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)"]
+testing = ["flufl.flake8", "importlib-resources (>=1.3)", "packaging", "pyfakefs", "pytest (>=6)", "pytest-black (>=0.3.7)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-enabler (>=1.3)", "pytest-mypy (>=0.9.1)", "pytest-perf (>=0.9.2)", "pytest-ruff"]
 
 [[package]]
 name = "isort"
@@ -957,13 +957,13 @@ files = [
 
 [[package]]
 name = "platformdirs"
-version = "3.5.3"
+version = "3.8.0"
 description = "A small Python package for determining appropriate platform-specific dirs, e.g. a \"user data dir\"."
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "platformdirs-3.5.3-py3-none-any.whl", hash = "sha256:0ade98a4895e87dc51d47151f7d2ec290365a585151d97b4d8d6312ed6132fed"},
-    {file = "platformdirs-3.5.3.tar.gz", hash = "sha256:e48fabd87db8f3a7df7150a4a5ea22c546ee8bc39bc2473244730d4b56d2cc4e"},
+    {file = "platformdirs-3.8.0-py3-none-any.whl", hash = "sha256:ca9ed98ce73076ba72e092b23d3c93ea6c4e186b3f1c3dad6edd98ff6ffcca2e"},
+    {file = "platformdirs-3.8.0.tar.gz", hash = "sha256:b0cabcb11063d21a0b261d557acb0a9d2126350e63b70cdf7db6347baea456dc"},
 ]
 
 [package.extras]
@@ -1542,5 +1542,5 @@ testing = ["big-O", "flake8 (<5)", "jaraco.functools", "jaraco.itertools", "more
 
 [metadata]
 lock-version = "2.0"
-python-versions = "^3.9"
-content-hash = "d4878b00c9044f468f56232f9711780ccf479f6ca6f0e3f3749d07669fd97f48"
+python-versions = ">=3.9"
+content-hash = "932a855529a7013e65ff932897960282dfbcce758838c91916df27ff2c7b8806"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,28 +34,28 @@ include = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.9"
-colorful = "^0.5.4"
+python = ">=3.9"
+colorful = ">=0.5.4"
 tomlkit = ">=0.5.11"
 packaging = ">=20.3"
 httpx = {extras = ["http2"], version = ">=0.23,<0.25"}
 rich = ">=12.4.4"
 typing-extensions = { version = "^4.4.0", python = "<3.8" }
-python-dateutil = "^2.8.2"
-semver = ">=2.13,<4.0"
-lxml = "^4.9.0"
+python-dateutil = ">=2.8.2"
+semver = ">=2.13"
+lxml = ">=4.9.0"
 
 [tool.poetry.dev-dependencies]
-autohooks = ">=22.7.0"
-autohooks-plugin-pylint = ">=21.6.0"
-autohooks-plugin-black = ">=22.7.0"
-autohooks-plugin-isort = ">=22.3.0"
-rope = "^1.9.0"
-coverage = "^7.2"
+autohooks = { version = ">=22.7.0", python = "^3.9" }
+autohooks-plugin-pylint = { version = ">=21.6.0", python = "^3.9" }
+autohooks-plugin-black = { version = ">=22.7.0", python = "^3.9" }
+autohooks-plugin-isort = { version = ">=22.3.0", python = "^3.9" }
+rope = ">=1.9.0"
+coverage = ">=7.2"
 myst-parser = ">=0.19.1"
-Sphinx = "^7.0.1"
-furo = "^2023.5.20"
-sphinx-autobuild = "^2021.3.14"
+Sphinx = ">=7.0.1"
+furo = ">=2023.5.20"
+sphinx-autobuild = ">=2021.3.14"
 
 [tool.black]
 line-length = 80


### PR DESCRIPTION


## What

Don't use upper limits for dependencies

## Why

Loosen the upper limits of the dependencies. Using upper limits has disadvantages of users not being able to update their dependencies for no real reason despite newer versions of the dependencies might be compatible.

