### PR TITLE
Change: Ensure HTTP errors are raised on GitHub security API

### DIFF
--- a/pontos/github/api/code_scanning.py
+++ b/pontos/github/api/code_scanning.py
@@ -45,6 +45,8 @@ class GitHubAsyncRESTCodeScanning(GitHubAsyncREST):
             params["direction"] = enum_or_value(direction)
 
         async for response in self._client.get_all(api, params=params):
+            response.raise_for_status()
+
             for alert in response.json():
                 yield CodeScanningAlert.from_dict(alert)
 

--- a/pontos/github/api/dependabot.py
+++ b/pontos/github/api/dependabot.py
@@ -50,6 +50,8 @@ class GitHubAsyncRESTDependabot(GitHubAsyncREST):
             params["direction"] = enum_or_value(direction)
 
         async for response in self._client.get_all(api, params=params):
+            response.raise_for_status()
+
             for alert in response.json():
                 yield DependabotAlert.from_dict(alert)
 

--- a/pontos/github/api/secret_scanning.py
+++ b/pontos/github/api/secret_scanning.py
@@ -48,6 +48,8 @@ class GitHubAsyncRESTSecretScanning(GitHubAsyncREST):
             params["direction"] = enum_or_value(direction)
 
         async for response in self._client.get_all(api, params=params):
+            response.raise_for_status()
+
             for alert in response.json():
                 yield SecretScanningAlert.from_dict(alert)
 
@@ -353,6 +355,8 @@ class GitHubAsyncRESTSecretScanning(GitHubAsyncREST):
         params = {"per_page": "100"}
 
         async for response in self._client.get_all(api, params=params):
+            response.raise_for_status()
+
             for location in response.json():
                 location_type = location["type"]
                 location_details = location["details"]


### PR DESCRIPTION


## What

Ensure HTTP errors are raised on GitHub security API

## Why

If GitHub returns a http error response ensure that the error is raised when using the GitHub security API (dependabot, secret scanning, code scanning).

