### PR TITLE
Fix: Use "stable" URL for downloading GitHub release assets

### DIFF
--- a/pontos/github/api/release.py
+++ b/pontos/github/api/release.py
@@ -269,7 +269,10 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
 
         assets_json = response.json()
         for asset_json in assets_json:
-            asset_url: str = asset_json.get("url", "")
+            # use browser_download_url here because url doesn't response with
+            # exactly the same data on every request.
+            # not getting exactly the same data changes the hash sum.
+            asset_url: str = asset_json.get("browser_download_url", "")
             name: str = asset_json.get("name", "")
 
             if match_pattern and not Path(name).match(match_pattern):

--- a/tests/github/api/test_release.py
+++ b/tests/github/api/test_release.py
@@ -291,8 +291,8 @@ class GitHubAsyncRESTReleasesTestCase(GitHubAsyncRESTTestCase):
         get_assets_url_response.json.return_value = data
         get_assets_response = create_response()
         get_assets_response.json.return_value = [
-            {"url": "http://bar", "name": "bar"},
-            {"url": "http://baz", "name": "baz"},
+            {"browser_download_url": "http://bar", "name": "bar"},
+            {"browser_download_url": "http://baz", "name": "baz"},
         ]
         response = create_response(headers=MagicMock())
         response.headers.get.return_value = 2
@@ -381,8 +381,8 @@ class GitHubAsyncRESTReleasesTestCase(GitHubAsyncRESTTestCase):
         get_assets_url_response.json.return_value = data
         get_assets_response = create_response()
         get_assets_response.json.return_value = [
-            {"url": "http://bar", "name": "bar"},
-            {"url": "http://baz", "name": "baz"},
+            {"browser_download_url": "http://bar", "name": "bar"},
+            {"browser_download_url": "http://baz", "name": "baz"},
         ]
         response = create_response(headers=MagicMock())
         response.headers.get.return_value = 2


### PR DESCRIPTION


## What

Use "stable" URL for downloading GitHub release assets

## Why

Using the url of the assets json response returns different data with every request. This URL is therefore unstable and every downloaded file will have a different hash su,m. For being able to create signature we need a stable API that returns the same data with every request. Therefore don't use the url property from the json response and instead the browser_download_url which is stable.

## References

https://github.com/greenbone/gsa/issues/3801

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


