### PR TITLE
Fix typo in CVE Change EventName enum

### DIFF
--- a/pontos/nvd/models/cve_change.py
+++ b/pontos/nvd/models/cve_change.py
@@ -12,7 +12,7 @@ from pontos.models import Model, StrEnum
 
 class EventName(StrEnum):
     CVE_RECEIVED = "CVE Received"
-    INITAL_ANALYSIS = "Initial Analysis"
+    INITIAL_ANALYSIS = "Initial Analysis"
     REANALYSIS = "Reanalysis"
     CVE_MODIFIED = "CVE Modified"
     MODIFIED_ANALYSIS = "Modified Analysis"

--- a/tests/nvd/cve_changes/test_api.py
+++ b/tests/nvd/cve_changes/test_api.py
@@ -54,7 +54,7 @@ class CVEChangesApiTestCase(IsolatedAsyncioTestCase):
         cve_change = await anext(it)
 
         self.assertEqual(cve_change.cve_id, "CVE-1")
-        self.assertEqual(cve_change.event_name, EventName.INITAL_ANALYSIS)
+        self.assertEqual(cve_change.event_name, EventName.INITIAL_ANALYSIS)
         self.assertEqual(
             cve_change.cve_change_id,
             UUID("5160FDEB-0FF0-457B-AA36-0AEDCAB2522E"),
@@ -179,7 +179,7 @@ class CVEChangesApiTestCase(IsolatedAsyncioTestCase):
     async def test_cve_changes_event_name(self):
         self.http_client.get.side_effect = create_cve_changes_responses()
 
-        it = aiter(self.api.changes(event_name=EventName.INITAL_ANALYSIS))
+        it = aiter(self.api.changes(event_name=EventName.INITIAL_ANALYSIS))
         cve_changes = await anext(it)
 
         self.assertEqual(cve_changes.cve_id, "CVE-1")

--- a/tests/nvd/models/test_cve_change.py
+++ b/tests/nvd/models/test_cve_change.py
@@ -53,8 +53,8 @@ class CVEChangeTestCase(unittest.TestCase):
 class EventNameTestCase(unittest.TestCase):
     def test_init(self):
         self.assertEqual(
-            EventName("Initial Analysis"), EventName.INITAL_ANALYSIS
+            EventName("Initial Analysis"), EventName.INITIAL_ANALYSIS
         )
 
     def test__str__(self):
-        self.assertEqual(str(EventName.INITAL_ANALYSIS), "Initial Analysis")
+        self.assertEqual(str(EventName.INITIAL_ANALYSIS), "Initial Analysis")


### PR DESCRIPTION

## What

Fix typo in CVE Change EventName enum

## Why

INITAL_ANALYSIS -> INITIAL_ANALYSIS

## References

#920

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


