### PR TITLE
Fix: Missing event name

### DIFF
--- a/pontos/nvd/models/cve_change.py
+++ b/pontos/nvd/models/cve_change.py
@@ -12,6 +12,7 @@ from pontos.models import Model
 
 
 class EventName(str, Enum):
+    CVE_RECEIVED = "CVE Received"
     INITAL_ANALYSIS = "Initial Analysis"
     REANALYSIS = "Reanalysis"
     CVE_MODIFIED = "CVE Modified"


### PR DESCRIPTION
## What
This PR adds the missing `CVE Received` event name (see https://nvd.nist.gov/developers/vulnerabilities#cveHistory-eventName).

## Why
Because I seem to have missed it in https://github.com/greenbone/pontos/pull/920.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


