### PR TITLE
Fix: Update pack_extended_attributes cpe function signature

### DIFF
--- a/pontos/cpe/_cpe.py
+++ b/pontos/cpe/_cpe.py
@@ -79,7 +79,7 @@ def pack_extended_attributes(
     target_sw: Optional[str],
     target_hw: Optional[str],
     other: Optional[str],
-) -> Optional[str]:
+) -> str:
     """
     Pack the extended attributes (v2.3) for an edition attribute (v2.2)
     """


### PR DESCRIPTION
## What

Update pack_extended_attributes cpe function signature

## Why

The function always returns a str and never None.

