### PR TITLE
Fix models/code_scanning.py: add 'documentation' to Classification enum

### DIFF
--- a/pontos/github/models/code_scanning.py
+++ b/pontos/github/models/code_scanning.py
@@ -71,6 +71,7 @@ class Classification(Enum):
     GENERATED = "generated"
     TEST = "test"
     LIBRARY = "library"
+    DOCUMENTATION = "documentation"
 
 
 @dataclass


### PR DESCRIPTION
## What

Added  'documentation' to Classification Enum.

## Why

Using code_scanning.organization_alerts resulted in a ModelError.

## References

https://jira.greenbone.net/browse/DEVOPS-856

## Checklist

- [x] code_scanning.organization_alerts ran successfully after calling it locally after the fix


