### PR TITLE
Improve error message for http errors while running GitHub script

### DIFF
--- a/pontos/github/script/__init__.py
+++ b/pontos/github/script/__init__.py
@@ -90,7 +90,12 @@ def main():
         try:
             error = e.response.json()
             message = error.get("message")
-            print("Error:", message, file=sys.stderr)
+            print(
+                f"HTTP error while running script {known_args.script} and "
+                f"doing a {e.request.method} request to {e.request.url}. "
+                f"Error was: {message}. ",
+                file=sys.stderr,
+            )
         except json.JSONDecodeError:
             # not a json response
             print(e, file=sys.stderr)


### PR DESCRIPTION
## What

Improve error message for http errors while running GitHub script

## Why

Print more details about the request and running script when a http error occurs. This allows for better analysis of the cause of the error.


## References
https://github.com/greenbone/cloud-billing-service/actions/runs/5472225377/jobs/9964174105#step:10:1160


