### PR TITLE
Repository topics api

### DIFF
--- a/pontos/github/api/repositories.py
+++ b/pontos/github/api/repositories.py
@@ -522,3 +522,38 @@ class GitHubAsyncRESTRepositories(GitHubAsyncREST):
 
         data: dict[str, Any] = response.json()
         return data.get("names", [])
+
+    async def update_topics(
+        self, repo: str, new_topics: Iterable[str]
+    ) -> Iterable[str]:
+        """
+        Replace all topics of a repository
+
+        Args:
+            repo: GitHub repository (owner/name) to update the topics for
+            new_topics: Iterable of new topics to set on the repository
+
+        Raises:
+            HTTPStatusError: A httpx.HTTPStatusError is raised if the request
+                failed.
+
+        Returns:
+            An iterable of topics as string
+
+        Example:
+            .. code-block:: python
+
+                from pontos.github.api import GitHubAsyncRESTApi
+
+                async with GitHubAsyncRESTApi(token) as api:
+                    topics = await api.repositories.update_topics(
+                        "foo/bar", ["foo", "bar"]
+                    )
+        """
+        api = f"/repos/{repo}/topics"
+        data = {"names": list(new_topics)}
+        response = await self._client.put(api, data=data)  # type: ignore[arg-type] # noqa: E501
+        response.raise_for_status()
+
+        data: dict[str, Any] = response.json()
+        return data.get("names", [])

--- a/pontos/github/api/repositories.py
+++ b/pontos/github/api/repositories.py
@@ -15,7 +15,7 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from typing import Optional, Union
+from typing import Any, Iterable, Optional, Union
 
 from pontos.github.api.client import GitHubAsyncREST
 from pontos.github.api.helper import JSON_OBJECT
@@ -493,3 +493,32 @@ class GitHubAsyncRESTRepositories(GitHubAsyncREST):
         response = await self._client.post(api, data=data)
         response.raise_for_status()
         return Repository.from_dict(response.json())
+
+    async def topics(self, repo: str) -> Iterable[str]:
+        """
+        List all topics of a repository
+
+        Args:
+            repo: GitHub repository (owner/name) to list the topics for
+
+        Raises:
+            HTTPStatusError: A httpx.HTTPStatusError is raised if the request
+                failed.
+
+        Returns:
+            An iterable of topics as string
+
+        Example:
+            .. code-block:: python
+
+                from pontos.github.api import GitHubAsyncRESTApi
+
+                async with GitHubAsyncRESTApi(token) as api:
+                    topics = await api.repositories.topics("foo/bar")
+        """
+        api = f"/repos/{repo}/topics"
+        response = await self._client.get(api)
+        response.raise_for_status()
+
+        data: dict[str, Any] = response.json()
+        return data.get("names", [])

--- a/pontos/github/scripts/topics.py
+++ b/pontos/github/scripts/topics.py
@@ -1,0 +1,44 @@
+# Copyright (C) 2022 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+"""
+This script prints out all repositories existing in the space of the given
+organization
+"""
+
+from argparse import ArgumentParser, Namespace
+
+from pontos.github.api import GitHubAsyncRESTApi
+
+
+def add_script_arguments(parser: ArgumentParser) -> None:
+    parser.add_argument("repository", help="owner/repo")
+    parser.add_argument("topics", nargs="*", help="new topics to set")
+
+
+async def github_script(api: GitHubAsyncRESTApi, args: Namespace) -> int:
+    if not args.topics:
+        topics = await api.repositories.topics(args.repository)
+    else:
+        topics = await api.repositories.update_topics(
+            args.repository, args.topics
+        )
+
+    for topic in topics:
+        print(topic)
+
+    return 0

--- a/tests/github/api/test_repositories.py
+++ b/tests/github/api/test_repositories.py
@@ -773,3 +773,15 @@ class GitHubAsyncRESTRepositoriesTestCase(GitHubAsyncRESTTestCase):
                 "web_commit_signoff_required": False,
             },
         )
+
+    async def test_get_topics(self):
+        response = create_response()
+        response.json.return_value = {"names": ["foo", "bar", "baz"]}
+        self.client.get.return_value = response
+
+        topics = await self.api.topics("foo/bar")
+
+        self.client.get.assert_awaited_once_with("/repos/foo/bar/topics")
+
+        self.assertEqual(len(topics), 3)
+        self.assertEqual(topics, ["foo", "bar", "baz"])

--- a/tests/github/api/test_repositories.py
+++ b/tests/github/api/test_repositories.py
@@ -785,3 +785,25 @@ class GitHubAsyncRESTRepositoriesTestCase(GitHubAsyncRESTTestCase):
 
         self.assertEqual(len(topics), 3)
         self.assertEqual(topics, ["foo", "bar", "baz"])
+
+    async def test_update_topics(self):
+        response = create_response()
+        response.json.return_value = {}
+        response.json.return_value = {"names": ["foo", "bar"]}
+
+        self.client.put.return_value = response
+
+        new_topics = await self.api.update_topics(
+            "foo/bar",
+            (
+                "foo",
+                "bar",
+            ),
+        )
+
+        self.client.put.assert_awaited_once_with(
+            "/repos/foo/bar/topics", data={"names": ["foo", "bar"]}
+        )
+
+        self.assertEqual(len(new_topics), 2)
+        self.assertEqual(new_topics, ["foo", "bar"])


### PR DESCRIPTION
## What

Implement GitHub API for getting and updating repository topics

## Why

We want to be able to analyze the set topics and automate updating them.

## References

DEVOPS-818

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


