### PR TITLE
Add: Add new API for parsing CPEs (pontos.cpe)

### DIFF
--- a/pontos/cpe/__init__.py
+++ b/pontos/cpe/__init__.py
@@ -1,0 +1,17 @@
+# SPDX-FileCopyrightText: 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from ._cpe import ANY, CPE, NA, CPEParsingError, Part
+
+"""
+Module for parsing and handling Common Platform Enumeration (CPE) information
+"""
+
+__all__ = (
+    "ANY",
+    "NA",
+    "CPEParsingError",
+    "Part",
+    "CPE",
+)

--- a/pontos/cpe/_cpe.py
+++ b/pontos/cpe/_cpe.py
@@ -1,0 +1,545 @@
+# SPDX-FileCopyrightText: 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import re
+import urllib.parse
+from dataclasses import dataclass
+from enum import Enum
+from typing import Optional
+
+from pontos.errors import PontosError
+
+__all__ = (
+    "ANY",
+    "NA",
+    "CPEParsingError",
+    "Part",
+    "CPE",
+)
+
+ANY = "*"
+NA = "-"
+
+
+class CPEParsingError(PontosError):
+    """
+    An error occurred while parsing a CPE
+    """
+
+
+class Part(Enum):
+    """
+    Represents the possible values for a part CPE attribute
+    """
+
+    APPLICATION = "a"
+    OPERATING_SYSTEM = "o"
+    HARDWARE_DEVICE = "h"
+
+
+def is_uri_binding(cpe: str) -> bool:
+    """
+    Returns True if cpe is a CPE v2.2 URI string
+    """
+    return cpe.startswith("cpe:/")
+
+
+def is_formatted_string_binding(cpe: str) -> bool:
+    """
+    Returns True if cpe is a CPE v2.3 formatted string
+    """
+    return cpe.startswith("cpe:2.3:")
+
+
+def _remove_backslash(value: str) -> str:
+    """
+    Remove a single backslash
+    """
+    return re.sub("\\\\(\\W)", lambda match: match.group(1), value)
+
+
+def _url_quote(value: str) -> str:
+    """
+    Quote value according to the pct_encode function from the spec
+    """
+    return urllib.parse.quote(value, safe="").lower()
+
+
+def _url_unquote(value: str) -> str:
+    """
+    Un-quote value according to the the spec
+    """
+    return urllib.parse.unquote(value)
+
+
+def pack_extended_attributes(
+    edition: Optional[str],
+    sw_edition: Optional[str],
+    target_sw: Optional[str],
+    target_hw: Optional[str],
+    other: Optional[str],
+) -> Optional[str]:
+    """
+    Pack the extended attributes (v2.3) for an edition attribute (v2.2)
+    """
+    if (
+        (not sw_edition or sw_edition == ANY)
+        and (not target_sw or target_sw == ANY)
+        and (not target_hw or target_hw == ANY)
+        and (not other or other == ANY)
+    ):
+        if not edition or edition == ANY:
+            return ""
+        else:
+            return edition
+    else:
+        return (
+            f"~{'' if not edition or edition == ANY else edition}"
+            f"~{'' if not sw_edition or sw_edition == ANY else sw_edition}"
+            f"~{'' if not target_sw or target_sw == ANY else target_sw}"
+            f"~{'' if not target_hw or target_hw == ANY else target_hw}"
+            f"~{'' if not other or other == ANY else other}"
+        )
+
+
+def unpack_edition(edition: str) -> dict[str, Optional[str]]:
+    """
+    Unpack the edition attribute of v2.2 into extended attributes of v2.3
+    """
+    return dict(
+        zip(
+            [
+                "edition",
+                "sw_edition",
+                "target_sw",
+                "target_hw",
+                "other",
+            ],
+            [None if not a else a for a in edition.split("~")[1:-1]],
+        )
+    )
+
+
+def bind_value_for_fs(value: Optional[str]) -> str:
+    """
+    Convert an attribute value for formatted string representation
+    """
+    if not value or value == ANY:
+        return ANY
+
+    value = value.replace("\\.", ".")
+    value = value.replace("\\-", "-")
+    value = value.replace("\\_", "_")
+    return value
+
+
+def _add_quoting(value: str) -> str:
+    """
+    Add quoting for parsing attributes from formatted string format
+    """
+    result = ""
+    index = 0
+    embedded = False
+
+    while index < len(value):
+        c = value[index]
+        if c.isalnum() or c in ["_"]:  # not sure about "-" and "~"
+            result += c
+            index += 1
+            embedded = True
+            continue
+
+        if c == "\\":
+            result += value[index : index + 2]
+            index += 2
+            embedded = True
+            continue
+
+        if c == ANY:
+            if index == 0 or index == (len(value) - 1):
+                result += c
+                index += 1
+                embedded = True
+                continue
+            else:
+                raise CPEParsingError(
+                    "An unquoted asterisk must appear at the beginning or end "
+                    f"of '{value}'"
+                )
+        if c == "?":
+            if (
+                (  # ? is legal at the beginning or the end
+                    (index == 0) or (index == (len(value) - 1))
+                )
+                or (  # embedded is false, so must be preceded by ?
+                    not embedded and (value[index - 1 : index] == "?")
+                )
+                or (  # embedded is true, so must be followed by ?
+                    embedded and (value[index + 1] == "?")
+                )
+            ):
+                result += c
+                index += 1
+                embedded = False
+                continue
+            else:
+                raise CPEParsingError(
+                    "An unquoted question mark must appear at the beginning or "
+                    f"end, or in a leading or trailing sequence '{value}'"
+                )
+
+        # all other characters must be quoted
+        result += f"\\{c}"
+        index += 1
+        embedded = True
+
+    return result
+
+
+def unbind_value_fs(value: Optional[str]) -> Optional[str]:
+    """
+    Convert a formatted string representation to an attribute value
+    """
+    if value is None or value == ANY or value == NA:
+        return value
+    return _add_quoting(value)
+
+
+def _transform_for_uri(value: str) -> str:
+    """
+    Applies transform to convert an attribute for an uri representation
+
+    The following transformations are applied:
+        - Pass alphanumeric characters thru untouched
+        - Percent-encode quoted non-alphanumerics as needed
+        - Unquoted special characters are mapped to their special forms
+    """
+    transformed = ""
+    index = 0
+    while index < len(value):
+        c = value[index]
+
+        # alpha numeric characters
+        if c.isalnum() or c in ["_", "-", ".", "~"]:
+            transformed += c
+            index += 1
+            continue
+
+        # percent encoding
+        if c == "\\":
+            index += 1
+            next = value[index]
+            transformed += _url_quote(_remove_backslash(next))
+            index += 1
+            continue
+
+        # special forms
+        if c == "?":
+            transformed += "%01"
+        elif c == "*":
+            transformed += "%02"
+
+        index += 1
+
+    return transformed
+
+
+def bind_value_for_uri(value: Optional[str]) -> str:
+    """
+    Convert an attribute value for uri representation
+    """
+    if not value or value == ANY:
+        return ""
+    if value == NA:
+        return value
+    return _transform_for_uri(value)
+
+
+def unbind_value_uri(value: Optional[str]) -> Optional[str]:
+    """
+    Convert an uri representation to an attribute value
+    """
+    if value is None:
+        return None
+    if value == "":
+        return ANY
+    if value == NA:
+        return NA
+
+    result = ""
+    index = 0
+    embedded = False
+    while index < len(value):
+        c = value[index]
+        if c == "." or c == "-" or c == "~":
+            result += f"\\{c}"
+            index += 1
+            embedded = True
+            continue
+
+        if c != "%":
+            result += c
+            index += 1
+            embedded = True
+            continue
+
+        form = value[index : index + 3]
+        if form == "%01":
+            if (
+                index == 0
+                or (index == (len(value) - 3))
+                or (not embedded and (value[index - 3 : index] == "%01"))
+                or (
+                    embedded
+                    and (len(value) >= index + 6)
+                    and (value[index + 3 : index + 6]) == "%01"
+                )
+            ):
+                result += "?"
+            else:
+                raise CPEParsingError(
+                    "A percent-encoded question mark is not found at the "
+                    f"beginning or the end or embedded in sequence '{value}'"
+                )
+        elif form == "%02":
+            if (index == 0) or (index == (len(value) - 3)):
+                result += "*"
+            else:
+                raise CPEParsingError(
+                    "Percent-encoded asterisk is no at the beginning "
+                    f"or the end of '{value}'"
+                )
+        else:
+            result += f"\\{_url_unquote(form)}"
+        index += 3
+        embedded = True
+
+    return result
+
+
+@dataclass(frozen=True)  # should require keywords only with Python >= 3.10
+class CPE:
+    """
+    Represents a Common Platform Enumeration (CPE) name
+
+    Supports CPE specification 2.2 (uri) and 2.3 (formatted string)
+
+    Attributes:
+        part: Value should be "a" for application, "o" for operating system or
+            "h" for hardware
+        vendor: Person or organization that manufactured or created the product
+        product: Identifies the most common and recognizable title or name of
+            the product
+        version: A vendor-specific alphanumeric string characterizing the
+            particular release version of the product
+        update: A vendor-specific alphanumeric string characterizing the
+            particular update, service pack, or point release of the product
+        edition: The edition attribute is considered deprecated in the 2.3
+            CPE specification, and it should be assigned the logical value ANY
+            except where required for backward compatibility with version 2.2 of
+            the CPE specification. This attribute is referred to as the “legacy
+            edition” attribute
+        language: Defines the language supported in the user interface of the
+            product (as language tags defined by RFC5646)
+        sw_edition: Characterizes how the product is tailored to a particular
+            market or class of end users. Extended attribute introduced with
+            version 2.3 of the CPE specification
+        target_sw: Characterizes the software computing environment within which
+            the product operates. Extended attribute introduced with
+            version 2.3 of the CPE specification
+        hardware_sw: Characterizes the instruction set architecture (e.g., x86)
+            on which the product operates. Extended attribute introduced with
+            version 2.3 of the CPE specification
+        other: Captures any other general descriptive or identifying information
+            which is vendor- or product-specific and which does not logically
+            fit in any other attribute value. Extended attribute introduced with
+            version 2.3 of the CPE specification
+        cpe_string: The original parsed CPE string
+
+    Example:
+        .. code-block:: python
+
+            from pontos.cpe import CPE
+
+            cpe = CPE.from_string("cpe:2.3:o:google:android:13.0:*:*:*:*:*:*:*")
+
+            print(cpe.vendor)           # google
+            print(cpe.product)          # android
+            print(cpe.version)          # 13\.0
+            print(cpe.as_uri_binding()) # cpe:/o:google:android:13.0
+    """
+
+    part: Part
+    vendor: str
+    product: str
+    version: Optional[str] = None
+    update: Optional[str] = None
+    edition: Optional[str] = None
+    language: Optional[str] = None
+    sw_edition: Optional[str] = None
+    target_sw: Optional[str] = None
+    target_hw: Optional[str] = None
+    other: Optional[str] = None
+    cpe_string: Optional[str] = None
+
+    @staticmethod
+    def from_string(cpe: str) -> "CPE":
+        """
+        Create a new CPE from a string
+        """
+        cleaned_cpe = cpe.strip().lower()
+        parts = cpe.split(":")
+
+        if is_uri_binding(cleaned_cpe):
+            values: dict[str, Optional[str]] = dict(
+                zip(
+                    [
+                        "vendor",
+                        "product",
+                        "version",
+                        "update",
+                        "edition",
+                        "language",
+                    ],
+                    parts[2:],
+                )
+            )
+            for attribute in [
+                "vendor",
+                "product",
+                "version",
+                "update",
+                "language",
+            ]:
+                values[attribute] = unbind_value_uri(values.get(attribute))
+
+            edition = values.get("edition")
+            if (
+                edition is None
+                or edition == ""
+                or edition == NA
+                or edition[0] != "~"
+            ):
+                edition = unbind_value_uri(edition)
+            else:
+                values.update(unpack_edition(edition))
+
+            return CPE(cpe_string=cleaned_cpe, part=Part(parts[1][1]), **values)  # type: ignore[arg-type]
+
+        elif is_formatted_string_binding(cleaned_cpe):
+            values = dict(
+                zip(
+                    [
+                        "vendor",
+                        "product",
+                        "version",
+                        "update",
+                        "edition",
+                        "language",
+                        "sw_edition",
+                        "target_sw",
+                        "target_hw",
+                        "other",
+                    ],
+                    [unbind_value_fs(a) for a in parts[3:]],
+                )
+            )
+
+            return CPE(cpe_string=cleaned_cpe, part=Part(parts[2]), **values)  # type: ignore[arg-type]
+
+        raise CPEParsingError(
+            f"Invalid CPE string '{cpe}'. CPE does not start with "
+            "'cpe:/' or 'cpe:2.3'"
+        )
+
+    def has_extended_attribute(self) -> bool:
+        """
+        Returns True if the CPE has an extended attribute set
+        """
+        return bool(
+            self.sw_edition or self.target_sw or self.target_hw or self.other
+        )
+
+    def is_uri_binding(self) -> bool:
+        """
+        Returns True if the CPE is parsed from a URI binding
+        """
+        if self.cpe_string:
+            return is_uri_binding(self.cpe_string)
+        return not self.has_extended_attribute()
+
+    def is_formatted_string_binding(self) -> bool:
+        """
+        Returns True if the CPE is parsed from a formatted string binding
+        """
+        if self.cpe_string:
+            return is_formatted_string_binding(self.cpe_string)
+        return self.has_extended_attribute()
+
+    def as_uri_binding(self) -> str:
+        """
+        Converts the CPE to an URI binding
+        """
+        part = self.part.value
+        vendor = bind_value_for_uri(self.vendor)
+        product = bind_value_for_uri(self.product)
+        version = bind_value_for_uri(self.version)
+        update = bind_value_for_uri(self.update)
+        language = bind_value_for_uri(self.language)
+        edition = bind_value_for_uri(self.edition)
+        sw_edition = bind_value_for_uri(self.sw_edition)
+        target_sw = bind_value_for_uri(self.target_sw)
+        target_hw = bind_value_for_uri(self.target_hw)
+        other = bind_value_for_uri(self.other)
+
+        edition = pack_extended_attributes(
+            edition,
+            sw_edition,
+            target_sw,
+            target_hw,
+            other,
+        )
+
+        uri = f"cpe:/{part}:{vendor}:{product}"
+        if version or update or edition or language:
+            uri = f"{uri}:{version}"
+        if update or edition or language:
+            uri = f"{uri}:{update}"
+        if edition or language:
+            uri = f"{uri}:{edition}"
+        if language:
+            uri = f"{uri}:{language}"
+        return uri
+
+    def as_formatted_string_binding(self) -> str:
+        """
+        Converts the CPE to a formatted string binding
+        """
+        part = self.part.value
+        vendor = bind_value_for_fs(self.vendor)
+        product = bind_value_for_fs(self.product)
+        version = bind_value_for_fs(self.version)
+        update = bind_value_for_fs(self.update)
+        edition = bind_value_for_fs(self.edition)
+        language = bind_value_for_fs(self.language)
+        sw_edition = bind_value_for_fs(self.sw_edition)
+        target_sw = bind_value_for_fs(self.target_sw)
+        target_hw = bind_value_for_fs(self.target_hw)
+        other = bind_value_for_fs(self.other)
+        return (
+            f"cpe:2.3:{part}:{vendor}:{product}:{version}:{update}:"
+            f"{edition}:{language}:{sw_edition}:{target_sw}:{target_hw}:{other}"
+        )
+
+    def __str__(self) -> str:
+        """
+        Returns the string representation (uri of formatted string) of the CPE
+        """
+        if self.cpe_string:
+            return self.cpe_string
+
+        if not self.has_extended_attribute():
+            return self.as_uri_binding()
+
+        return self.as_formatted_string_binding()

