### PR TITLE
Add: Add additional comparison for Version classes (ge, lt and le)

### DIFF
--- a/pontos/version/schemes/_pep440.py
+++ b/pontos/version/schemes/_pep440.py
@@ -225,6 +225,27 @@ class PEP440Version(Version):
             other = self.from_version(other)
         return self._version > other._version
 
+    def __ge__(self, other: Any) -> bool:
+        if not isinstance(other, Version):
+            raise ValueError(f"Can't compare {type(self)} with {type(other)}")
+        if not isinstance(other, type(self)):
+            other = self.from_version(other)
+        return self._version >= other._version
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, Version):
+            raise ValueError(f"Can't compare {type(self)} with {type(other)}")
+        if not isinstance(other, type(self)):
+            other = self.from_version(other)
+        return self._version < other._version
+
+    def __le__(self, other: Any) -> bool:
+        if not isinstance(other, Version):
+            raise ValueError(f"Can't compare {type(self)} with {type(other)}")
+        if not isinstance(other, type(self)):
+            other = self.from_version(other)
+        return self._version <= other._version
+
     def __str__(self) -> str:
         return str(self._version)
 

--- a/pontos/version/schemes/_semantic.py
+++ b/pontos/version/schemes/_semantic.py
@@ -164,20 +164,7 @@ class SemanticVersion(Version):
         )
 
     def __ne__(self, other: Any) -> bool:
-        if other is None:
-            return True
-        if isinstance(other, str):
-            # allow to compare against "current" for now
-            return True
-        if not isinstance(other, Version):
-            raise ValueError(f"Can't compare {type(self)} with {type(other)}")
-        if not isinstance(other, type(self)):
-            other = self.from_version(other)
-
-        return (
-            self._version_info != other._version_info
-            or self._version_info.build != other._version_info.build
-        )
+        return not self == other
 
     def __gt__(self, other: Any) -> bool:
         if not isinstance(other, Version):
@@ -222,6 +209,27 @@ class SemanticVersion(Version):
 
         # both are equal
         return False
+
+    def __ge__(self, other: Any) -> bool:
+        if not isinstance(other, Version):
+            raise ValueError(f"Can't compare {type(self)} with {type(other)}")
+        if not isinstance(other, type(self)):
+            other = self.from_version(other)
+        return self > other or self == other
+
+    def __lt__(self, other: Any) -> bool:
+        if not isinstance(other, Version):
+            raise ValueError(f"Can't compare {type(self)} with {type(other)}")
+        if not isinstance(other, type(self)):
+            other = self.from_version(other)
+        return (not self > other) and self != other
+
+    def __le__(self, other: Any) -> bool:
+        if not isinstance(other, Version):
+            raise ValueError(f"Can't compare {type(self)} with {type(other)}")
+        if not isinstance(other, type(self)):
+            other = self.from_version(other)
+        return not self > other or self == other
 
     def __str__(self) -> str:
         """A string representation of the version"""

--- a/pontos/version/version.py
+++ b/pontos/version/version.py
@@ -147,6 +147,18 @@ class Version(ABC):
         pass
 
     @abstractmethod
+    def __ge__(self, other: Any) -> bool:
+        pass
+
+    @abstractmethod
+    def __lt__(self, other: Any) -> bool:
+        pass
+
+    @abstractmethod
+    def __le__(self, other: Any) -> bool:
+        pass
+
+    @abstractmethod
     def __str__(self) -> str:
         """A string representation of the version"""
 

--- a/tests/cpe/test_cpe.py
+++ b/tests/cpe/test_cpe.py
@@ -245,7 +245,6 @@ class CPETestCase(unittest.TestCase):
             "cpe:2.3:a:qrokes:qr_twitter_widget:*:*:*:*:*:wordpress:*:*"
         )
         cpe = CPE.from_string(cpe_string)
