### PR TITLE
Add tests for java version parsing

### DIFF
--- a/pontos/version/commands/_java.py
+++ b/pontos/version/commands/_java.py
@@ -24,6 +24,7 @@ from ._command import VersionCommand
 from ..errors import VersionError
 from ..version import Version, VersionUpdate
 
+
 # This class is used for Java Version command(s)
 class JavaVersionCommand(VersionCommand):
     VERSION_PATTERN = (

--- a/pontos/version/commands/_java.py
+++ b/pontos/version/commands/_java.py
@@ -24,16 +24,17 @@ from ._command import VersionCommand
 from ..errors import VersionError
 from ..version import Version, VersionUpdate
 
-VERSION_PATTERN = (
-    r"^(?P<pre>.*[^\d])"
-    r"(?P<version>\d+\.\d+\.\d+"
-    r"(-?([ab]|rc|alpha|beta)\d+(.dev\d+)?)?)"
-    r"(?P<post>.*$)"
-)
-
-
 # This class is used for Java Version command(s)
 class JavaVersionCommand(VersionCommand):
+    VERSION_PATTERN = (
+        r"^(?P<pre>.*[^\d])?"
+        r"("
+        r"?P<version>\d+\.\d+\.\d+"
+        r"([-\.]+(dev|rc|beta|a|alpha|b)\d+)*"
+        r")"
+        r"(?P<post>.*$)"
+    )
+
     project_file_name = "upgradeVersion.json"
 
     def get_current_version(self) -> Version:
@@ -79,6 +80,9 @@ class JavaVersionCommand(VersionCommand):
             changed_files=changed_files,
         )
 
+    def parse_line(self, version_line: str):
+        return re.match(self.VERSION_PATTERN, version_line, re.DOTALL)
+
     def _update_version_files(self, new_version) -> List[Path]:
         config = self._load_config()
 
@@ -90,7 +94,7 @@ class JavaVersionCommand(VersionCommand):
                 line_number = file_config["line"]
                 version_line = lines[line_number - 1]
 
-                matches = re.match(VERSION_PATTERN, version_line, re.DOTALL)
+                matches = self.parse_line(version_line)
                 if matches is None:
                     raise VersionError(
                         f"Line has no version, "
@@ -143,7 +147,7 @@ class JavaVersionCommand(VersionCommand):
                         f"file:'{file_path}'"
                     )
                 version_line = readlines[line_number - 1]
-                matches = re.match(VERSION_PATTERN, version_line, re.DOTALL)
+                matches = self.parse_line(version_line)
                 if matches is None:
                     raise VersionError(
                         f"Line has no version, "

--- a/tests/version/commands/test_java.py
+++ b/tests/version/commands/test_java.py
@@ -14,6 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
+import re
 import unittest
 from pathlib import Path
 from string import Template
@@ -71,6 +72,43 @@ sentry.release={}
 server.port=8080
 """
 
+class VerifyJavaVersionParsingTestCase(unittest.TestCase):
+    def test_version_parsing(self):
+        versions = {
+            "2023.12.10",
+            "2023.1.1",
+            "2023.10.1",
+            "2023.1.99",
+            "0.0.1",
+            "1.2.3-a1",
+            "1.2.3-alpha1",
+            "1.2.3-alpha1-dev1",
+            "1.2.3-b1",
+            "1.2.3-beta1",
+            "1.2.3-beta1-dev1",
+            "1.2.3-rc1",
+            "1.2.3-rc1-dev1",
+            "1.2.3-dev1",
+            "22.4.1",
+            "22.4.1-dev1",
+            "0.5.0.dev1",
+            "1.0.0-dev1",
+            "1.0.0-alpha1",
+            "1.0.0-alpha1-dev1",
+            "1.0.0-beta1",
+            "1.0.0-beta1-dev1",
+            "1.0.0-rc1",
+            "1.0.0-rc1-dev1",
+        }
+        for version in versions:
+            with self.subTest(version=version):
+                matches = JavaVersionCommand(
+                    SemanticVersioningScheme
+                ).parse_line(f"pre{version}post")
+
+                self.assertEqual(matches.group("pre"), "pre")
+                self.assertEqual(matches.group("version"), version)
+                self.assertEqual(matches.group("post"), "post")
 
 class GetCurrentJavaVersionCommandTestCase(unittest.TestCase):
     def test_getting_version(self):

--- a/tests/version/commands/test_java.py
+++ b/tests/version/commands/test_java.py
@@ -72,6 +72,7 @@ sentry.release={}
 server.port=8080
 """
 
+
 class VerifyJavaVersionParsingTestCase(unittest.TestCase):
     def test_version_parsing(self):
         versions = {
@@ -109,6 +110,7 @@ class VerifyJavaVersionParsingTestCase(unittest.TestCase):
                 self.assertEqual(matches.group("pre"), "pre")
                 self.assertEqual(matches.group("version"), version)
                 self.assertEqual(matches.group("post"), "post")
+
 
 class GetCurrentJavaVersionCommandTestCase(unittest.TestCase):
     def test_getting_version(self):

--- a/tests/version/commands/test_java.py
+++ b/tests/version/commands/test_java.py
@@ -14,7 +14,6 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
-import re
 import unittest
 from pathlib import Path
 from string import Template


### PR DESCRIPTION
## Why

Java version detection was not recognizing all suffixes of a version string

