### PR TITLE
Change: Assume UTC when no offset it specified

### DIFF
--- a/pontos/models/__init__.py
+++ b/pontos/models/__init__.py
@@ -16,7 +16,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 from dataclasses import dataclass
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 from enum import Enum
 from inspect import isclass
 from typing import Any, Dict, Type, Union, get_args, get_origin, get_type_hints
@@ -93,11 +93,10 @@ def _get_value_from_model_field_cls(
         value = dateparser.isoparse(value)
         # the iso format may not contain UTC data or a UTC offset
         # this means it is considered local time (Python calls this "naive"
-        # datetime) and can't really be compared to other times. maybe we
-        # should always assume UTC for these formats.
-        # This could be done the following:
-        # if not value.tzinfo:
-        #     value = value.replace(tzinfo=timezone.utc)
+        # datetime) and can't really be compared to other times.
+        # Let's UTC in these cases:
+        if not value.tzinfo:
+            value = value.replace(tzinfo=timezone.utc)
     elif isclass(model_field_cls) and issubclass(model_field_cls, date):
         value = date.fromisoformat(value)
     elif get_origin(model_field_cls) == list:

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -112,7 +112,9 @@ class ExampleModelTestCase(unittest.TestCase):
             foo: datetime
 
         model = ExampleModel.from_dict({"foo": "1988-10-01T04:00:00.000"})
-        self.assertEqual(model.foo, datetime(1988, 10, 1, 4))
+        self.assertEqual(
+            model.foo, datetime(1988, 10, 1, 4, tzinfo=timezone.utc)
+        )
 
         model = ExampleModel.from_dict({"foo": "1988-10-01T04:00:00Z"})
         self.assertEqual(
@@ -131,7 +133,10 @@ class ExampleModelTestCase(unittest.TestCase):
         )
 
         model = ExampleModel.from_dict({"foo": "2021-06-06T11:15:10.213"})
-        self.assertEqual(model.foo, datetime(2021, 6, 6, 11, 15, 10, 213000))
+        self.assertEqual(
+            model.foo,
+            datetime(2021, 6, 6, 11, 15, 10, 213000, tzinfo=timezone.utc),
+        )
 
     def test_date(self):
         @dataclass
@@ -190,7 +195,9 @@ class ExampleModelTestCase(unittest.TestCase):
         )
 
         self.assertEqual(model.foo, "abc")
-        self.assertEqual(model.bar, datetime(1988, 10, 1, 4))
+        self.assertEqual(
+            model.bar, datetime(1988, 10, 1, 4, tzinfo=timezone.utc)
+        )
         self.assertEqual(model.id, 123)
         self.assertEqual(model.baz, ["a", "b", "c"])
         self.assertIsNotNone(model.ipsum)

--- a/tests/nvd/cpe/test_api.py
+++ b/tests/nvd/cpe/test_api.py
@@ -18,7 +18,7 @@
 # pylint: disable=line-too-long, arguments-differ, redefined-builtin
 # ruff: noqa: E501
 
-from datetime import datetime
+from datetime import datetime, timezone
 from itertools import repeat
 from typing import Any, Optional
 from unittest.mock import MagicMock, patch
@@ -132,9 +132,13 @@ class CPEApiTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(cpe.cpe_name_id, uuid_replace(uuid, 1, 1))
         self.assertFalse(cpe.deprecated)
         self.assertEqual(
-            cpe.last_modified, datetime(2022, 12, 9, 18, 15, 16, 973000)
+            cpe.last_modified,
+            datetime(2022, 12, 9, 18, 15, 16, 973000, tzinfo=timezone.utc),
         )
-        self.assertEqual(cpe.created, datetime(2022, 12, 9, 16, 20, 6, 943000))
+        self.assertEqual(
+            cpe.created,
+            datetime(2022, 12, 9, 16, 20, 6, 943000, tzinfo=timezone.utc),
+        )
 
         self.assertEqual(cpe.refs, [])
         self.assertEqual(cpe.titles, [])

--- a/tests/nvd/cve/test_api.py
+++ b/tests/nvd/cve/test_api.py
@@ -17,7 +17,7 @@
 
 # pylint: disable=line-too-long, arguments-differ, redefined-builtin
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from unittest.mock import MagicMock, patch
 
@@ -111,10 +111,12 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
         self.assertEqual(cve.id, "CVE-2022-45536")
         self.assertEqual(cve.source_identifier, "cve@mitre.org")
         self.assertEqual(
-            cve.published, datetime(2022, 11, 22, 21, 15, 11, 103000)
+            cve.published,
+            datetime(2022, 11, 22, 21, 15, 11, 103000, tzinfo=timezone.utc),
         )
         self.assertEqual(
-            cve.last_modified, datetime(2022, 11, 23, 16, 2, 7, 367000)
+            cve.last_modified,
+            datetime(2022, 11, 23, 16, 2, 7, 367000, tzinfo=timezone.utc),
         )
         self.assertEqual(len(cve.descriptions), 1)
         self.assertEqual(len(cve.references), 2)

