### PR TITLE
Add: Allow to clone and adjust a CPE

### DIFF
--- a/pontos/cpe/_cpe.py
+++ b/pontos/cpe/_cpe.py
@@ -562,6 +562,40 @@ class CPE:
             f"{edition}:{language}:{sw_edition}:{target_sw}:{target_hw}:{other}"
         )
 
+    def clone(
+        self,
+        **kwargs,
+    ) -> "CPE":
+        """
+        Clone a CPE and allow to override parts
+
+        Example:
+            .. code-block:: python
+
+                from pontos.cpe import CPE, ANY
+
+                android_13 = CPE.from_string(
+                    "cpe:2.3:o:google:android:13.0:*:*:*:*:*:*:*"
+                )
+                all_android_versions = cpe.clone(version=ANY)
+        """
+        args = {
+            "part": self.part,
+            "vendor": self.vendor,
+            "product": self.product,
+            "version": self.version,
+            "update": self.update,
+            "edition": self.edition,
+            "language": self.language,
+            "sw_edition": self.sw_edition,
+            "target_sw": self.target_sw,
+            "target_hw": self.target_hw,
+            "other": self.other,
+            "cpe_string": self.cpe_string,
+        }
+        args.update(**kwargs)
+        return CPE(**args)  # type: ignore[arg-type]
+
     def __str__(self) -> str:
         """
         Returns the string representation (uri of formatted string) of the CPE

--- a/tests/cpe/test_cpe.py
+++ b/tests/cpe/test_cpe.py
@@ -591,3 +591,19 @@ class CPETestCase(unittest.TestCase):
             target_sw="ipsum",
         )
         self.assertTrue(cpe.has_extended_attribute())
+
+    def test_clone(self):
+        cpe = CPE.from_string(
+            "cpe:2.3:a:hp:openview_network_manager:7.51:*:*:*:*:linux:*:*"
+        )
+
+        cpe2 = cpe.clone()
+        self.assertIsNot(cpe, cpe2)
+
+        cpe = CPE.from_string(
+            "cpe:2.3:a:hp:openview_network_manager:7.51:*:*:*:*:linux:*:*"
+        )
+        cpe2 = cpe.clone(version=ANY)
+        self.assertIsNot(cpe, cpe2)
+        self.assertEqual(cpe.version, "7\\.51")
+        self.assertEqual(cpe2.version, ANY)


### PR DESCRIPTION
## What

 Allow to clone and adjust a CPE>

## Why

Add a new CPE method to clone a CPE object and allow to adjust the parts of the CPE while cloning. This will become necessary when transforming a CPE for example having a CPE with a specific version put we want to address all versions of this product.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


