### PR TITLE
Fix releases with non conanic versions

### DIFF
--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -41,7 +41,7 @@ from .helper import ReleaseType, find_signing_key, get_git_repository_name
 
 @dataclass
 class ReleaseInformation:
-    last_release_version: Version | None
+    last_release_version: Optional[Version]
     release_version: Version
     git_release_tag: str
     next_version: Version
@@ -129,7 +129,7 @@ class ReleaseCommand:
     def _create_changelog(
         self,
         release_version: Version,
-        last_release_version: Version | None,
+        last_release_version: Optional[Version],
         cc_config: Path,
     ) -> str:
         changelog_builder = ChangelogBuilder(

--- a/pontos/release/release.py
+++ b/pontos/release/release.py
@@ -140,7 +140,9 @@ class ReleaseCommand:
         )
 
         return changelog_builder.create_changelog(
-            last_version=last_release_version,
+            last_version=last_release_version.parsed_version
+            if last_release_version
+            else None,
             next_version=release_version,
         )
 

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -41,6 +41,16 @@ class Version(ABC):
       names for the first value in the tuple: `alpha`, `beta`, `rc` and `dev`
     """
 
+    def __init__(self, original_version: str) -> None:
+        self._parsed_version = original_version
+
+    @property
+    def parsed_version(self) -> str:
+        """
+        Original version string from which the version has been parsed
+        """
+        return self._parsed_version
+
     @property
     @abstractmethod
     def major(self) -> int:

--- a/tests/version/schemes/test_pep440.py
+++ b/tests/version/schemes/test_pep440.py
@@ -63,6 +63,40 @@ class PEP440VersionTestCase(unittest.TestCase):
         for version in versions:
             self.assertEqual(Version.from_string(version), Version(version))
 
+    def test_parsed_version(self):
+        versions = [
+            "0.0.1",
+            "1.2.3",
+            "1.2.3-post1.dev1",
+            "1.2.3-a1",
+            "1.2.3-b1",
+            "1.2.3-rc1",
+            "1.2.3-a1+dev1",
+            "1.2.3-a1-dev1",
+            "1.4.1",
+            "2.4.1-dev1",
+            "2.4.1-dev3",
+            "1.2.3.post1",
+            "1.2.3a1",
+            "1.2.3b1",
+            "1.2.3rc1",
+            "1.2.3a1+dev1",
+            "1.2.3a1.dev1",
+            "22.4.1.dev1",
+            "22.4.1.dev3",
+            "2022.4.1.dev3",
+        ]
+        for version in versions:
+            self.assertEqual(
+                Version.from_string(version).parsed_version, version
+            )
+
+        semver_version = SemanticVersion.from_string("22.4.1-dev1")
+        pep440_version = Version.from_version(semver_version)
+
+        self.assertEqual(str(pep440_version), "22.4.1.dev1")
+        self.assertEqual(pep440_version.parsed_version, "22.4.1-dev1")
+
     def test_parse_error(self):
         versions = [
             "abc",

--- a/tests/version/schemes/test_semantic.py
+++ b/tests/version/schemes/test_semantic.py
@@ -49,6 +49,36 @@ class SemanticVersionTestCase(unittest.TestCase):
         for version in versions:
             self.assertEqual(Version.from_string(version), Version(version))
 
+    def test_parsed_version(self):
+        versions = [
+            "0.0.1",
+            "1.2.3",
+            "1.2.3-foo1",
+            "1.2.3-a1",
+            "1.2.3-alpha1",
+            "1.2.3-alpha1-dev1",
+            "1.2.3-b1",
+            "1.2.3-beta1",
+            "1.2.3-beta1-dev1",
+            "1.2.3-rc1",
+            "1.2.3-rc1-dev1",
+            "1.2.3-dev1",
+            "1.2.3+foo1",
+            "22.4.1",
+            "22.4.1-dev1",
+            "22.4.1-dev3",
+        ]
+        for version in versions:
+            self.assertEqual(
+                Version.from_string(version).parsed_version, version
+            )
+
+        pep440_version = PEP440Version.from_string("22.4.1.dev1")
+        semver_version = Version.from_version(pep440_version)
+
+        self.assertEqual(str(semver_version), "22.4.1-dev1")
+        self.assertEqual(semver_version.parsed_version, "22.4.1.dev1")
+
     def test_parse_error(self):
         versions = [
             "abc",


### PR DESCRIPTION
## What

Allow to create release if the last release version can't be parsed and/or the last release version has been adjusted to fit into the versioning scheme like with PEP440.

## Why

Don't fail to create releases with now invalid old tags. With this changes it is even possible to change the versioning scheme more easily.

## References

https://github.com/greenbone/pheme/actions/runs/5444535784/jobs/9902518476

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


