### PR TITLE
Fix: Ignore invalid versions in tag when determining last release

### DIFF
--- a/pontos/version/helper.py
+++ b/pontos/version/helper.py
@@ -7,6 +7,7 @@ from typing import Iterator, Optional
 
 from pontos.git import Git, TagSort
 from pontos.git.git import DEFAULT_TAG_SORT_SUFFIX
+from pontos.version.errors import VersionError
 
 from .version import ParseVersionFuncType, Version
 
@@ -40,7 +41,12 @@ def get_last_release_versions(
     for tag in tag_list:
         last_release_version = tag.strip(git_tag_prefix)
 
-        version = parse_version(last_release_version)
+        try:
+            version = parse_version(last_release_version)
+        except VersionError:
+            # be safe and ignore invalid versions
+            continue
+
         if version.is_pre_release and ignore_pre_releases:
             continue
 


### PR DESCRIPTION

## What

Ignore invalid versions in tag when determining last release

## Why

Not all tags may be valid versions. Therefore don't fail to determine the last release version when showing release information and creating a release.

Part 1 for fixing the changelog of major/minor/calendar releases to include changes from previous pre-releases.

## References

DEVOPS-899

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


