### PR TITLE
Add: Allow to set the number of results to request per page for NVD API

### DIFF
--- a/pontos/nvd/cpe/api.py
+++ b/pontos/nvd/cpe/api.py
@@ -141,6 +141,7 @@ class CPEApi(NVDApi):
         match_criteria_id: Optional[str] = None,
         request_results: Optional[int] = None,
         start_index: int = 0,
+        results_per_page: Optional[int] = None,
     ) -> NVDResults[CPE]:
         """
         Get all CPEs for the provided arguments
@@ -162,6 +163,8 @@ class CPEApi(NVDApi):
                 to download all available CPEs.
             start_index: Index of the first CPE to be returned. Useful only for
                 paginated requests that should not start at the first page.
+            results_per_page: Number of results in a single requests. Mostly
+                useful for paginated requests.
 
         Returns:
             A NVDResponse for CPEs
@@ -205,10 +208,9 @@ class CPEApi(NVDApi):
         if match_criteria_id:
             params["matchCriteriaId"] = match_criteria_id
 
-        results_per_page = (
-            request_results
-            if request_results and request_results < MAX_CPES_PER_PAGE
-            else MAX_CPES_PER_PAGE
+        results_per_page = min(
+            results_per_page or MAX_CPES_PER_PAGE,
+            request_results or MAX_CPES_PER_PAGE,
         )
 
         return NVDResults(

--- a/pontos/nvd/cve/api.py
+++ b/pontos/nvd/cve/api.py
@@ -122,6 +122,7 @@ class CVEApi(NVDApi):
         has_oval: Optional[bool] = None,
         request_results: Optional[int] = None,
         start_index: int = 0,
+        results_per_page: Optional[int] = None,
     ) -> NVDResults[CVE]:
         """
         Get all CVEs for the provided arguments
@@ -174,6 +175,8 @@ class CVEApi(NVDApi):
                 to download all available CVEs.
             start_index: Index of the first CVE to be returned. Useful only for
                 paginated requests that should not start at the first page.
+            results_per_page: Number of results in a single requests. Mostly
+                useful for paginated requests.
 
         Returns:
             A NVDResponse for CVEs
@@ -252,10 +255,9 @@ class CVEApi(NVDApi):
         if has_oval:
             params["hasOval"] = ""
 
-        results_per_page = (
-            request_results
-            if request_results and request_results < MAX_CVES_PER_PAGE
-            else MAX_CVES_PER_PAGE
+        results_per_page = min(
+            results_per_page or MAX_CVES_PER_PAGE,
+            request_results or MAX_CVES_PER_PAGE,
         )
         return NVDResults(
             self,

--- a/pontos/nvd/cve_changes/api.py
+++ b/pontos/nvd/cve_changes/api.py
@@ -86,6 +86,7 @@ class CVEChangesApi(NVDApi):
         event_name: Optional[Union[EventName, str]] = None,
         request_results: Optional[int] = None,
         start_index: int = 0,
+        results_per_page: Optional[int] = None,
     ) -> NVDResults[CVEChange]:
         """
         Get all CVEs for the provided arguments
@@ -102,6 +103,8 @@ class CVEChangesApi(NVDApi):
             start_index: Index of the first CVE change to be returned. Useful
                 only for paginated requests that should not start at the first
                 page.
+            results_per_page: Number of results in a single requests. Mostly
+                useful for paginated requests.
 
         Returns:
             A NVDResponse for CVE changes
@@ -146,10 +149,9 @@ class CVEChangesApi(NVDApi):
         if event_name:
             params["eventName"] = event_name
 
-        results_per_page = (
-            request_results
-            if request_results and request_results < MAX_CVE_CHANGES_PER_PAGE
-            else MAX_CVE_CHANGES_PER_PAGE
+        results_per_page = min(
+            results_per_page or MAX_CVE_CHANGES_PER_PAGE,
+            request_results or MAX_CVE_CHANGES_PER_PAGE,
         )
         return NVDResults(
             self,


### PR DESCRIPTION
## What

Allow to set the number of results to request per page for NVD API

## Why

Allow a user of the NVD API to specify the number of results within a response. This allows to adjust the size of each "page".