### PR TITLE
Fix: Swagger file should be Path not str

### DIFF
--- a/pontos/version/commands/_java.py
+++ b/pontos/version/commands/_java.py
@@ -129,7 +129,7 @@ class JavaVersionCommand(VersionCommand):
     ) -> None:
         # update swagger config file version
         swagger_config_file = find_file(
-            filename="SwaggerConfig.java",
+            filename=Path("SwaggerConfig.java"),
             search_path="src",
             search_glob="**/config/swagger/*",
         )


### PR DESCRIPTION
## What
Fix checking filename for Swaggerfile in Java Version ... needs to be `Path` not `str`
<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

Workflow fails

<!-- Describe why are these changes necessary? -->

## References
DEVOPS-733
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


