### PR TITLE
Split conventional commits

### DIFF
--- a/pontos/changelog/__init__.py
+++ b/pontos/changelog/__init__.py
@@ -24,5 +24,6 @@ __all__ = (
     "ChangelogError",
     "ChangelogBuilderError",
     "ChangelogBuilder",
+    "ConventionalCommits",
     "main",
 )

--- a/pontos/changelog/conventional_commits.py
+++ b/pontos/changelog/conventional_commits.py
@@ -19,7 +19,7 @@
 import re
 from datetime import date
 from pathlib import Path
-from typing import Dict, List, Optional, Union
+from typing import Dict, List, Optional, TypedDict, Union
 
 import tomlkit
 
@@ -38,11 +38,167 @@ DEFAULT_CHANGELOG_CONFIG = """commit_types = [
 ]
 """
 
+CommitID = str
+
+
+class CommitType(TypedDict):
+    message: str
+    group: str
+
+
+class ConventionalCommits:
+    """
+    Extracts conventional commits from the git log
+
+    Example:
+        Collect the conventional commits between the tags "v1.2.3" and "v2.0.0"
+        using the default config settings. Afterwards get the list of commits
+        for the "Added" category.
+
+        .. code-block:: python
+
+            from pontos.changelog import ConventionalCommits
+
+            collector = ConventionalCommits(space="my-org", project="my-project)
+            commits = collector.get_commits(
+                from_ref="v1.2.3",
+                to_ref="v2.0.0",
+            )
+            added = commits.get("Added")
+    """
+
+    def __init__(
+        self,
+        space: str,
+        project: str,
+        config: Optional[Path] = None,
+    ) -> None:
+        """
+        Create a new ConventionalCommits instance for collecting conventional
+        commits from a git log.
+
+        Args:
+            space: GitHub space to use (organization or user name).
+            project: GitHub project to create a changelog for
+            config: Optional TOML config for conventional commit parsing
+                settings.
+        """
+        if config:
+            if not config.exists():
+                raise ChangelogBuilderError(
+                    f"Changelog Config file '{config.absolute()}' does not "
+                    "exist."
+                )
+
+            self._config = tomlkit.parse(config.read_text(encoding="utf-8"))
+        else:
+            self._config = tomlkit.parse(DEFAULT_CHANGELOG_CONFIG)
+
+        self._space = space
+        self._project = project
+
+    def get_commits(
+        self,
+        from_ref: Optional[SupportsStr] = None,
+        to_ref: SupportsStr = "HEAD",
+    ) -> dict[str, list[str]]:
+        """
+        Get all commits by conventional commit type between a range of git
+        references.
+
+        Args:
+            from_ref: Git commit ID or reference where to start looking for
+                conventional commits. If None, to_ref is ignored and all
+                 conventional commits are returned.
+            to_ref: Git commit ID or reference where to stop looking for
+                conventional commits. By default HEAD is used.
+
+        Returns:
+            A dict containing the grouped commit messages
+        """
+        commit_list = self._get_git_log(from_ref, to_ref)
+        return self._sort_commits(commit_list)
+
+    def commit_types(self) -> list[CommitType]:
+        return self._config.get("commit_types", [])
+
+    def _get_git_log(
+        self, from_ref: Optional[SupportsStr], to_ref: SupportsStr = "HEAD"
+    ) -> list[str]:
+        """Getting the git log for the a range of commits.
+
+        Requires the fitting branch to be checked out if to_ref is not set.
+
+        Args:
+            from_ref: Git commit ID or reference of the first log entry. If
+                None, to_ref is ignored and all log entries of the current
+                checked out branch are returned.
+            to_ref: Git commit ID or reference where to stop considering the
+                log entries. By default HEAD is used which points to the last
+                commit of the checked out branch.
+
+        Returns:
+            A list of `git log` entries
+        """
+        git = Git()
+        if not from_ref:
+            return git.log(oneline=True)
+
+        return git.log(
+            f"{from_ref}..{to_ref}",
+            oneline=True,
+        )
+
+    def _sort_commits(self, commits: list[str]) -> dict[str, list[str]]:
+        """Sort the commits by commit type and group them
+        in a dict
+        ```
+        {
+            'Added:': [
+                'commit 1 [1234567](..)',
+                'commit 2 [1234568](..)',
+                '...',
+            ],
+            'Fixed:': [
+                ...
+            ],
+        }
+        ```
+
+        Returns
+            The dict containing the commit messages
+        """
+        commit_link = f"{ADDRESS}{self._space}/{self._project}/commit/"
+
+        commit_dict = {}
+        if commits and len(commits) > 0:
+            for commit in commits:
+                commit = commit.split(" ", maxsplit=1)
+                for commit_type in self.commit_types():
+                    reg = re.compile(
+                        rf'{commit_type["message"]}\s?[:|-]', flags=re.I
+                    )
+                    match = reg.match(commit[1])
+                    if match:
+                        if commit_type["group"] not in commit_dict:
+                            commit_dict[commit_type["group"]] = []
+
+                        # remove the commit tag from commit message
+                        cleaned_msg = (
+                            commit[1].replace(match.group(0), "").strip()
+                        )
+                        commit_dict[commit_type["group"]].append(
+                            f"{cleaned_msg} [{commit[0]}]"
+                            f"({commit_link}{commit[0]})"
+                        )
+
+        return commit_dict
+
 
 class ChangelogBuilder:
     """
     Creates Changelog from conventional commits using the git log
-    from the latest tag.
+    from the latest version.
 
     Example:
         Create a changelog as a string from the changes between git tags
@@ -77,21 +233,15 @@ class ChangelogBuilder:
                 Default is "v".
             config: TOML config for conventional commit parsing settings
         """
