### PR TITLE
No next version

### DIFF
--- a/pontos/release/parser.py
+++ b/pontos/release/parser.py
@@ -123,12 +123,21 @@ def parse_args(args) -> Tuple[Optional[str], Optional[str], Namespace]:
         'released version. Examples: "1.2", "2", "22.4"',
     )
 
-    create_parser.add_argument(
+    next_version_group = create_parser.add_mutually_exclusive_group()
+
+    next_version_group.add_argument(
         "--next-version",
         help=(
             "Sets the next version in project definition "
             "after the release. Default: set to next dev version"
         ),
+    )
+
+    next_version_group.add_argument(
+        "--no-next-version",
+        help="Don't set a next version after the release.",
+        dest="next_version",
+        action="store_false",
     )
 
     create_parser.add_argument(

--- a/pontos/release/parser.py
+++ b/pontos/release/parser.py
@@ -187,7 +187,7 @@ def parse_args(args) -> Tuple[Optional[str], Optional[str], Namespace]:
     )
     create_parser.add_argument(
         "--github-pre-release",
-        help="Enforce uploading a release as GitHub " "pre-release. ",
+        help="Enforce uploading a release as GitHub pre-release. ",
         action="store_true",
     )
 

--- a/tests/release/test_parser.py
+++ b/tests/release/test_parser.py
@@ -121,6 +121,26 @@ class CreateParseArgsTestCase(unittest.TestCase):
 
         self.assertEqual(args.next_version, PEP440Version("1.2.3"))
 
+    def test_no_next_version(self):
+        _, _, args = parse_args(
+            ["create", "--no-next-version", "--release-type", "patch"]
+        )
+
+        self.assertFalse(args.next_version)
+
+    def test_next_version_conflict(self):
+        with self.assertRaises(SystemExit), redirect_stderr(StringIO()):
+            parse_args(
+                [
+                    "create",
+                    "--release-type",
+                    "patch",
+                    "--no-next-version",
+                    "--next-verson",
+                    "1.2.3",
+                ]
+            )
+
     def test_release_type(self):
         _, _, args = parse_args(["create", "--release-type", "patch"])
 


### PR DESCRIPTION
## What

Make updating the version after a release optional.

## Why

For some workflows it is necessary to not create an extra commit after a release.

## References

DEVOPS-828

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