--- a/tests/nvd/cve_changes/test_api.py
+++ b/tests/nvd/cve_changes/test_api.py
@@ -61,7 +61,8 @@ class CVEChangesApiTestCase(IsolatedAsyncioTestCase):
         )
         self.assertEqual(cve_change.source_identifier, "nvd@nist.gov")
         self.assertEqual(
-            cve_change.created, datetime(2022, 3, 18, 20, 13, 8, 123000)
+            cve_change.created,
+            datetime(2022, 3, 18, 20, 13, 8, 123000, tzinfo=timezone.utc),
         )
         self.assertEqual(
             cve_change.details,

--- a/tests/nvd/models/test_cpe.py
+++ b/tests/nvd/models/test_cpe.py
@@ -17,7 +17,7 @@
 # ruff: noqa: E501
 
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from pontos.nvd.models.cpe import CPE, ReferenceType
@@ -37,9 +37,13 @@ class CPETestCase(unittest.TestCase):
         )
         self.assertFalse(cpe.deprecated)
         self.assertEqual(
-            cpe.last_modified, datetime(2022, 12, 9, 18, 15, 16, 973000)
+            cpe.last_modified,
+            datetime(2022, 12, 9, 18, 15, 16, 973000, tzinfo=timezone.utc),
         )
-        self.assertEqual(cpe.created, datetime(2022, 12, 9, 16, 20, 6, 943000))
+        self.assertEqual(
+            cpe.created,
+            datetime(2022, 12, 9, 16, 20, 6, 943000, tzinfo=timezone.utc),
+        )
 
         self.assertEqual(cpe.titles, [])
         self.assertEqual(cpe.refs, [])

--- a/tests/nvd/models/test_cve.py
+++ b/tests/nvd/models/test_cve.py
@@ -19,7 +19,7 @@
 # ruff: noqa: E501
 
 import unittest
-from datetime import date, datetime
+from datetime import date, datetime, timezone
 
 from pontos.nvd.models import cvss_v2, cvss_v3
 from pontos.nvd.models.cve import CVE, CVSSType, Operator
@@ -33,10 +33,12 @@ class CVETestCase(unittest.TestCase):
         self.assertEqual(cve.id, "CVE-2022-45536")
         self.assertEqual(cve.source_identifier, "cve@mitre.org")
         self.assertEqual(
-            cve.published, datetime(2022, 11, 22, 21, 15, 11, 103000)
+            cve.published,
+            datetime(2022, 11, 22, 21, 15, 11, 103000, tzinfo=timezone.utc),
         )
         self.assertEqual(
-            cve.last_modified, datetime(2022, 11, 23, 16, 2, 7, 367000)
+            cve.last_modified,
+            datetime(2022, 11, 23, 16, 2, 7, 367000, tzinfo=timezone.utc),
         )
         self.assertEqual(len(cve.descriptions), 1)
         self.assertEqual(len(cve.references), 2)
@@ -506,7 +508,9 @@ class CVETestCase(unittest.TestCase):
             comment.comment,
             "Fixed in Apache HTTP Server 1.3.12:\nhttp://httpd.apache.org/security/vulnerabilities_13.html",
         )
-        self.assertEqual(comment.last_modified, datetime(2008, 7, 2))
+        self.assertEqual(
+            comment.last_modified, datetime(2008, 7, 2, tzinfo=timezone.utc)
+        )
 
     def test_evaluator_comment(self):
         cve = CVE.from_dict(

--- a/tests/nvd/models/test_cve_change.py
+++ b/tests/nvd/models/test_cve_change.py
@@ -6,7 +6,7 @@
 # ruff: noqa: E501
 
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from uuid import UUID
 
 from pontos.nvd.models.cve_change import CVEChange, Detail, EventName
@@ -25,7 +25,8 @@ class CVEChangeTestCase(unittest.TestCase):
         )
         self.assertEqual(cve_change.source_identifier, "nvd@nist.gov")
         self.assertEqual(
-            cve_change.created, datetime(2022, 3, 18, 20, 13, 8, 123000)
+            cve_change.created,
+            datetime(2022, 3, 18, 20, 13, 8, 123000, tzinfo=timezone.utc),
         )
         self.assertEqual(
             cve_change.details,


### PR DESCRIPTION
## What
This PR changes the behavior of handling datetime objects. Instead of assuming the local timezone, we should assume UTC instead.

## Why
NVD always returns datetime objects in UTC, so we should mark them as those. The only documentation, I've found regarding this is `datetime objects in the API response are always returned with a zero offset from UTC` (see https://nvd.nist.gov/general/news/api-20-announcements).

Example:
```
➜  ~ curl -s "https://services.nvd.nist.gov/rest/json/cves/2.0?cveId=CVE-2022-45536" | jq ".vulnerabilities[0].cve.published"
"2022-11-22T21:15:11.103"
```

Current behavior:
```
➜  pontos git:(main) poetry run python            
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pontos.nvd.cve import CVEApi
>>> import asyncio
>>> from datetime import timezone
>>> async def foo(id):
...     async with CVEApi() as api:
...             return await api.cve(id)
... 
>>> asyncio.run(foo("CVE-2022-45536")).published
datetime.datetime(2022, 11, 22, 21, 15, 11, 103000)
>>> asyncio.run(foo("CVE-2022-45536")).published.timestamp()
1669148111.103
```
With this patch:
```
➜  pontos git:(assume_utc) poetry run python
Python 3.10.12 (main, Nov 20 2023, 15:14:05) [GCC 11.4.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> from pontos.nvd.cve import CVEApi
>>> import asyncio
>>> from datetime import timezone
>>> async def foo(id):
...     async with CVEApi() as api:
...             return await api.cve(id)
... 
>>> asyncio.run(foo("CVE-2022-45536")).published
datetime.datetime(2022, 11, 22, 21, 15, 11, 103000, tzinfo=datetime.timezone.utc)
>>> asyncio.run(foo("CVE-2022-45536")).published.timestamp()
1669151711.103
```

## References
The LoC form this PR have been first added in https://github.com/greenbone/pontos/commit/2e397c32087299275d5ab09b50e711bad21e2c69. 

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