-        if config:
-            if not config.exists():
-                raise ChangelogBuilderError(
-                    f"Changelog Config file '{config.absolute()}' does not "
-                    "exist."
-                )
-
-            self.config = tomlkit.parse(config.read_text(encoding="utf-8"))
-        else:
-            self.config = tomlkit.parse(DEFAULT_CHANGELOG_CONFIG)
-
         self.project = project
         self.space = space
 
         self.git_tag_prefix = git_tag_prefix
+        self._conventional_commits = ConventionalCommits(
+            self.space,
+            self.project,
+            config,
+        )
 
     def create_changelog(
         self,
@@ -112,7 +262,9 @@ class ChangelogBuilder:
         Returns:
             The created changelog content.
         """
-        commit_dict = self.get_commits(last_version)
+        commit_dict = self._conventional_commits.get_commits(
+            f"{self.git_tag_prefix}{last_version}" if last_version else None
+        )
         return self._build_changelog(last_version, next_version, commit_dict)
 
     def create_changelog_file(
@@ -138,95 +290,12 @@ class ChangelogBuilder:
         )
         self._write_changelog_file(changelog, output)
 
-    def get_commits(
-        self,
-        last_version: Optional[SupportsStr] = None,
-    ) -> Dict[str, List[str]]:
-        """
-        Get all commits by conventional commit type
-
-        Args:
-            last_version: Version of the last release. If None it is considered
-                as the first release.
-
-        Returns:
-            A dict containing the grouped commit messages
-        """
-        commit_list = self._get_git_log(last_version)
-        return self._sort_commits(commit_list)
-
     def _get_first_commit(self) -> str:
         """
         Git the first commit ID for the current branch
         """
         git = Git()
         return git.rev_list("HEAD", max_parents=0, abbrev_commit=True)[0]
-
-    def _get_git_log(self, last_version: Optional[SupportsStr]) -> List[str]:
-        """Getting the git log for the next version.
-
-        Requires the fitting branch to be checked out
-
-        Returns:
-            A list of `git log` entries
-        """
-        git = Git()
-        if not last_version:
-            return git.log(oneline=True)
-
-        git_version = f"{self.git_tag_prefix}{last_version}"
-        return git.log(
-            f"{git_version}..HEAD",
-            oneline=True,
-        )
-
-    def _sort_commits(self, commits: List[str]) -> Dict[str, List[str]]:
-        """Sort the commits by commit type and group them
-        in a dict
-        ```
-        {
-            'Added:': [
-                'commit 1 [1234567](..)',
-                'commit 2 [1234568](..)',
-                '...',
-            ],
-            'Fixed:': [
-                ...
-            ],
-        }
-        ```
-
-        Returns
-            The dict containing the commit messages
-        """
-        # get the commit types from the toml
-        commit_types = self.config.get("commit_types")
-
-        commit_link = f"{ADDRESS}{self.space}/{self.project}/commit/"
-
-        commit_dict = {}
-        if commits and len(commits) > 0:
-            for commit in commits:
-                commit = commit.split(" ", maxsplit=1)
-                for commit_type in commit_types:
-                    reg = re.compile(
-                        rf'{commit_type["message"]}\s?[:|-]', flags=re.I
-                    )
-                    match = reg.match(commit[1])
-                    if match:
-                        if commit_type["group"] not in commit_dict:
-                            commit_dict[commit_type["group"]] = []
-
-                        # remove the commit tag from commit message
-                        cleaned_msg = (
-                            commit[1].replace(match.group(0), "").strip()
-                        )
-                        commit_dict[commit_type["group"]].append(
-                            f"{cleaned_msg} [{commit[0]}]"
-                            f"({commit_link}{commit[0]})"
-                        )
-
-        return commit_dict
 
     def _build_changelog(
         self,
@@ -254,8 +323,7 @@ class ChangelogBuilder:
             changelog.append("## [Unreleased]")
 
         # changelog entries
-        commit_types = self.config.get("commit_types")
-        for commit_type in commit_types:
+        for commit_type in self._conventional_commits.commit_types():
             if commit_type["group"] in commit_dict.keys():
                 changelog.append(f"\n## {commit_type['group']}")
                 for msg in commit_dict[commit_type["group"]]:

--- a/tests/changelog/test_conventional_commits.py
+++ b/tests/changelog/test_conventional_commits.py
@@ -529,10 +529,7 @@ class ConventionalCommitsTestCase(unittest.TestCase):
             "d0c4d0c Doc: bar baz documenting",
         ]
 
-        conventional_commits = ConventionalCommits(
-            space="foo",
-            project="bar",
-        )
+        conventional_commits = ConventionalCommits()
         commits = conventional_commits.get_commits(from_ref="0.0.1")
 
         self.assertEqual(len(commits), 4)  # four commit types
@@ -541,11 +538,16 @@ class ConventionalCommitsTestCase(unittest.TestCase):
         self.assertEqual(len(commits["Removed"]), 1)
         self.assertEqual(len(commits["Bug Fixes"]), 1)
 
+        removed = commits["Removed"][0]
+        self.assertEqual(removed.commit_id, "42a42a4")
+        self.assertEqual(removed.message, "foo bar again")
+
+        commit_id, message = removed
+        self.assertEqual(commit_id, "42a42a4")
+        self.assertEqual(message, "foo bar again")
+
     def test_default_config(self):
-        conventional_commits = ConventionalCommits(
-            space="foo",
-            project="bar",
-        )
+        conventional_commits = ConventionalCommits()
 
         categories = conventional_commits.commit_types()
 


### PR DESCRIPTION
## What

Split generating the changelog into a conventional commits parser and changelog generator. The conventional commits parser is extended to allow parsing a commit range.

## Why

Both are two distinct use cases. We don't need to create markdown links for the conventional commits action. Also parsing a range will make it easier to implement the conventional commits actions for forked pull requests.

## References

DEVOPS-720

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


