### PR TITLE
Add: New "CVE CISA KEV Update" event

### DIFF
--- a/pontos/nvd/models/cve_change.py
+++ b/pontos/nvd/models/cve_change.py
@@ -23,6 +23,7 @@ class EventName(StrEnum):
     CWE_REMAP = "CWE Remap"
     CVE_REJECTED = "CVE Rejected"
     CVE_UNREJECTED = "CVE Unrejected"
+    CVE_CISA_KEV_UPDATE = "CVE CISA KEV Update"
 
 
 @dataclass


### PR DESCRIPTION
## What
This PR adds the recently introduced `CVE CISA KEV Update` event. See https://nvd.nist.gov/developers/vulnerabilities#cveHistory-eventName.

## Why
To be able to parse e.g. [CVE-2023-47565](https://services.nvd.nist.gov/rest/json/cvehistory/2.0?cveId=CVE-2023-47565) in `poetry run pontos-nvd-cve-changes -s 0 --cve-id CVE-2023-47565` correctly.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


