### PR TITLE
Change: Include changes from pre-releases in non pre-releases

### DIFF
--- a/pontos/release/create.py
+++ b/pontos/release/create.py
@@ -196,6 +196,18 @@ class CreateReleaseCommand(AsyncCommand):
                 tag_name=f"{self.git_tag_prefix}{release_series}.*"
                 if release_series
                 else None,
+                # include changes from pre-releases in release changelog for
+                # non pre-release changes
+                ignore_pre_releases=release_type
+                not in [
+                    ReleaseType.ALPHA,
+                    ReleaseType.BETA,
+                    ReleaseType.RELEASE_CANDIDATE,
+                ]
+                # but not when using a release series because then we might not
+                # be able to determine the last release if there are only
+                # pre-releases in the series yet
+                and not release_series,
             )
         except PontosError as e:
             last_release_version = None

--- a/tests/release/test_create.py
+++ b/tests/release/test_create.py
@@ -413,6 +413,13 @@ class CreateReleaseTestCase(unittest.TestCase):
                 token=token,  # type: ignore[arg-type]
             )
 
+        get_last_release_version_mock.assert_called_once_with(
+            parse_version=PEP440VersioningScheme.parse_version,
+            git_tag_prefix="v",
+            tag_name=None,
+            ignore_pre_releases=True,
+        )
+
         git_instance_mock.push.assert_has_calls(
             [
                 call(follow_tags=True, remote=None),
@@ -516,6 +523,13 @@ class CreateReleaseTestCase(unittest.TestCase):
                 args=args,
                 token=token,  # type: ignore[arg-type]
             )
+
+        get_last_release_version_mock.assert_called_once_with(
+            parse_version=PEP440VersioningScheme.parse_version,
+            git_tag_prefix="v",
+            tag_name=None,
+            ignore_pre_releases=True,
+        )
 
         git_instance_mock.push.assert_has_calls(
             [
@@ -625,6 +639,13 @@ class CreateReleaseTestCase(unittest.TestCase):
                 token=token,  # type: ignore[arg-type]
             )
 
+        get_last_release_version_mock.assert_called_once_with(
+            parse_version=PEP440VersioningScheme.parse_version,
+            git_tag_prefix="v",
+            tag_name=None,
+            ignore_pre_releases=True,
+        )
+
         git_instance_mock.push.assert_has_calls(
             [
                 call(follow_tags=True, remote=None),
@@ -730,6 +751,13 @@ class CreateReleaseTestCase(unittest.TestCase):
                 token=token,  # type: ignore[arg-type]
             )
 
+        get_last_release_version_mock.assert_called_once_with(
+            parse_version=PEP440VersioningScheme.parse_version,
+            git_tag_prefix="v",
+            tag_name=None,
+            ignore_pre_releases=True,
+        )
+
         git_instance_mock.push.assert_has_calls(
             [
                 call(follow_tags=True, remote=None),
@@ -832,6 +860,13 @@ class CreateReleaseTestCase(unittest.TestCase):
                 args=args,
                 token=token,  # type: ignore[arg-type]
             )
+
+        get_last_release_version_mock.assert_called_once_with(
+            parse_version=PEP440VersioningScheme.parse_version,
+            git_tag_prefix="v",
+            tag_name=None,
+            ignore_pre_releases=False,
+        )
 
         git_instance_mock.push.assert_has_calls(
             [
@@ -938,6 +973,13 @@ class CreateReleaseTestCase(unittest.TestCase):
                 token=token,  # type: ignore[arg-type]
             )
 
+        get_last_release_version_mock.assert_called_once_with(
+            parse_version=PEP440VersioningScheme.parse_version,
+            git_tag_prefix="v",
+            tag_name=None,
+            ignore_pre_releases=False,
+        )
+
         git_instance_mock.push.assert_has_calls(
             [
                 call(follow_tags=True, remote=None),
@@ -1042,6 +1084,13 @@ class CreateReleaseTestCase(unittest.TestCase):
                 args=args,
                 token=token,  # type: ignore[arg-type]
             )
+
+        get_last_release_version_mock.assert_called_once_with(
+            parse_version=PEP440VersioningScheme.parse_version,
+            git_tag_prefix="v",
+            tag_name=None,
+            ignore_pre_releases=False,
+        )
 
         git_instance_mock.push.assert_has_calls(
             [
@@ -2715,7 +2764,11 @@ class ReleaseGoProjectTestCase(unittest.TestCase):
                     token=token,  # type: ignore[arg-type]
                 )
 
-            self.assertEqual(released, CreateReleaseReturnValue.SUCCESS)
+            self.assertEqual(
+                released,
+                CreateReleaseReturnValue.SUCCESS,
+                f"Invalid return value for {r}",
+            )
             self.assertEqual(
                 create_api_mock.call_args.args[1],
                 f"v{r.expected_release_version}",


### PR DESCRIPTION

## What

Include changes from pre-releases in non pre-releases

## Why

Ignore pre-releases when determining the last release version if a non pre-release is created. This includes all the changes of the previous pre-releases into the changelog.

Part 2 for fixing the changelog of major/minor/calendar releases to include changes from previous pre-releases.

## References
DEVOPS-899

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


