### PR TITLE
Change: Add `const` and `nargs` to `git-tag-prefix`

### DIFF
--- a/pontos/release/parser.py
+++ b/pontos/release/parser.py
@@ -134,6 +134,8 @@ def parse_args(args) -> Tuple[str, str, Namespace]:
     release_parser.add_argument(
         "--git-tag-prefix",
         default="v",
+        const="",
+        nargs="?",
         help="Prefix for git tag versions. Default: %(default)s",
     )
     release_parser.add_argument(
@@ -199,6 +201,8 @@ def parse_args(args) -> Tuple[str, str, Namespace]:
     sign_parser.add_argument(
         "--git-tag-prefix",
         default="v",
+        const="",
+        nargs="?",
         help="Prefix for git tag versions. Default: %(default)s",
     )
     sign_parser.add_argument(

--- a/tests/release/test_parser.py
+++ b/tests/release/test_parser.py
@@ -87,6 +87,12 @@ class ReleaseParseArgsTestCase(unittest.TestCase):
 
         self.assertEqual(args.git_tag_prefix, "")
 
+        _, _, args = parse_args(
+            ["release", "--git-tag-prefix", "--release-type", "patch"]
+        )
+
+        self.assertEqual(args.git_tag_prefix, "")
+
     def test_space(self):
         _, _, args = parse_args(
             ["release", "--space", "foo", "--release-type", "patch"]


### PR DESCRIPTION
## What

Change: Add const and nargs to git-tag-prefix

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why

when passing `--git-tag-prefix` without an arg, it fails.

<!-- Describe why are these changes necessary? -->

## References
DEVOPS-733
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