--- a/tests/cpe/__init__.py
+++ b/tests/cpe/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/cpe/test_cpe.py
+++ b/tests/cpe/test_cpe.py
@@ -1,0 +1,521 @@
+# SPDX-FileCopyrightText: 2022 - 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+# ruff: noqa: E501
+
+import unittest
+
+from pontos.cpe import ANY, CPE, NA, CPEParsingError, Part
+
+
+class CPETestCase(unittest.TestCase):
+    def test_uri_binding(self):
+        cpe_string = "cpe:/o:microsoft:windows_xp:::pro"
+        cpe = CPE.from_string(cpe_string)
+
+        self.assertEqual(str(cpe), "cpe:/o:microsoft:windows_xp:::pro")
+        self.assertEqual(
+            cpe.as_uri_binding(), "cpe:/o:microsoft:windows_xp:::pro"
+        )
+        self.assertEqual(
+            cpe.as_formatted_string_binding(),
+            "cpe:2.3:o:microsoft:windows_xp:*:*:pro:*:*:*:*:*",
+        )
+        self.assertTrue(cpe.is_uri_binding())
+        self.assertFalse(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.OPERATING_SYSTEM)
+        self.assertEqual(cpe.vendor, "microsoft")
+        self.assertEqual(cpe.product, "windows_xp")
+        self.assertEqual(cpe.edition, "pro")
+        self.assertEqual(cpe.version, ANY)
+        self.assertEqual(cpe.update, ANY)
+        self.assertIsNone(cpe.language)
+        self.assertIsNone(cpe.sw_edition)
+        self.assertIsNone(cpe.target_sw)
+        self.assertIsNone(cpe.target_hw)
+        self.assertIsNone(cpe.other)
+
+        cpe = CPE.from_string(
+            "cpe:/a:foo%5cbar:big%24money_manager_2010:::~~special~ipod_touch~80gb~"
+        )
+        print(repr(cpe))
+        self.assertEqual(
+            str(cpe),
+            "cpe:/a:foo%5cbar:big%24money_manager_2010:::~~special~ipod_touch~80gb~",
+        )
+        self.assertEqual(
+            cpe.as_uri_binding(),
+            "cpe:/a:foo%5cbar:big%24money_manager_2010:::~~special~ipod_touch~80gb~",
+        )
+        self.assertEqual(
+            cpe.as_formatted_string_binding(),
+            "cpe:2.3:a:foo\\\\bar:big\$money_manager_2010:*:*:*:*:special:ipod_touch:80gb:*",
+        )
+        self.assertTrue(cpe.is_uri_binding())
+        self.assertFalse(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "foo\\\\bar")
+        self.assertEqual(cpe.product, "big\$money_manager_2010")
+        self.assertEqual(cpe.version, ANY)
+        self.assertEqual(cpe.update, ANY)
+        self.assertIsNone(cpe.language)
+        self.assertIsNone(cpe.edition)
+        self.assertEqual(cpe.sw_edition, "special")
+        self.assertEqual(cpe.target_sw, "ipod_touch")
+        self.assertEqual(cpe.target_hw, "80gb")
+        self.assertIsNone(cpe.other)
+
+    def test_formatted_string_binding(self):
+        cpe_string = (
+            "cpe:2.3:a:qrokes:qr_twitter_widget:*:*:*:*:*:wordpress:*:*"
+        )
+        cpe = CPE.from_string(cpe_string)
+        print(repr(cpe))
+
+        self.assertEqual(
+            str(cpe),
+            "cpe:2.3:a:qrokes:qr_twitter_widget:*:*:*:*:*:wordpress:*:*",
+        )
+        self.assertEqual(
+            cpe.as_uri_binding(),
+            "cpe:/a:qrokes:qr_twitter_widget:::~~~wordpress~~",
+        )
+        self.assertEqual(
+            cpe.as_formatted_string_binding(),
+            "cpe:2.3:a:qrokes:qr_twitter_widget:*:*:*:*:*:wordpress:*:*",
+        )
+        self.assertFalse(cpe.is_uri_binding())
+        self.assertTrue(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "qrokes")
+        self.assertEqual(cpe.product, "qr_twitter_widget")
+        self.assertEqual(cpe.version, ANY)
+        self.assertEqual(cpe.update, ANY)
+        self.assertEqual(cpe.edition, ANY)
+        self.assertEqual(cpe.language, ANY)
+        self.assertEqual(cpe.sw_edition, ANY)
+        self.assertEqual(cpe.target_sw, "wordpress")
+        self.assertEqual(cpe.target_hw, ANY)
+        self.assertEqual(cpe.other, ANY)
+
+    def test_uri_bind_examples(self):
+        # test examples from https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf
+
+        # example 1
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="microsoft",
+            product="internet_explorer",
+            version="8\.0\.6001",
+            update="beta",
+            edition=ANY,
+        )
+        self.assertEqual(
+            cpe.as_uri_binding(),
+            "cpe:/a:microsoft:internet_explorer:8.0.6001:beta",
+        )
+
+        # example 2
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="microsoft",
+            product="internet_explorer",
+            version="8\.*",
+            update="sp?",
+        )
+        self.assertEqual(
+            cpe.as_uri_binding(),
+            "cpe:/a:microsoft:internet_explorer:8.%02:sp%01",
+        )
+
+        # example 3
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="hp",
+            product="insight_diagnostics",
+            version="7\.4\.0\.1570",
+            update=NA,
+            sw_edition="online",
+            target_sw="win2003",
+            target_hw="x64",
+        )
+        self.assertEqual(
+            cpe.as_uri_binding(),
+            "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win2003~x64~",
+        )
+
+        # example 4
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="hp",
+            product="openview_network_manager",
+            version="7\.51",
+            target_sw="linux",
+        )
+        self.assertEqual(
+            cpe.as_uri_binding(),
+            "cpe:/a:hp:openview_network_manager:7.51::~~~linux~~",
+        )
+
+        # example 5
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="foo\\\\bar",
+            product="big\$money_manager_2010",
+            sw_edition="special",
+            target_sw="ipod_touch",
+            target_hw="80gb",
+        )
+        self.assertEqual(
+            cpe.as_uri_binding(),
+            "cpe:/a:foo%5cbar:big%24money_manager_2010:::~~special~ipod_touch~80gb~",
+        )
+
+    def test_uri_unbind_examples(self):
+        # test examples from https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf
+
+        # example 1
+        cpe = CPE.from_string(
+            "cpe:/a:microsoft:internet_explorer:8.0.6001:beta"
+        )
+        self.assertTrue(cpe.is_uri_binding())
+        self.assertFalse(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "microsoft")
+        self.assertEqual(cpe.product, "internet_explorer")
+        self.assertEqual(cpe.version, "8\.0\.6001")
+        self.assertEqual(cpe.update, "beta")
+        self.assertIsNone(cpe.language)
+        self.assertIsNone(cpe.edition)
+        self.assertIsNone(cpe.sw_edition)
+        self.assertIsNone(cpe.target_sw)
+        self.assertIsNone(cpe.target_hw)
+        self.assertIsNone(cpe.other)
+
+        # example 2
+        cpe = CPE.from_string("cpe:/a:microsoft:internet_explorer:8.%2a:sp%3f")
+        self.assertTrue(cpe.is_uri_binding())
+        self.assertFalse(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "microsoft")
+        self.assertEqual(cpe.product, "internet_explorer")
+        self.assertEqual(cpe.version, "8\.\*")
+        self.assertEqual(cpe.update, "sp\?")
+        self.assertIsNone(cpe.language)
+        self.assertIsNone(cpe.edition)
+        self.assertIsNone(cpe.sw_edition)
+        self.assertIsNone(cpe.target_sw)
+        self.assertIsNone(cpe.target_hw)
+        self.assertIsNone(cpe.other)
+
+        # example 3
+        cpe = CPE.from_string("cpe:/a:microsoft:internet_explorer:8.%02:sp%01")
+        self.assertTrue(cpe.is_uri_binding())
+        self.assertFalse(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "microsoft")
+        self.assertEqual(cpe.product, "internet_explorer")
+        self.assertEqual(cpe.version, "8\.*")
+        self.assertEqual(cpe.update, "sp?")
+        self.assertIsNone(cpe.language)
+        self.assertIsNone(cpe.edition)
+        self.assertIsNone(cpe.sw_edition)
+        self.assertIsNone(cpe.target_sw)
+        self.assertIsNone(cpe.target_hw)
+        self.assertIsNone(cpe.other)
+
+        # example 4
+        cpe = CPE.from_string(
+            "cpe:/a:hp:insight_diagnostics:7.4.0.1570::~~online~win2003~x64~"
+        )
+        print(repr(cpe))
+        self.assertTrue(cpe.is_uri_binding())
+        self.assertFalse(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "hp")
+        self.assertEqual(cpe.product, "insight_diagnostics")
+        self.assertEqual(cpe.version, "7\.4\.0\.1570")
+        self.assertEqual(cpe.update, ANY)
+        self.assertIsNone(cpe.language)
+        self.assertIsNone(cpe.edition)
+        self.assertEqual(cpe.sw_edition, "online")
+        self.assertEqual(cpe.target_sw, "win2003")
+        self.assertEqual(cpe.target_hw, "x64")
+        self.assertIsNone(cpe.other)
+
+        # example 5
+        cpe = CPE.from_string(
+            "cpe:/a:hp:openview_network_manager:7.51:-:~~~linux~~"
+        )
+        self.assertTrue(cpe.is_uri_binding())
+        self.assertFalse(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "hp")
+        self.assertEqual(cpe.product, "openview_network_manager")
+        self.assertEqual(cpe.version, "7\.51")
+        self.assertEqual(cpe.update, NA)
+        self.assertIsNone(cpe.language)
+        self.assertIsNone(cpe.edition)
+        self.assertIsNone(cpe.sw_edition)
+        self.assertEqual(cpe.target_sw, "linux")
+        self.assertIsNone(cpe.target_hw)
+        self.assertIsNone(cpe.other)
+
+        # example 6
+        # with self.assertRaises(CPEParsingError):
+        #     CPE.from_string(
+        #         "cpe:/a:foo%5cbar:big%24money_2010%07:::~~special~ipod_touch~80gb~"
+        #     )
+
+        # example 7
+        cpe = CPE.from_string("cpe:/a:foo~bar:big%7emoney_2010")
+        self.assertTrue(cpe.is_uri_binding())
+        self.assertFalse(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "foo\~bar")
+        self.assertEqual(cpe.product, "big\~money_2010")
+        self.assertIsNone(cpe.version)
+        self.assertIsNone(cpe.update)
+        self.assertIsNone(cpe.language)
+        self.assertIsNone(cpe.edition)
+        self.assertIsNone(cpe.sw_edition)
+        self.assertIsNone(cpe.target_sw)
+        self.assertIsNone(cpe.target_hw)
+        self.assertIsNone(cpe.other)
+
+        # example 8
+        with self.assertRaisesRegex(
+            CPEParsingError,
+            "^Percent-encoded asterisk is no at the beginning or the end "
+            "of '12.%02.1234'$",
+        ):
+            CPE.from_string("cpe:/a:foo:bar:12.%02.1234")
+
+    def test_formatted_bind_examples(self):
+        # test examples from https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf
+
+        # example 1
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="microsoft",
+            product="internet_explorer",
+            version="8\.0\.6001",
+            update="beta",
+            edition=ANY,
+        )
+        self.assertEqual(
+            cpe.as_formatted_string_binding(),
+            "cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*",
+        )
+
+        # example 2
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="microsoft",
+            product="internet_explorer",
+            version="8\.*",
+            update="sp?",
+            edition=ANY,
+        )
+        self.assertEqual(
+            cpe.as_formatted_string_binding(),
+            "cpe:2.3:a:microsoft:internet_explorer:8.*:sp?:*:*:*:*:*:*",
+        )
+
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="microsoft",
+            product="internet_explorer",
+            version="8\.\*",
+            update="sp?",
+        )
+        self.assertEqual(
+            cpe.as_formatted_string_binding(),
+            "cpe:2.3:a:microsoft:internet_explorer:8.\*:sp?:*:*:*:*:*:*",
+        )
+
+        # example 3
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="hp",
+            product="insight",
+            version="7\.4\.0\.1570",
+            update=NA,
+            sw_edition="online",
+            target_sw="win2003",
+            target_hw="x64",
+        )
+        self.assertEqual(
+            cpe.as_formatted_string_binding(),
+            "cpe:2.3:a:hp:insight:7.4.0.1570:-:*:*:online:win2003:x64:*",
+        )
+
+        # example 4
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="hp",
+            product="openview_network_manager",
+            version="7\.51",
+            target_sw="linux",
+        )
+        self.assertEqual(
+            cpe.as_formatted_string_binding(),
+            "cpe:2.3:a:hp:openview_network_manager:7.51:*:*:*:*:linux:*:*",
+        )
+
+        # example 5
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="foo\\\\bar",
+            product="big\$money_2010",
+            sw_edition="special",
+            target_sw="ipod_touch",
+            target_hw="80gb",
+        )
+        self.assertEqual(
+            cpe.as_formatted_string_binding(),
+            "cpe:2.3:a:foo\\\\bar:big\$money_2010:*:*:*:*:special:ipod_touch:80gb:*",
+        )
+
+    def test_formatted_unbind_examples(self):
+        # test examples from https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf
+
+        # example 1
+        cpe = CPE.from_string(
+            "cpe:2.3:a:microsoft:internet_explorer:8.0.6001:beta:*:*:*:*:*:*"
+        )
+        self.assertFalse(cpe.is_uri_binding())
+        self.assertTrue(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "microsoft")
+        self.assertEqual(cpe.product, "internet_explorer")
+        # self.assertEqual(cpe.version, "8\.0\.6001")
+        self.assertEqual(cpe.update, "beta")
+        self.assertEqual(cpe.language, ANY)
+        self.assertEqual(cpe.edition, ANY)
+        self.assertEqual(cpe.sw_edition, ANY)
+        self.assertEqual(cpe.target_sw, ANY)
+        self.assertEqual(cpe.target_hw, ANY)
+        self.assertEqual(cpe.other, ANY)
+
+        # example 2
+        cpe = CPE.from_string(
+            "cpe:2.3:a:microsoft:internet_explorer:8.*:sp?:*:*:*:*:*:*"
+        )
+        self.assertFalse(cpe.is_uri_binding())
+        self.assertTrue(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "microsoft")
+        self.assertEqual(cpe.product, "internet_explorer")
+        self.assertEqual(cpe.version, "8\.*")
+        self.assertEqual(cpe.update, "sp?")
+        self.assertEqual(cpe.language, ANY)
+        self.assertEqual(cpe.edition, ANY)
+        self.assertEqual(cpe.sw_edition, ANY)
+        self.assertEqual(cpe.target_sw, ANY)
+        self.assertEqual(cpe.target_hw, ANY)
+        self.assertEqual(cpe.other, ANY)
+
+        # example 3
+        cpe = CPE.from_string(
+            "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:win2003:x64:*"
+        )
+        self.assertFalse(cpe.is_uri_binding())
+        self.assertTrue(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "hp")
+        self.assertEqual(cpe.product, "insight_diagnostics")
+        self.assertEqual(cpe.version, "7\.4\.0\.1570")
+        self.assertEqual(cpe.update, NA)
+        self.assertEqual(cpe.language, ANY)
+        self.assertEqual(cpe.edition, ANY)
+        self.assertEqual(cpe.sw_edition, "online")
+        self.assertEqual(cpe.target_sw, "win2003")
+        self.assertEqual(cpe.target_hw, "x64")
+        self.assertEqual(cpe.other, ANY)
+
+        with self.assertRaisesRegex(
+            CPEParsingError,
+            "^An unquoted asterisk must appear at the beginning or end of "
+            "'7.4.*.1570'$",
+        ):
+            # embedded unquoted asterisk in the version attribute
+            CPE.from_string(
+                "cpe:2.3:a:hp:insight_diagnostics:7.4.*.1570:*:*:*:*:*:*"
+            )
+
+        # example 4
+        cpe = CPE.from_string(
+            "cpe:2.3:a:foo\\\\bar:big\$money:2010:*:*:*:special:ipod_touch:80gb:*"
+        )
+        self.assertFalse(cpe.is_uri_binding())
+        self.assertTrue(cpe.is_formatted_string_binding())
+        self.assertEqual(cpe.part, Part.APPLICATION)
+        self.assertEqual(cpe.vendor, "foo\\\\bar")
+        self.assertEqual(cpe.product, "big\$money")
+        self.assertEqual(cpe.version, "2010")
+        self.assertEqual(cpe.update, ANY)
+        self.assertEqual(cpe.edition, ANY)
+        self.assertEqual(cpe.language, ANY)
+        self.assertEqual(cpe.sw_edition, "special")
+        self.assertEqual(cpe.target_sw, "ipod_touch")
+        self.assertEqual(cpe.target_hw, "80gb")
+        self.assertEqual(cpe.other, ANY)
+
+    def test_as_uri_binding(self):
+        cpe_string = "cpe:2.3:a:microsoft:internet_explorer:8\\.*:sp?"
+        cpe = CPE.from_string(cpe_string)
+        self.assertEqual(
+            cpe.as_uri_binding(),
+            "cpe:/a:microsoft:internet_explorer:8.%02:sp%01",
+        )
+
+    def test_as_uri_binding_with_edition(self):
+        cpe_string = "cpe:2.3:a:hp:insight_diagnostics:7.4.0.1570:-:*:*:online:win2003:x64"
+        cpe = CPE.from_string(cpe_string)
+
+        self.assertEqual(
+            cpe.as_uri_binding(),
+            "cpe:/a:hp:insight_diagnostics:7.4.0.1570:-:~~online~win2003~x64~",
+        )
+
+    def test_parse_error(self):
+        with self.assertRaisesRegex(
+            CPEParsingError,
+            "^Invalid CPE string 'foo/bar'. CPE does not start with 'cpe:/' "
+            "or 'cpe:2.3'$",
+        ):
+            CPE.from_string("foo/bar")
+
+    def test_str(self):
+        cpe = CPE(part=Part.APPLICATION, vendor="foo", product="bar")
+        self.assertEqual(str(cpe), "cpe:/a:foo:bar")
+
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="foo",
+            product="bar",
+            target_sw="ipsum",
+        )
+        self.assertEqual(str(cpe), "cpe:2.3:a:foo:bar:*:*:*:*:*:ipsum:*:*")
+
+        cpe = CPE(
+            cpe_string="cpe:2.3:a:foo:bar",
+            part=Part.APPLICATION,
+            vendor="foo",
+            product="bar",
+        )
+        self.assertEqual(str(cpe), "cpe:2.3:a:foo:bar")
+
+    def test_has_extended_attribute(self):
+        cpe = CPE(part=Part.APPLICATION, vendor="foo", product="bar")
+        self.assertFalse(cpe.has_extended_attribute())
+
+        cpe = CPE(
+            part=Part.APPLICATION,
+            vendor="foo",
+            product="bar",
+            target_sw="ipsum",
+        )
+        self.assertTrue(cpe.has_extended_attribute())


### PR DESCRIPTION


## What

Add new API for parsing CPEs (pontos.cpe)

It follows the spec at https://nvlpubs.nist.gov/nistpubs/Legacy/IR/nistir7695.pdf very closely and implements all their escaping. Just the conversion to percent-encoded strings for quoting non-alphanumeric characters is using `urllib.parser.quote` and `unquote` which support additional quoting besides specified in the CPE document.

## Why

Allow to parse and analyze CPE information from their v2.2 and v2.3 string representations. It's also possible to convert a v2.2 CPE representation into a v2.3 and vice versa. We need this for being able to use the new NIST CVE and CPE API.

## References

DEVOPS-472

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