-        print(repr(cpe))
 
         self.assertEqual(
             str(cpe),
@@ -403,7 +402,6 @@ class CPETestCase(unittest.TestCase):
         cpe = CPE.from_string(
             "cpe:/a:hp:insight_diagnostics:7.4.0.1570::~~online~win2003~x64~"
         )
-        print(repr(cpe))
         self.assertTrue(cpe.is_uri_binding())
         self.assertFalse(cpe.is_formatted_string_binding())
         self.assertEqual(cpe.part, Part.APPLICATION)

--- a/tests/version/schemes/test_pep440.py
+++ b/tests/version/schemes/test_pep440.py
@@ -336,6 +336,240 @@ class PEP440VersionTestCase(unittest.TestCase):
                 f"{version1} should not be greater then {version2}",
             )
 
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) > version2)
+
+    def test_greater_or_equal_then(self):
+        versions = [
+            ("1.0.0", "0.9.9999"),
+            ("1.0.1", "1.0.0"),
+            ("1.0.0", "1.0.0"),
+            ("1.0.0", "1.0.0.dev1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-beta1"),
+            ("1.0.0", "1.0.0-rc1"),
+            ("1.0.0.dev1", "1.0.0.dev1"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0-alpha1", "1.0.0-dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1.dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-alpha2", "1.0.0-alpha1"),
+            ("1.0.0-alpha1.dev1", "1.0.0-alpha1.dev1"),
+            ("1.0.0-beta1", "1.0.0-dev1"),
+            ("1.0.0-beta1", "1.0.0-alpha1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-beta1", "1.0.0-beta1.dev1"),
+            ("1.0.0-beta2", "1.0.0-beta1"),
+            ("1.0.0-beta1.dev1", "1.0.0-beta1.dev1"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+            ("1.0.0-rc1", "1.0.0-dev1"),
+            ("1.0.0-rc1", "1.0.0-alpha1"),
+            ("1.0.0-rc1", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-rc1.dev1"),
+            ("1.0.0-rc1.dev1", "1.0.0-rc1.dev1"),
+            ("1.0.0-rc2", "1.0.0-rc1"),
+        ]
+        for version1, version2 in versions:
+            self.assertTrue(
+                Version.from_string(version1) >= Version.from_string(version2),
+                f"{version1} should be greater or equal then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "1.0.0+dev1"),
+            ("1.0.0.dev1", "1.0.0.dev2"),
+            ("1.0.0", "1.0.1"),
+            ("1.0.0-dev1", "1.0.0"),
+            ("1.0.0-dev1", "1.0.0-alpha1"),
+            ("1.0.0-dev1", "1.0.0-beta1"),
+            ("1.0.0-dev1", "1.0.0-rc1"),
+            ("1.0.0+dev1", "1.0.0+dev2"),
+            ("1.0.0-alpha1", "1.0.0-beta1"),
+            ("1.0.0-alpha1", "1.0.0-rc1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1.dev1", "1.0.0-alpha1.dev2"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev2"),
+            ("1.0.0-beta1", "1.0.0-rc1"),
+            ("1.0.0-beta1", "1.0.0-beta1+dev1"),
+            ("1.0.0-beta1.dev1", "1.0.0-beta1.dev2"),
+            ("1.0.0-beta1+dev1", "1.0.0-beta1+dev2"),
+            ("1.0.0-rc1", "1.0.0"),
+            ("1.0.0-rc1", "1.0.0-rc1+dev1"),
+            ("1.0.0-rc1.dev1", "1.0.0-rc1.dev2"),
+            ("1.0.0-rc1+dev1", "1.0.0-rc1+dev2"),
+        ]
+        for version1, version2 in versions:
+            self.assertFalse(
+                Version.from_string(version1) >= Version.from_string(version2),
+                f"{version1} should not be greater or equal then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) >= version2)
+
+    def test_less_then(self):
+        versions = [
+            ("1.0.0", "0.9.9999"),
+            ("1.0.1", "1.0.0"),
+            ("1.0.0", "1.0.0.dev1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-beta1"),
+            ("1.0.0", "1.0.0-rc1"),
+            ("1.0.0-alpha1", "1.0.0-dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1.dev1"),
+            ("1.0.0-alpha2", "1.0.0-alpha1"),
+            ("1.0.0-beta1", "1.0.0-dev1"),
+            ("1.0.0-beta1", "1.0.0-alpha1"),
+            ("1.0.0-beta1", "1.0.0-beta1.dev1"),
+            ("1.0.0-beta2", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-dev1"),
+            ("1.0.0-rc1", "1.0.0-alpha1"),
+            ("1.0.0-rc1", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-rc1.dev1"),
+            ("1.0.0-rc2", "1.0.0-rc1"),
+        ]
+        for version2, version1 in versions:
+            self.assertTrue(
+                Version.from_string(version1) < Version.from_string(version2),
+                f"{version1} should be less then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "1.0.0"),
+            ("1.0.0", "1.0.0+dev1"),
+            ("1.0.0.dev1", "1.0.0.dev1"),
+            ("1.0.0.dev1", "1.0.0.dev2"),
+            ("1.0.0", "1.0.1"),
+            ("1.0.0-dev1", "1.0.0"),
+            ("1.0.0-dev1", "1.0.0-alpha1"),
+            ("1.0.0-dev1", "1.0.0-beta1"),
+            ("1.0.0-dev1", "1.0.0-rc1"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0+dev1", "1.0.0+dev2"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-alpha1", "1.0.0-beta1"),
+            ("1.0.0-alpha1", "1.0.0-rc1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1.dev1", "1.0.0-alpha1.dev1"),
+            ("1.0.0-alpha1.dev1", "1.0.0-alpha1.dev2"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev2"),
+            ("1.0.0-beta1", "1.0.0-rc1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-beta1", "1.0.0-beta1+dev1"),
+            ("1.0.0-beta1.dev1", "1.0.0-beta1.dev1"),
+            ("1.0.0-beta1.dev1", "1.0.0-beta1.dev2"),
+            ("1.0.0-beta1+dev1", "1.0.0-beta1+dev2"),
+            ("1.0.0-rc1", "1.0.0"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+            ("1.0.0-rc1", "1.0.0-rc1+dev1"),
+            ("1.0.0-rc1.dev1", "1.0.0-rc1.dev1"),
+            ("1.0.0-rc1.dev1", "1.0.0-rc1.dev2"),
+            ("1.0.0-rc1+dev1", "1.0.0-rc1+dev2"),
+        ]
+        for version2, version1 in versions:
+            self.assertFalse(
+                Version.from_string(version1) < Version.from_string(version2),
+                f"{version1} should not be less then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) < version2)
+
+    def test_less_or_equal_then(self):
+        versions = [
+            ("1.0.0", "0.9.9999"),
+            ("1.0.1", "1.0.0"),
+            ("1.0.0", "1.0.0"),
+            ("1.0.0", "1.0.0.dev1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-beta1"),
+            ("1.0.0", "1.0.0-rc1"),
+            ("1.0.0.dev1", "1.0.0.dev1"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0-alpha1", "1.0.0-dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1.dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-alpha2", "1.0.0-alpha1"),
+            ("1.0.0-alpha1.dev1", "1.0.0-alpha1.dev1"),
+            ("1.0.0-beta1", "1.0.0-dev1"),
+            ("1.0.0-beta1", "1.0.0-alpha1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-beta1", "1.0.0-beta1.dev1"),
+            ("1.0.0-beta2", "1.0.0-beta1"),
+            ("1.0.0-beta1.dev1", "1.0.0-beta1.dev1"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+            ("1.0.0-rc1", "1.0.0-dev1"),
+            ("1.0.0-rc1", "1.0.0-alpha1"),
+            ("1.0.0-rc1", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-rc1.dev1"),
+            ("1.0.0-rc1.dev1", "1.0.0-rc1.dev1"),
+            ("1.0.0-rc2", "1.0.0-rc1"),
+        ]
+        for version2, version1 in versions:
+            self.assertTrue(
+                Version.from_string(version1) <= Version.from_string(version2),
+                f"{version1} should be less or equal then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "1.0.0+dev1"),
+            ("1.0.0.dev1", "1.0.0.dev2"),
+            ("1.0.0", "1.0.1"),
+            ("1.0.0-dev1", "1.0.0"),
+            ("1.0.0-dev1", "1.0.0-alpha1"),
+            ("1.0.0-dev1", "1.0.0-beta1"),
+            ("1.0.0-dev1", "1.0.0-rc1"),
+            ("1.0.0+dev1", "1.0.0+dev2"),
+            ("1.0.0-alpha1", "1.0.0-beta1"),
+            ("1.0.0-alpha1", "1.0.0-rc1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1.dev1", "1.0.0-alpha1.dev2"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev2"),
+            ("1.0.0-beta1", "1.0.0-rc1"),
+            ("1.0.0-beta1", "1.0.0-beta1+dev1"),
+            ("1.0.0-beta1.dev1", "1.0.0-beta1.dev2"),
+            ("1.0.0-beta1+dev1", "1.0.0-beta1+dev2"),
+            ("1.0.0-rc1", "1.0.0"),
+            ("1.0.0-rc1", "1.0.0-rc1+dev1"),
+            ("1.0.0-rc1.dev1", "1.0.0-rc1.dev2"),
+            ("1.0.0-rc1+dev1", "1.0.0-rc1+dev2"),
+        ]
+        for version2, version1 in versions:
+            self.assertFalse(
+                Version.from_string(version1) <= Version.from_string(version2),
+                f"{version1} should not be less or equal then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) <= version2)
+
     def test_is_dev_release(self):
         versions = [
             "1.0.0.dev1",

--- a/tests/version/schemes/test_semantic.py
+++ b/tests/version/schemes/test_semantic.py
@@ -306,6 +306,243 @@ class SemanticVersionTestCase(unittest.TestCase):
                 f"{version1} should not be greater then {version2}",
             )
 
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) > version2)
+
+    def test_greater_or_equal_then(self):
+        versions = [
+            ("1.0.0", "0.9.9999"),
+            ("1.0.0", "1.0.0"),
+            ("1.0.1", "1.0.0"),
+            ("1.0.0", "1.0.0-dev1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-beta1"),
+            ("1.0.0", "1.0.0-rc1"),
+            ("1.0.0-dev1", "1.0.0-dev1"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0-alpha1", "1.0.0-dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-alpha1-dev1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-alpha2", "1.0.0-alpha1"),
+            ("1.0.0-beta1", "1.0.0-dev1"),
+            ("1.0.0-beta1", "1.0.0-alpha1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-beta1", "1.0.0-beta1-dev1"),
+            ("1.0.0-beta2", "1.0.0-beta1"),
+            ("1.0.0-beta1-dev1", "1.0.0-beta1-dev1"),
+            ("1.0.0-rc1", "1.0.0-dev1"),
+            ("1.0.0-rc1", "1.0.0-alpha1"),
+            ("1.0.0-rc1", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+            ("1.0.0-rc1", "1.0.0-rc1-dev1"),
+            ("1.0.0-rc2", "1.0.0-rc1"),
+            ("1.0.0-rc1-dev1", "1.0.0-rc1-dev1"),
+        ]
+        for version1, version2 in versions:
+            self.assertTrue(
+                Version.from_string(version1) >= Version.from_string(version2),
+                f"{version1} should be greater or equal then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "1.0.0+dev1"),
+            ("1.0.0-dev1", "1.0.0-dev2"),
+            ("1.0.0", "1.0.1"),
+            ("1.0.0-dev1", "1.0.0"),
+            ("1.0.0-dev1", "1.0.0-alpha1"),
+            ("1.0.0-dev1", "1.0.0-beta1"),
+            ("1.0.0-dev1", "1.0.0-rc1"),
+            ("1.0.0+dev1", "1.0.0+dev2"),
+            ("1.0.0-alpha1", "1.0.0-beta1"),
+            ("1.0.0-alpha1", "1.0.0-rc1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1-dev1", "1.0.0-alpha1-dev2"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev2"),
+            ("1.0.0-beta1", "1.0.0-rc1"),
+            ("1.0.0-beta1", "1.0.0-beta1+dev1"),
+            ("1.0.0-beta1-dev1", "1.0.0-beta1-dev2"),
+            ("1.0.0-beta1+dev1", "1.0.0-beta1+dev2"),
+            ("1.0.0-rc1", "1.0.0"),
+            ("1.0.0-rc1", "1.0.0-rc1+dev1"),
+            ("1.0.0-rc1-dev1", "1.0.0-rc1-dev2"),
+            ("1.0.0-rc1+dev1", "1.0.0-rc1+dev2"),
+        ]
+        for version1, version2 in versions:
+            self.assertFalse(
+                Version.from_string(version1) >= Version.from_string(version2),
+                f"{version1} should not be greater or equal then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) >= version2)
+
+    def test_less_then(self):
+        versions = [
+            ("1.0.0", "0.9.9999"),
+            ("1.0.1", "1.0.0"),
+            ("1.0.0", "1.0.0-dev1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-beta1"),
+            ("1.0.0", "1.0.0-rc1"),
+            ("1.0.0-alpha1", "1.0.0-dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-alpha2", "1.0.0-alpha1"),
+            ("1.0.0-beta1", "1.0.0-dev1"),
+            ("1.0.0-beta1", "1.0.0-alpha1"),
+            ("1.0.0-beta1", "1.0.0-beta1-dev1"),
+            ("1.0.0-beta2", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-dev1"),
+            ("1.0.0-rc1", "1.0.0-alpha1"),
+            ("1.0.0-rc1", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-rc1-dev1"),
+            ("1.0.0-rc2", "1.0.0-rc1"),
+            # the following ones are strange with current semver implementation
+            # because they are both less then and greater then at the same time
+            ("1.0.0", "1.0.0+dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
+            ("1.0.0+dev1", "1.0.0+dev2"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev2"),
+            ("1.0.0-beta1", "1.0.0-beta1+dev1"),
+            ("1.0.0-beta1+dev1", "1.0.0-beta1+dev2"),
+            ("1.0.0-rc1", "1.0.0-rc1+dev1"),
+            ("1.0.0-rc1+dev1", "1.0.0-rc1+dev2"),
+        ]
+        for version2, version1 in versions:
+            self.assertTrue(
+                Version.from_string(version1) < Version.from_string(version2),
+                f"{version1} should be less then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", "1.0.0"),
+            ("1.0.0-dev1", "1.0.0-dev1"),
+            ("1.0.0-dev1", "1.0.0-dev2"),
+            ("1.0.0", "1.0.1"),
+            ("1.0.0-dev1", "1.0.0"),
+            ("1.0.0-dev1", "1.0.0-alpha1"),
+            ("1.0.0-dev1", "1.0.0-beta1"),
+            ("1.0.0-dev1", "1.0.0-rc1"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-alpha1", "1.0.0-beta1"),
+            ("1.0.0-alpha1", "1.0.0-rc1"),
+            ("1.0.0-alpha1-dev1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-alpha1-dev1", "1.0.0-alpha1-dev2"),
+            ("1.0.0-beta1", "1.0.0-rc1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-beta1-dev1", "1.0.0-beta1-dev1"),
+            ("1.0.0-beta1-dev1", "1.0.0-beta1-dev2"),
+            ("1.0.0-rc1", "1.0.0"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+            ("1.0.0-rc1-dev1", "1.0.0-rc1-dev1"),
+            ("1.0.0-rc1-dev1", "1.0.0-rc1-dev2"),
+        ]
+        for version2, version1 in versions:
+            self.assertFalse(
+                Version.from_string(version1) < Version.from_string(version2),
+                f"{version1} should not be less then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) < version2)
+
+    def test_less_or_equal_then(self):
+        versions = [
+            ("1.0.0", "0.9.9999"),
+            ("1.0.0", "1.0.0"),
+            ("1.0.1", "1.0.0"),
+            ("1.0.0", "1.0.0-dev1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-alpha1"),
+            ("1.0.0", "1.0.0-beta1"),
+            ("1.0.0", "1.0.0-rc1"),
+            ("1.0.0-dev1", "1.0.0-dev1"),
+            ("1.0.0+dev1", "1.0.0+dev1"),
+            ("1.0.0-alpha1", "1.0.0-dev1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1"),
+            ("1.0.0-alpha1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-alpha1-dev1", "1.0.0-alpha1-dev1"),
+            ("1.0.0-alpha2", "1.0.0-alpha1"),
+            ("1.0.0-beta1", "1.0.0-dev1"),
+            ("1.0.0-beta1", "1.0.0-alpha1"),
+            ("1.0.0-beta1", "1.0.0-beta1"),
+            ("1.0.0-beta1", "1.0.0-beta1-dev1"),
+            ("1.0.0-beta2", "1.0.0-beta1"),
+            ("1.0.0-beta1-dev1", "1.0.0-beta1-dev1"),
+            ("1.0.0-rc1", "1.0.0-dev1"),
+            ("1.0.0-rc1", "1.0.0-alpha1"),
+            ("1.0.0-rc1", "1.0.0-beta1"),
+            ("1.0.0-rc1", "1.0.0-rc1"),
+            ("1.0.0-rc1", "1.0.0-rc1-dev1"),
+            ("1.0.0-rc2", "1.0.0-rc1"),
+            ("1.0.0-rc1-dev1", "1.0.0-rc1-dev1"),
+            # the strange ones
+            ("1.0.0", "1.0.0+dev1"),
+            ("1.0.0+dev1", "1.0.0+dev2"),
+            ("1.0.0-alpha1", "1.0.0-alpha1+dev1"),
+            ("1.0.0-alpha1+dev1", "1.0.0-alpha1+dev2"),
+            ("1.0.0-beta1", "1.0.0-beta1+dev1"),
+            ("1.0.0-beta1+dev1", "1.0.0-beta1+dev2"),
+            ("1.0.0-rc1", "1.0.0-rc1+dev1"),
+            ("1.0.0-rc1+dev1", "1.0.0-rc1+dev2"),
+        ]
+        for version2, version1 in versions:
+            self.assertTrue(
+                Version.from_string(version1) <= Version.from_string(version2),
+                f"{version1} should be greater or equal then {version2}",
+            )
+
+        versions = [
+            ("1.0.0-dev1", "1.0.0-dev2"),
+            ("1.0.0", "1.0.1"),
+            ("1.0.0-dev1", "1.0.0"),
+            ("1.0.0-dev1", "1.0.0-alpha1"),
+            ("1.0.0-dev1", "1.0.0-beta1"),
+            ("1.0.0-dev1", "1.0.0-rc1"),
+            ("1.0.0-alpha1", "1.0.0-beta1"),
+            ("1.0.0-alpha1", "1.0.0-rc1"),
+            ("1.0.0-alpha1-dev1", "1.0.0-alpha1-dev2"),
+            ("1.0.0-beta1", "1.0.0-rc1"),
+            ("1.0.0-beta1-dev1", "1.0.0-beta1-dev2"),
+            ("1.0.0-rc1", "1.0.0"),
+            ("1.0.0-rc1-dev1", "1.0.0-rc1-dev2"),
+        ]
+        for version2, version1 in versions:
+            self.assertFalse(
+                Version.from_string(version1) <= Version.from_string(version2),
+                f"{version1} should not be greater or equal then {version2}",
+            )
+
+        versions = [
+            ("1.0.0", object()),
+            ("1.0.0", 1),
+            ("1.0.0", True),
+        ]
+        for version1, version2 in versions:
+            with self.assertRaisesRegex(ValueError, "Can't compare"):
+                self.assertFalse(Version.from_string(version1) <= version2)
+
     def test_is_dev_release(self):
         versions = [
             "1.0.0-dev1",


### PR DESCRIPTION
## What
Add additional comparison for Version classes (ge, lt and le)

## Why

Allow to compare versions with greater or equal then, less then and less or equal then. This is required for comparing CPE versions.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


