### PR TITLE
Add: Introduce `pontos-release show` CLI

### DIFF
--- a/pontos/release/show.py
+++ b/pontos/release/show.py
@@ -1,0 +1,177 @@
+# SPDX-FileCopyrightText: 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import json
+from argparse import Namespace
+from enum import Enum, IntEnum, auto
+from typing import Optional
+
+from pontos.errors import PontosError
+from pontos.git import Git
+from pontos.github.actions import ActionIO
+from pontos.release.command import Command
+from pontos.release.helper import ReleaseType, get_next_release_version
+from pontos.terminal import Terminal
+from pontos.typing import SupportsStr
+from pontos.version import Version, VersionError
+from pontos.version.helper import get_last_release_version
+from pontos.version.schemes import VersioningScheme
+
+
+class ShowReleaseReturnValue(IntEnum):
+    """
+    Possible return values of ReleaseCommand
+    """
+
+    SUCCESS = 0
+    NO_LAST_RELEASE_VERSION = auto()
+    NO_RELEASE_VERSION = auto()
+
+
+class OutputFormat(Enum):
+    ENV = "env"
+    JSON = "json"
+    GITHUB_ACTION = "github-action"
+
+
+class ShowReleaseCommand(Command):
+    def __init__(self, *, terminal: Terminal, error_terminal: Terminal) -> None:
+        super().__init__(terminal=terminal, error_terminal=error_terminal)
+        self.git = Git()
+
+    def run(  # type: ignore[override]
+        self,
+        *,
+        output_format: OutputFormat = OutputFormat.ENV,
+        versioning_scheme: VersioningScheme,
+        release_type: ReleaseType,
+        release_version: Optional[Version],
+        release_series: Optional[str] = None,
+        git_tag_prefix: Optional[str] = None,
+    ) -> int:
+        git_tag_prefix = git_tag_prefix or ""
+
+        try:
+            last_release_version = get_last_release_version(
+                parse_version=versioning_scheme.parse_version,
+                git_tag_prefix=git_tag_prefix,
+                tag_name=f"{git_tag_prefix}{release_series}.*"
+                if release_series
+                else None,
+            )
+        except PontosError as e:
+            last_release_version = None
+            self.print_warning(f"Could not determine last release version. {e}")
+
+        if not last_release_version and not release_version:
+            self.print_error("Unable to determine last release version.")
+            return ShowReleaseReturnValue.NO_LAST_RELEASE_VERSION
+
+        calculator = versioning_scheme.calculator()
+
+        try:
+            release_version = get_next_release_version(
+                last_release_version=last_release_version,
+                calculator=calculator,
+                release_type=release_type,
+                release_version=release_version,
+            )
+        except VersionError as e:
+            self.print_error(f"Unable to determine release version. {e}")
+            return ShowReleaseReturnValue.NO_RELEASE_VERSION
+
+        if last_release_version:
+            last_release_version_dict = {
+                "last_release_version": str(last_release_version),
+                "last_release_version_major": last_release_version.major,
+                "last_release_version_minor": last_release_version.minor,
+                "last_release_version_patch": last_release_version.patch,
+            }
+        else:
+            last_release_version_dict = {
+                "last_release_version": "",
+                "last_release_version_major": "",
+                "last_release_version_minor": "",
+                "last_release_version_patch": "",
+            }
+
+        if output_format == OutputFormat.JSON:
+            release_dict = {
+                "release_version": str(release_version),
+                "release_version_major": release_version.major,
+                "release_version_minor": release_version.minor,
+                "release_version_patch": release_version.patch,
+            }
+            release_dict.update(last_release_version_dict)
+            self.terminal.print(json.dumps(release_dict, indent=2))
+        elif output_format == OutputFormat.GITHUB_ACTION:
+            with ActionIO.out() as output:
+                output.write(
+                    "last_release_version",
+                    last_release_version_dict["last_release_version"],
+                )
+                output.write(
+                    "last_release_version_major",
+                    last_release_version_dict["last_release_version_major"],
+                )
+                output.write(
+                    "last_release_version_minor",
+                    last_release_version_dict["last_release_version_minor"],
+                )
+                output.write(
+                    "last_release_version_patch",
+                    last_release_version_dict["last_release_version_patch"],
+                )
+                output.write("release_version_major", release_version.major)
+                output.write("release_version_minor", release_version.minor)
+                output.write("release_version_patch", release_version.patch)
+                output.write("release_version", release_version)
+        else:
+            self.terminal.print(
+                "LAST_RELEASE_VERSION="
+                f"{last_release_version_dict['last_release_version']}"
+            )
+            self.terminal.print(
+                "LAST_RELEASE_VERSION_MAJOR="
+                f"{last_release_version_dict['last_release_version_major']}"
+            )
+            self.terminal.print(
+                "LAST_RELEASE_VERSION_MINOR="
+                f"{last_release_version_dict['last_release_version_minor']}"
+            )
+            self.terminal.print(
+                "LAST_RELEASE_VERSION_PATCH="
+                f"{last_release_version_dict['last_release_version_patch']}"
+            )
+            self.terminal.print(f"RELEASE_VERSION={release_version}")
+            self.terminal.print(
+                f"RELEASE_VERSION_MAJOR={release_version.major}"
+            )
+            self.terminal.print(
+                f"RELEASE_VERSION_MINOR={release_version.minor}"
+            )
+            self.terminal.print(
+                f"RELEASE_VERSION_PATCH={release_version.patch}"
+            )
+
+        return ShowReleaseReturnValue.SUCCESS
+
+
+def show(
+    args: Namespace,
+    terminal: Terminal,
+    error_terminal: Terminal,
+    **_kwargs,
+) -> SupportsStr:
+    return ShowReleaseCommand(
+        terminal=terminal,
+        error_terminal=error_terminal,
+    ).run(
+        versioning_scheme=args.versioning_scheme,
+        release_type=args.release_type,
+        release_version=args.release_version,
+        git_tag_prefix=args.git_tag_prefix,
+        release_series=args.release_series,
+        output_format=args.output_format,
+    )

