### PR TITLE
Add: Introduce a pontos module for additional typings

### DIFF
--- a/pontos/changelog/conventional_commits.py
+++ b/pontos/changelog/conventional_commits.py
@@ -17,15 +17,15 @@
 
 
 import re
-from abc import abstractmethod
 from datetime import date
 from pathlib import Path
-from typing import Dict, List, Optional, Protocol, Union, runtime_checkable
+from typing import Dict, List, Optional, Union
 
 import tomlkit
 
 from pontos.changelog.errors import ChangelogBuilderError
 from pontos.git import Git
+from pontos.typing import SupportsStr
 
 ADDRESS = "https://github.com/"
 
@@ -37,13 +37,6 @@ DEFAULT_CHANGELOG_CONFIG = """commit_types = [
     { message = "^deps", group = "Dependencies"},
 ]
 """
-
-
-@runtime_checkable
-class SupportsStr(Protocol):
-    @abstractmethod
-    def __str__(self) -> str:
-        pass
 
 
 class ChangelogBuilder:

--- a/pontos/typing/__init__.py
+++ b/pontos/typing/__init__.py
@@ -1,0 +1,30 @@
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+from abc import abstractmethod
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class SupportsStr(Protocol):
+    """
+    A protocol for classes supporting __str__
+    """
+
+    @abstractmethod
+    def __str__(self) -> str:
+        pass

--- a/tests/typing/__init__.py
+++ b/tests/typing/__init__.py
@@ -1,0 +1,16 @@
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.

--- a/tests/typing/test_typing.py
+++ b/tests/typing/test_typing.py
@@ -1,0 +1,35 @@
+# Copyright (C) 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import unittest
+
+from pontos.typing import SupportsStr
+
+
+class SupportsStrTestCase(unittest.TestCase):
+    def test_str(self):
+        self.assertIsInstance("", SupportsStr)
+        self.assertIsInstance(None, SupportsStr)
+
+    def test_some_class(self):
+        class Foo:
+            def __str__(self) -> str:
+                pass
+
+        foo = Foo()
+
+        self.assertIsInstance(foo, SupportsStr)


### PR DESCRIPTION
## What

Introduce a pontos module for additional typings

## Why

Currently the module contains the SupportsStr protocol. Personally I don't know why this protocol isn't available in the standard lib. The protocol will fix some mypy issues in future where str is expected but a non str type is passed..