### PR TITLE
Change: Use trusted publisher process to deploy on PyPI

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    environment: pypi
+    permissions:
+      id-token: write
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
@@ -14,9 +17,8 @@ jobs:
         with:
           python-version: "3.10"
           install-dependencies: "false"
-      - name: Build and publish
+      - name: Build
         run: |
           poetry build
-          poetry publish
-        env:
-          POETRY_PYPI_TOKEN_PYPI: ${{ secrets.PYPI_TOKEN }}
+      - name: Publish
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
## What

Use trusted publisher process to deploy on PyPI

[Trusted publisher](https://docs.pypi.org/trusted-publishers/) uses OpenID Connect (OIDC) to issue short term tokens for GitHub. [Github implements the OIDC standard](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/about-security-hardening-with-openid-connect) since some month.

## Why

Try out trusted publisher for PyPI to even more secure our deployment chain. Using trusted publisher allows us to get rid of long living tokens.

