### PR TITLE
Fix: Allow empty CPE match for CVE configuration nodes

### DIFF
--- a/pontos/nvd/models/cve.py
+++ b/pontos/nvd/models/cve.py
@@ -227,13 +227,14 @@ class Node(Model):
     A CVE configuration node
 
     Attributes:
-        operator:
-        cpe_match:
+        operator: Operator (and/or) for this node
+        cpe_match: The CPE match for the node. Despite a cpe match is required
+            int NISTs API spec the data seems to contain nodes without matches.
         negate:
     """
 
     operator: Operator
-    cpe_match: List[CPEMatch]
+    cpe_match: Optional[List[CPEMatch]] = None
     negate: Optional[bool] = None
 
 


### PR DESCRIPTION

## What

Allow empty CPE match for CVE configuration nodes

## Why
It seems despite violating their spec some CVE configuration nodes don't contain a CPE match.

## References

DEVOPS-841



