### PR TITLE
Release repository argument

### DIFF
--- a/pontos/release/helper.py
+++ b/pontos/release/helper.py
@@ -127,3 +127,15 @@ def get_next_release_version(
         return calculator.next_release_candidate_version(last_release_version)
 
     raise VersionError(f"Unsupported release type {release_type.value}.")
+
+
+def repository_split(repository: str) -> tuple[str, str]:
+    """
+    Split a GitHub repository (owner/name) into a space, project tuple
+    """
+    splitted_repo = repository.split("/")
+    if len(splitted_repo) != 2:
+        raise ValueError(
+            f"Invalid repository {repository}. Format must be " "owner/name."
+        )
+    return splitted_repo[0], splitted_repo[1]

--- a/pontos/release/parser.py
+++ b/pontos/release/parser.py
@@ -147,15 +147,27 @@ def parse_args(args) -> Tuple[Optional[str], Optional[str], Namespace]:
         help="The key to sign the commits and tag for a release",
         default=os.environ.get("GPG_SIGNING_KEY"),
     )
-    create_parser.add_argument(
-        "--project",
-        help="The github project",
+
+    repo_group = create_parser.add_argument_group(
+        "Repository",
+        description="Where to publish the new release. Either a full repository"
+        " name or a space/project combination.",
     )
-    create_parser.add_argument(
+    repo_group.add_argument(
+        "--repository",
+        help="GitHub repository name (owner/name). For example "
+        "octocat/Hello-World",
+    )
+    repo_group.add_argument(
         "--space",
         default="greenbone",
-        help="User/Team name in github",
+        help="Owner (User/Team/Organization) name at GitHub",
     )
+    repo_group.add_argument(
+        "--project",
+        help="The GitHub project",
+    )
+
     create_parser.add_argument(
         "--local",
         action="store_true",
@@ -218,16 +230,25 @@ def parse_args(args) -> Tuple[Optional[str], Optional[str], Namespace]:
         nargs="?",
         help="Prefix for git tag versions. Default: %(default)s",
     )
-    sign_parser.add_argument(
-        "--project",
-        help="The github project",
+    repo_group = sign_parser.add_argument_group(
+        "Repository",
+        description="Where to publish the new release. Either a full repository"
+        " name or a space/project combination.",
     )
-    sign_parser.add_argument(
+    repo_group.add_argument(
+        "--repository",
+        help="GitHub repository name (owner/name). For example "
+        "octocat/Hello-World",
+    )
+    repo_group.add_argument(
         "--space",
         default="greenbone",
-        help="user/team name in github",
+        help="Owner (User/Team/Organization) name at GitHub",
     )
-
+    repo_group.add_argument(
+        "--project",
+        help="The GitHub project",
+    )
     sign_parser.add_argument(
         "--passphrase",
         help=(

--- a/pontos/release/sign.py
+++ b/pontos/release/sign.py
@@ -8,7 +8,7 @@ import hashlib
 import subprocess
 from argparse import Namespace
 from asyncio.subprocess import Process
-from enum import IntEnum
+from enum import IntEnum, auto
 from os import PathLike
 from pathlib import Path
 from typing import AsyncContextManager, Optional, SupportsInt, Union
@@ -36,12 +36,12 @@ class SignReturnValue(IntEnum):
     """
 
     SUCCESS = 0
-    TOKEN_MISSING = 1
-    NO_PROJECT = 2
-    NO_RELEASE_VERSION = 3
-    NO_RELEASE = 4
-    UPLOAD_ASSET_ERROR = 5
-    SIGNATURE_GENERATION_FAILED = 6
+    TOKEN_MISSING = auto()
+    NO_PROJECT = auto()
+    NO_RELEASE_VERSION = auto()
+    NO_RELEASE = auto()
+    UPLOAD_ASSET_ERROR = auto()
+    SIGNATURE_GENERATION_FAILED = auto()
 
 
 class SignatureError(PontosError):

--- a/tests/release/test_helper.py
+++ b/tests/release/test_helper.py
@@ -17,6 +17,7 @@ from pontos.release.helper import (
     find_signing_key,
     get_git_repository_name,
     get_next_release_version,
+    repository_split,
 )
 from pontos.testing import temp_git_repository
 from pontos.version import VersionError
@@ -293,3 +294,24 @@ class GetNextReleaseVersionTestCase(unittest.TestCase):
                 release_type=ReleaseType.ALPHA,
                 release_version=release_version,
             )
+
+
+class RepositorySplitTestCase(unittest.TestCase):
+    def test_invalid_repository(self):
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Invalid repository foo/bar/baz. Format must be owner/name.",
+        ):
+            repository_split("foo/bar/baz")
+
+        with self.assertRaisesRegex(
+            ValueError,
+            r"Invalid repository foo_bar_baz. Format must be owner/name.",
+        ):
+            repository_split("foo_bar_baz")
+
+    def test_repository(self):
+        space, project = repository_split("foo/bar")
+
+        self.assertEqual(space, "foo")
+        self.assertEqual(project, "bar")

--- a/tests/release/test_sign.py
+++ b/tests/release/test_sign.py
@@ -80,6 +80,25 @@ class SignTestCase(unittest.TestCase):
 
             self.assertEqual(result, SignReturnValue.NO_RELEASE_VERSION)
 
+    def test_invalid_repository(self):
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                    "--repository",
+                    "foo_bar",
+                ]
+            )
+
+            result = sign(
+                terminal=mock_terminal(),
+                error_terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
+
+            self.assertEqual(result, SignReturnValue.INVALID_REPOSITORY)
+
     @patch("pontos.release.sign.get_last_release_version", autospec=True)
     def test_no_release_version(self, get_last_release_version_mock: MagicMock):
         get_last_release_version_mock.return_value = None
@@ -225,6 +244,114 @@ class SignTestCase(unittest.TestCase):
 
             github_releases_mock.upload_release_assets.assert_called_once_with(
                 "greenbone/foo",
+                "v1.2.3",
+                [
+                    (Path("file.zip.asc"), "application/pgp-signature"),
+                    (Path("file.tar.asc"), "application/pgp-signature"),
+                    (Path("file1.asc"), "application/pgp-signature"),
+                    (Path("file2.asc"), "application/pgp-signature"),
+                ],
+            )
+
+    @patch("pontos.release.sign.cmd_runner", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_asset", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_tar", autospec=True)
+    @patch("pontos.release.sign.SignCommand.download_zip", autospec=True)
+    @patch("pontos.release.sign.GitHubAsyncRESTApi.releases", autospec=True)
+    def test_sign_success_with_repository(
+        self,
+        github_releases_mock: AsyncMock,
+        download_zip_mock: AsyncMock,
+        download_tar_mock: AsyncMock,
+        download_asset_mock: AsyncMock,
+        cmd_runner_mock: AsyncMock,
+    ):
+        tar_file = Path("file.tar")
+        zip_file = Path("file.zip")
+        some_asset = Path("file1")
+        other_asset = Path("file2")
+        download_tar_mock.return_value = tar_file
+        download_zip_mock.return_value = zip_file
+        download_asset_mock.side_effect = [some_asset, other_asset]
+        github_releases_mock.exists = AsyncMock(return_value=True)
+        github_releases_mock.download_release_assets.return_value = (
+            AsyncIteratorMock(
+                [
+                    (
+                        "foo",
+                        MagicMock(),
+                    ),
+                    ("bar", MagicMock()),
+                ]
+            )
+        )
+        process = AsyncMock(spec=Process, returncode=0)
+        process.communicate.return_value = ("", "")
+        cmd_runner_mock.return_value = process
+
+        with temp_directory(change_into=True):
+            _, token, args = parse_args(
+                [
+                    "sign",
+                    "--repository",
+                    "foo/bar",
+                    "--release-version",
+                    "1.2.3",
+                ]
+            )
+
+            result = sign(
+                terminal=mock_terminal(),
+                error_terminal=mock_terminal(),
+                args=args,
+                token=token,
+            )
+
+            self.assertEqual(result, SignReturnValue.SUCCESS)
+
+            cmd_runner_mock.assert_has_calls(
+                [
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        zip_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        tar_file,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        some_asset,
+                    ),
+                    call(
+                        "gpg",
+                        "--default-key",
+                        "0ED1E580",
+                        "--yes",
+                        "--detach-sign",
+                        "--armor",
+                        other_asset,
+                    ),
+                ]
+            )
+
+            github_releases_mock.upload_release_assets.assert_called_once_with(
+                "foo/bar",
                 "v1.2.3",
                 [
                     (Path("file.zip.asc"), "application/pgp-signature"),


### PR DESCRIPTION
## What

Allow to pass `--repository` instead of `--space` and `--project` to `pontos-release` `create` and `sign`.

## Why

GitHub nearly always passes an "owner/name" combination for identifying the repository. Therefore we should support this pattern too. For example this is the only way to get the repo in an action from `${{ github.repository }}` via the [github context](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context)

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


