### PR TITLE
Add: Export NVDResults from pontos.nvd

### DIFF
--- a/pontos/nvd/__init__.py
+++ b/pontos/nvd/__init__.py
@@ -15,11 +15,12 @@
 # You should have received a copy of the GNU General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from .api import NVDApi, convert_camel_case, format_date, now
+from .api import NVDApi, NVDResults, convert_camel_case, format_date, now
 
 __all__ = (
     "convert_camel_case",
     "format_date",
     "now",
     "NVDApi",
+    "NVDResults",
 )

--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -55,6 +55,7 @@ __all__ = (
     "format_date",
     "now",
     "NVDApi",
+    "NVDResults",
 )
 
 


### PR DESCRIPTION


## What

 Export NVDResults from pontos.nvd

## Why

Export NVDResults from the main nvd module. pontos.nvd.api is considered but sadly not explicitly marked as private.


