### PR TITLE
CVE api MAX_CVES_PER_PAGE to 2k

### DIFF
--- a/pontos/nvd/cve/api.py
+++ b/pontos/nvd/cve/api.py
@@ -45,7 +45,7 @@ from pontos.nvd.models.cvss_v3 import Severity as CVSSv3Severity
 __all__ = ("CVEApi",)
 
 DEFAULT_NIST_NVD_CVES_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
-MAX_CVES_PER_PAGE = 10000
+MAX_CVES_PER_PAGE = 2000
 
 
 class CVEApi(NVDApi):


### PR DESCRIPTION
## What

Adjusts the `MAX_CVES_PER_PAGE` value 2000 as per the updated (?) [docs](https://nvd.nist.gov/developers/vulnerabilities).

## Why

The current 10000 value auto-breaks implementing tools.

## References

Closes: https://jira.greenbone.net/browse/DEVOPS-862

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


