### PR TITLE
Change: Add URL to environment for PyPI deployment workflow

### DIFF
--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -7,7 +7,9 @@ on:
 jobs:
   deploy:
     runs-on: ubuntu-latest
-    environment: pypi
+    environment:
+      name: pypi
+      url: https://pypi.org/project/pontos/
     permissions:
       id-token: write
     steps:


### PR DESCRIPTION


## What

Add URL to environment for PyPI deployment workflow

## Why

Adding the URL to the pontos project on PyPI will display the URL at several places on the GitHub repository.