--- a/tests/release/test_show.py
+++ b/tests/release/test_show.py
@@ -1,0 +1,360 @@
+# SPDX-FileCopyrightText: 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+from pontos.git import Git
+from pontos.release.helper import ReleaseType
+from pontos.release.show import (
+    OutputFormat,
+    ShowReleaseCommand,
+    ShowReleaseReturnValue,
+)
+from pontos.testing import temp_file, temp_git_repository
+from pontos.version.schemes import PEP440VersioningScheme
+
+
+def setup_git_repo(temp_git: Path) -> None:
+    some_file = temp_git / "some-file.txt"
+    some_file.touch()
+
+    git = Git()
+    git.add(some_file)
+    git.commit("Add some file", gpg_sign=False, verify=False)
+    git.tag("v1.0.0", sign=False)
+
+
+class ShowTestCase(unittest.TestCase):
+    def test_env_output(self):
+        terminal = MagicMock()
+        with temp_git_repository() as temp_git:
+            setup_git_repo(temp_git)
+
+            show_cmd = ShowReleaseCommand(
+                terminal=terminal, error_terminal=MagicMock()
+            )
+
+            return_val = show_cmd.run(
+                versioning_scheme=PEP440VersioningScheme,
+                release_type=ReleaseType.PATCH,
+                release_version=None,
+                git_tag_prefix="v",
+                output_format=OutputFormat.ENV,
+            )
+
+            self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+            terminal.print.assert_has_calls(
+                [
+                    call("LAST_RELEASE_VERSION=1.0.0"),
+                    call("LAST_RELEASE_VERSION_MAJOR=1"),
+                    call("LAST_RELEASE_VERSION_MINOR=0"),
+                    call("LAST_RELEASE_VERSION_PATCH=0"),
+                    call("RELEASE_VERSION=1.0.1"),
+                    call("RELEASE_VERSION_MAJOR=1"),
+                    call("RELEASE_VERSION_MINOR=0"),
+                    call("RELEASE_VERSION_PATCH=1"),
+                ]
+            )
+
+            return_val = show_cmd.run(
+                versioning_scheme=PEP440VersioningScheme,
+                release_type=ReleaseType.MINOR,
+                release_version=None,
+                git_tag_prefix="v",
+                output_format=OutputFormat.ENV,
+            )
+
+            self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+            terminal.print.assert_has_calls(
+                [
+                    call("LAST_RELEASE_VERSION=1.0.0"),
+                    call("LAST_RELEASE_VERSION_MAJOR=1"),
+                    call("LAST_RELEASE_VERSION_MINOR=0"),
+                    call("LAST_RELEASE_VERSION_PATCH=0"),
+                    call("RELEASE_VERSION=1.1.0"),
+                    call("RELEASE_VERSION_MAJOR=1"),
+                    call("RELEASE_VERSION_MINOR=1"),
+                    call("RELEASE_VERSION_PATCH=0"),
+                ]
+            )
+
+            return_val = show_cmd.run(
+                versioning_scheme=PEP440VersioningScheme,
+                release_type=ReleaseType.MAJOR,
+                release_version=None,
+                git_tag_prefix="v",
+                output_format=OutputFormat.ENV,
+            )
+
+            self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+            terminal.print.assert_has_calls(
+                [
+                    call("LAST_RELEASE_VERSION=1.0.0"),
+                    call("LAST_RELEASE_VERSION_MAJOR=1"),
+                    call("LAST_RELEASE_VERSION_MINOR=0"),
+                    call("LAST_RELEASE_VERSION_PATCH=0"),
+                    call("RELEASE_VERSION=2.0.0"),
+                    call("RELEASE_VERSION_MAJOR=2"),
+                    call("RELEASE_VERSION_MINOR=0"),
+                    call("RELEASE_VERSION_PATCH=0"),
+                ]
+            )
+
+    def test_json_output(self):
+        terminal = MagicMock()
+        with temp_git_repository() as temp_git:
+            setup_git_repo(temp_git)
+
+            show_cmd = ShowReleaseCommand(
+                terminal=terminal, error_terminal=MagicMock()
+            )
+
+            return_val = show_cmd.run(
+                versioning_scheme=PEP440VersioningScheme,
+                release_type=ReleaseType.PATCH,
+                release_version=None,
+                git_tag_prefix="v",
+                output_format=OutputFormat.JSON,
+            )
+
+            expected = """{
+  "release_version": "1.0.1",
+  "release_version_major": 1,
+  "release_version_minor": 0,
+  "release_version_patch": 1,
+  "last_release_version": "1.0.0",
+  "last_release_version_major": 1,
+  "last_release_version_minor": 0,
+  "last_release_version_patch": 0
+}"""
+
+            self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+            terminal.print.assert_called_once_with(expected)
+            terminal.reset_mock()
+
+            return_val = show_cmd.run(
+                versioning_scheme=PEP440VersioningScheme,
+                release_type=ReleaseType.MINOR,
+                release_version=None,
+                git_tag_prefix="v",
+                output_format=OutputFormat.JSON,
+            )
+
+            expected = """{
+  "release_version": "1.1.0",
+  "release_version_major": 1,
+  "release_version_minor": 1,
+  "release_version_patch": 0,
+  "last_release_version": "1.0.0",
+  "last_release_version_major": 1,
+  "last_release_version_minor": 0,
+  "last_release_version_patch": 0
+}"""
+
+            self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+            terminal.print.assert_called_once_with(expected)
+            terminal.reset_mock()
+
+            return_val = show_cmd.run(
+                versioning_scheme=PEP440VersioningScheme,
+                release_type=ReleaseType.MAJOR,
+                release_version=None,
+                git_tag_prefix="v",
+                output_format=OutputFormat.JSON,
+            )
+
+            expected = """{
+  "release_version": "2.0.0",
+  "release_version_major": 2,
+  "release_version_minor": 0,
+  "release_version_patch": 0,
+  "last_release_version": "1.0.0",
+  "last_release_version_major": 1,
+  "last_release_version_minor": 0,
+  "last_release_version_patch": 0
+}"""
+
+            self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+            terminal.print.assert_called_once_with(expected)
+
+    def test_github_action_output(self):
+        terminal = MagicMock()
+        with temp_git_repository() as temp_git:
+            setup_git_repo(temp_git)
+
+            show_cmd = ShowReleaseCommand(
+                terminal=terminal, error_terminal=MagicMock()
+            )
+
+            output_file = temp_git.absolute() / "output"
+
+            with patch.dict(
+                "os.environ", {"GITHUB_OUTPUT": f"{output_file}"}, clear=True
+            ):
+                return_val = show_cmd.run(
+                    versioning_scheme=PEP440VersioningScheme,
+                    release_type=ReleaseType.PATCH,
+                    release_version=None,
+                    git_tag_prefix="v",
+                    output_format=OutputFormat.GITHUB_ACTION,
+                )
+
+                self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+                expected = """last_release_version=1.0.0
+last_release_version_major=1
+last_release_version_minor=0
+last_release_version_patch=0
+release_version_major=1
+release_version_minor=0
+release_version_patch=1
+release_version=1.0.1
+"""
+                actual = output_file.read_text(encoding="utf8")
+
+                self.assertEqual(expected, actual)
+
+                output_file.unlink()
+
+                return_val = show_cmd.run(
+                    versioning_scheme=PEP440VersioningScheme,
+                    release_type=ReleaseType.MINOR,
+                    release_version=None,
+                    git_tag_prefix="v",
+                    output_format=OutputFormat.GITHUB_ACTION,
+                )
+
+                self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+                expected = """last_release_version=1.0.0
+last_release_version_major=1
+last_release_version_minor=0
+last_release_version_patch=0
+release_version_major=1
+release_version_minor=1
+release_version_patch=0
+release_version=1.1.0
+"""
+                actual = output_file.read_text(encoding="utf8")
+
+                self.assertEqual(expected, actual)
+
+                output_file.unlink()
+
+                return_val = show_cmd.run(
+                    versioning_scheme=PEP440VersioningScheme,
+                    release_type=ReleaseType.MAJOR,
+                    release_version=None,
+                    git_tag_prefix="v",
+                    output_format=OutputFormat.GITHUB_ACTION,
+                )
+
+                self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+                expected = """last_release_version=1.0.0
+last_release_version_major=1
+last_release_version_minor=0
+last_release_version_patch=0
+release_version_major=2
+release_version_minor=0
+release_version_patch=0
+release_version=2.0.0
+"""
+                actual = output_file.read_text(encoding="utf8")
+
+                self.assertEqual(expected, actual)
+
+                output_file.unlink()
+
+    def test_initial_release(self):
+        terminal = MagicMock()
+        with temp_git_repository():
+            show_cmd = ShowReleaseCommand(
+                terminal=terminal, error_terminal=MagicMock()
+            )
+
+            return_val = show_cmd.run(
+                versioning_scheme=PEP440VersioningScheme,
+                release_type=ReleaseType.VERSION,
+                release_version=PEP440VersioningScheme.parse_version("1.0.0"),
+                git_tag_prefix="v",
+                output_format=OutputFormat.ENV,
+            )
+
+            self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+            terminal.print.assert_has_calls(
+                [
+                    call("LAST_RELEASE_VERSION="),
+                    call("LAST_RELEASE_VERSION_MAJOR="),
+                    call("LAST_RELEASE_VERSION_MINOR="),
+                    call("LAST_RELEASE_VERSION_PATCH="),
+                    call("RELEASE_VERSION=1.0.0"),
+                    call("RELEASE_VERSION_MAJOR=1"),
+                    call("RELEASE_VERSION_MINOR=0"),
+                    call("RELEASE_VERSION_PATCH=0"),
+                ]
+            )
+
+            terminal.reset_mock()
+
+            return_val = show_cmd.run(
+                versioning_scheme=PEP440VersioningScheme,
+                release_type=ReleaseType.VERSION,
+                release_version=PEP440VersioningScheme.parse_version("1.0.0"),
+                git_tag_prefix="v",
+                output_format=OutputFormat.JSON,
+            )
+
+            expected = """{
+  "release_version": "1.0.0",
+  "release_version_major": 1,
+  "release_version_minor": 0,
+  "release_version_patch": 0,
+  "last_release_version": "",
+  "last_release_version_major": "",
+  "last_release_version_minor": "",
+  "last_release_version_patch": ""
+}"""
+
+            self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+            terminal.print.assert_called_once_with(expected)
+
+            with temp_file(name="output") as output_file, patch.dict(
+                "os.environ", {"GITHUB_OUTPUT": f"{output_file}"}, clear=True
+            ):
+                return_val = show_cmd.run(
+                    versioning_scheme=PEP440VersioningScheme,
+                    release_type=ReleaseType.VERSION,
+                    release_version=PEP440VersioningScheme.parse_version(
+                        "1.0.0"
+                    ),
+                    git_tag_prefix="v",
+                    output_format=OutputFormat.GITHUB_ACTION,
+                )
+
+                self.assertEqual(return_val, ShowReleaseReturnValue.SUCCESS)
+
+                expected = """last_release_version=
+last_release_version_major=
+last_release_version_minor=
+last_release_version_patch=
+release_version_major=1
+release_version_minor=0
+release_version_patch=0
+release_version=1.0.0
+"""
+                actual = output_file.read_text(encoding="utf8")
+
+                self.assertEqual(expected, actual)


### PR DESCRIPTION


## What

Introduce pontos-release show CLI

## Why
Add a new CLI for displaying the current release and possible next release. This allows to get the next release version before actually creating a new release.


## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


