### PR TITLE
Change: Improve Model class for invalid data while parsing child models

### DIFF
--- a/pontos/models/__init__.py
+++ b/pontos/models/__init__.py
@@ -150,6 +150,12 @@ class Model:
                     "updated_at": "2017-07-08T16:18:44-04:00",
                 })
         """
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"Invalid data for creating an instance of {cls.__name__} "
+                f"model. Data is {data!r}"
+            )
+
         kwargs = {}
         additional_attrs = {}
         type_hints = get_type_hints(cls)
@@ -161,7 +167,7 @@ class Model:
                 elif value is not None:
                     model_field_cls = type_hints.get(name)
                     value = cls._get_value(model_field_cls, value)  # type: ignore # pylint: disable=line-too-long # noqa: E501
-            except TypeError as e:
+            except (ValueError, TypeError) as e:
                 raise ModelError(
                     f"Error while creating {cls.__name__} model. Could not set "
                     f"value for property '{name}' from '{value}'."


### PR DESCRIPTION


## What
Improve Model class for invalid data while parsing child models

## Why

Handle the situation more carefully when child models should be parsed but the response doesn't contain an object/dict.
## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


