### PR TITLE
Fix getting repo security and analysis

### DIFF
--- a/pontos/github/models/organization.py
+++ b/pontos/github/models/organization.py
@@ -267,12 +267,15 @@ class SecurityAndAnalysis(GitHubModel):
 
     Attributes:
         advanced_security: Status of GitHub Advanced Security is used
+        dependabot_security_updates: Status of Dependabot security updates are
+            used
         secret_scanning: Status of Secret Scanning is used
         secret_scanning_push_protection: Status of Secret Scanning Push
             Protection is used
     """
 
     advanced_security: Optional[SecurityAndAnalysisType] = None
+    dependabot_security_updates: Optional[SecurityAndAnalysisType] = None
     secret_scanning: Optional[SecurityAndAnalysisType] = None
     secret_scanning_push_protection: Optional[SecurityAndAnalysisType] = None
 

--- a/pontos/github/models/organization.py
+++ b/pontos/github/models/organization.py
@@ -272,9 +272,9 @@ class SecurityAndAnalysis(GitHubModel):
             Protection is used
     """
 
-    advanced_security: SecurityAndAnalysisType
-    secret_scanning: SecurityAndAnalysisType
-    secret_scanning_push_protection: SecurityAndAnalysisType
+    advanced_security: Optional[SecurityAndAnalysisType] = None
+    secret_scanning: Optional[SecurityAndAnalysisType] = None
+    secret_scanning_push_protection: Optional[SecurityAndAnalysisType] = None
 
 
 @dataclass

--- a/pontos/models/__init__.py
+++ b/pontos/models/__init__.py
@@ -163,8 +163,8 @@ class Model:
                     value = cls._get_value(model_field_cls, value)  # type: ignore # pylint: disable=line-too-long # noqa: E501
             except TypeError as e:
                 raise ModelError(
-                    f"Error while creating {cls.__name__}. Could not set value "
-                    f"for '{name}' from '{value}'."
+                    f"Error while creating {cls.__name__} model. Could not set "
+                    f"value for property '{name}' from '{value}'."
                 ) from e
 
             if name in type_hints:

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -205,7 +205,7 @@ class DottedAttributesTestCase(unittest.TestCase):
 
         with self.assertRaisesRegex(
             ModelError,
-            "Error while creating ExampleModel. Could not set value for 'foo' "
-            "from '{'bar': 'baz'}'.",
+            "Error while creating ExampleModel model. Could not set value for "
+            "property 'foo' from '{'bar': 'baz'}'.",
         ):
             ExampleModel.from_dict({"foo": {"bar": "baz"}})


### PR DESCRIPTION
## What

Don't crash when getting repositories when using a token.

## Why

When using a token the security and analysis information is included in the response. Despite the JSON schema is not mentioning optional settings the `advanced_security` object is not returned in our responses. To be able to still receive repository data the security and analysis settings are now marked as optional in the response models.

## References

Fixes https://jira.greenbone.net/browse/DEVOPS-822

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


