### PR TITLE
Remove: Replace `--space` and `--project` with `--repository` argument

### DIFF
--- a/pontos/changelog/_parser.py
+++ b/pontos/changelog/_parser.py
@@ -32,17 +32,10 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
     ).complete = shtab.FILE  # type: ignore[attr-defined]
 
     parser.add_argument(
-        "--project",
+        "--repository",
         required=True,
-        help="The github project. Used for building the links to the "
-        "repository.",
-    )
-
-    parser.add_argument(
-        "--space",
-        default="greenbone",
-        help="User/Team name in github. Used for building the links to the "
-        "repository",
+        help="The github repository (owner/name). Used for building the links "
+        "to the repository.",
     )
 
     parser.add_argument(

--- a/pontos/changelog/conventional_commits.py
+++ b/pontos/changelog/conventional_commits.py
@@ -51,7 +51,7 @@ class ConventionalCommits:
 
             from pontos.changelog import ConventionalCommits
 
-            collector = ConventionalCommits(space="my-org", project="my-project)
+            collector = ConventionalCommits()
             commits = collector.get_commits(
                 from_ref="v1.2.3",
                 to_ref="v2.0.0",
@@ -195,7 +195,7 @@ class ChangelogBuilder:
 
             from pontos.changelog import ChangelogBuilder
 
-            builder = ChangelogBuilder(space="my-org", project="my-project)
+            builder = ChangelogBuilder(repository="my-org/my-project)
             changelog = builder.create_changelog(
                 last_version="1.2.3",
                 next_version="2.0.0",
@@ -205,8 +205,7 @@ class ChangelogBuilder:
     def __init__(
         self,
         *,
-        space: str,
-        project: str,
+        repository: str,
         git_tag_prefix: Optional[str] = "v",
         config: Optional[Path] = None,
     ) -> None:
@@ -214,15 +213,13 @@ class ChangelogBuilder:
         Create a new ChangelogBuilder instance.
 
         Args:
-            space: GitHub space to use (organization or user name).
-            project: GitHub project to create a changelog for
+            repository: GitHub repository (owner/name) to create the changelog
+                for. For example: "octocat/Hello-World"
             git_tag_prefix: Git tag prefix to use when checking for git tags.
                 Default is "v".
             config: TOML config for conventional commit parsing settings
         """
-        self._project = project
-        self._space = space
-
+        self._repository = repository
         self._git_tag_prefix = git_tag_prefix
         self._conventional_commits = ConventionalCommits(config)
 
@@ -312,15 +309,14 @@ class ChangelogBuilder:
                 for log_entry in commit_dict[commit_type["group"]]:
                     commit_id, commit_message = log_entry
                     commit_link = (
-                        f"{ADDRESS}{self._space}/{self._project}/"
-                        f"commit/{commit_id}"
+                        f"{ADDRESS}{self._repository}/" f"commit/{commit_id}"
                     )
                     msg = f"{commit_message} [{commit_id}]({commit_link})"
                     changelog.append(f"* {msg}")
 
         # comparison line (footer)
         pre = "\n[Unreleased]: "
-        compare_link = f"{ADDRESS}{self._space}/{self._project}/compare/"
+        compare_link = f"{ADDRESS}{self._repository}/compare/"
         if next_version and last_version:
             pre = f"\n[{next_version}]: "
             diff = (

--- a/pontos/changelog/main.py
+++ b/pontos/changelog/main.py
@@ -31,8 +31,7 @@ def main(args: Optional[Sequence[str]] = None) -> NoReturn:
     try:
         changelog_builder = ChangelogBuilder(
             config=parsed_args.config,
-            project=parsed_args.project,
-            space=parsed_args.space,
+            repository=parsed_args.repository,
         )
         if parsed_args.output:
             changelog_builder.create_changelog_file(
@@ -46,9 +45,11 @@ def main(args: Optional[Sequence[str]] = None) -> NoReturn:
                 next_version=parsed_args.next_version,
             )
             term.out(changelog)
+    except KeyboardInterrupt:
+        sys.exit(1)
     except PontosError as e:
         term.error(str(e))
-        sys.exit(1)
+        sys.exit(2)
 
     sys.exit(0)
 

--- a/tests/changelog/test_conventional_commits.py
+++ b/tests/changelog/test_conventional_commits.py
@@ -73,8 +73,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 [0.0.2]: https://github.com/foo/bar/compare/v0.0.1...v0.0.2"""
 
         changelog_builder = ChangelogBuilder(
-            space="foo",
-            project="bar",
+            repository="foo/bar",
             config=config_toml,
         )
         changelog = changelog_builder.create_changelog(
@@ -100,8 +99,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
         git_mock.return_value.log.return_value = []
 
         changelog_builder = ChangelogBuilder(
-            space="foo",
-            project="bar",
+            repository="foo/bar",
             config=config_toml,
         )
         changelog = changelog_builder.create_changelog(
@@ -162,8 +160,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 [0.0.2]: https://github.com/foo/bar/compare/123...v0.0.2"""
 
         changelog_builder = ChangelogBuilder(
-            project="bar",
-            space="foo",
+            repository="foo/bar",
             config=config_toml,
         )
         changelog = changelog_builder.create_changelog(next_version="0.0.2")
@@ -218,8 +215,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 [Unreleased]: https://github.com/foo/bar/compare/v0.0.1...HEAD"""
 
         changelog_builder = ChangelogBuilder(
-            project="bar",
-            space="foo",
+            repository="foo/bar",
             config=config_toml,
         )
         changelog = changelog_builder.create_changelog(last_version="0.0.1")
@@ -278,8 +274,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 [Unreleased]: https://github.com/foo/bar/compare/123...HEAD"""
 
         changelog_builder = ChangelogBuilder(
-            project="bar",
-            space="foo",
+            repository="foo/bar",
             config=config_toml,
         )
         changelog = changelog_builder.create_changelog()
@@ -306,8 +301,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
             "8abcdef bar baz",
         ]
         changelog_builder = ChangelogBuilder(
-            space="foo",
-            project="bar",
+            repository="foo/bar",
             config=config_toml,
         )
         changelog = changelog_builder.create_changelog(
@@ -329,8 +323,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
             ),
         ):
             ChangelogBuilder(
-                space="foo",
-                project="bar",
+                repository="foo/bar",
                 config=temp_dir / "changelog.toml",
             )
 
@@ -355,8 +348,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
         ]
 
         changelog_builder = ChangelogBuilder(
-            space="foo",
-            project="bar",
+            repository="foo/bar",
         )
         expected_output = f"""## [0.0.2] - {today}
 
@@ -407,8 +399,7 @@ class ChangelogBuilderTestCase(unittest.TestCase):
         ]
 
         changelog_builder = ChangelogBuilder(
-            space="foo",
-            project="bar",
+            repository="foo/bar",
             git_tag_prefix="",
         )
         expected_output = f"""## [0.0.2] - {today}
@@ -485,7 +476,8 @@ class ChangelogBuilderTestCase(unittest.TestCase):
 [0.0.2]: https://github.com/foo/bar/compare/v0.0.1...v0.0.2"""
 
         changelog_builder = ChangelogBuilder(
-            space="foo", project="bar", config=config_toml
+            repository="foo/bar",
+            config=config_toml,
         )
 
         with temp_directory() as temp_dir:

--- a/tests/changelog/test_parser.py
+++ b/tests/changelog/test_parser.py
@@ -14,10 +14,8 @@ class ParseArgsTestCase(unittest.TestCase):
         parsed_args = parse_args(
             [
                 "-q",
-                "--project",
-                "urghs",
-                "--space",
-                "bla",
+                "--repository",
+                "urghs/bla",
                 "--config",
                 "foo.toml",
                 "--current-version",
@@ -32,8 +30,7 @@ class ParseArgsTestCase(unittest.TestCase):
         )
 
         self.assertTrue(parsed_args.quiet)
-        self.assertEqual(parsed_args.project, "urghs")
-        self.assertEqual(parsed_args.space, "bla")
+        self.assertEqual(parsed_args.repository, "urghs/bla")
         self.assertEqual(parsed_args.config, Path("foo.toml"))
         self.assertEqual(parsed_args.current_version, PEP440Version("1.2.3"))
         self.assertEqual(parsed_args.next_version, PEP440Version("2.3.4"))

--- a/tests/release/test_create.py
+++ b/tests/release/test_create.py
@@ -185,8 +185,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.2",
                 "--next-version",
@@ -397,8 +397,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "1.0.0",
             ]
@@ -501,8 +501,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "patch",
                 "--next-version",
@@ -614,8 +614,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "calendar",
             ]
@@ -727,8 +727,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "minor",
                 "--next-version",
@@ -839,8 +839,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "major",
                 "--next-version",
@@ -951,8 +951,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "alpha",
             ]
@@ -1063,8 +1063,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "beta",
             ]
@@ -1175,8 +1175,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "release-candidate",
             ]
@@ -1247,8 +1247,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, _, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.1",
             ]
@@ -1270,11 +1270,13 @@ class CreateReleaseTestCase(unittest.TestCase):
             [
                 "release",
                 "--repository",
-                "foo/bar/baz",
+                "foo/bar",
                 "--release-version",
                 "0.0.1",
             ]
         )
+
+        setattr(args, "repository", "foo/bar/baz")
 
         released = create_release(
             terminal=mock_terminal(),
@@ -1289,11 +1291,13 @@ class CreateReleaseTestCase(unittest.TestCase):
             [
                 "release",
                 "--repository",
-                "foo_bar_baz",
+                "foo/bar",
                 "--release-version",
                 "0.0.1",
             ]
         )
+
+        setattr(args, "repository", "foo_bar_baz")
 
         released = create_release(
             terminal=mock_terminal(),
@@ -1315,8 +1319,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.1",
             ]
@@ -1362,8 +1366,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.2",
                 "--next-version",
@@ -1406,8 +1410,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "major",
             ]
@@ -1433,8 +1437,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "minor",
             ]
@@ -1468,8 +1472,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--git-signing-key",
                 "123",
                 "--release-type",
@@ -1503,8 +1507,8 @@ class CreateReleaseTestCase(unittest.TestCase):
                 "release",
                 "--release-version",
                 "1.0.1",
-                "--project",
-                "bla",
+                "--repository",
+                "greenbone/bla",
             ]
         )
 
@@ -1544,8 +1548,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.1",
                 "--next-version",
@@ -1628,8 +1632,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.1",
                 "--next-version",
@@ -1707,8 +1711,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.1",
                 "--next-version",
@@ -1799,8 +1803,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.1",
                 "--next-version",
@@ -1898,8 +1902,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.1",
                 "--next-version",
@@ -1994,10 +1998,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--space",
-                "bar",
-                "--project",
-                "foo",
+                "--repository",
+                "bar/foo",
                 "--release-version",
                 "0.0.1",
                 "--next-version",
@@ -2095,10 +2097,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--space",
-                "bar",
-                "--project",
-                "foo",
+                "--repository",
+                "bar/foo",
                 "--release-version",
                 "0.0.1a1",
                 "--next-version",
@@ -2177,7 +2177,9 @@ class CreateReleaseTestCase(unittest.TestCase):
             StatusEntry(f"M  {GoVersionCommand.version_file_path}")
         ]
 
-        _, token, args = parse_args(["release", "--release-type", "patch"])
+        _, token, args = parse_args(
+            ["release", "--repository", "foo/bar", "--release-type", "patch"]
+        )
 
         with setup_go_project(current_version="0.0.1", tags=["0.0.1"]):
             released = create_release(
@@ -2279,8 +2281,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.2",
                 "--next-version",
@@ -2395,8 +2397,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-version",
                 "0.0.1",
                 "--next-version",
@@ -2483,8 +2485,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "patch",
                 "--next-version",
@@ -2589,8 +2591,8 @@ class CreateReleaseTestCase(unittest.TestCase):
         _, token, args = parse_args(
             [
                 "release",
-                "--project",
-                "foo",
+                "--repository",
+                "greenbone/foo",
                 "--release-type",
                 "patch",
                 "--no-next-version",
@@ -2732,7 +2734,13 @@ class ReleaseGoProjectTestCase(unittest.TestCase):
                 current_version=r.current_version, tags=r.tags
             ):
                 _, token, args = parse_args(
-                    ["release", "--release-type", r.release_type]
+                    [
+                        "release",
+                        "--repository",
+                        "foo/bar",
+                        "--release-type",
+                        r.release_type,
+                    ]
                 )
                 released = create_release(
                     terminal=mock_terminal(),
@@ -2898,7 +2906,13 @@ class ReleaseGoProjectTestCase(unittest.TestCase):
             with setup_go_project(
                 current_version=r.current_version, tags=r.tags
             ):
-                input_args = ["release", "--release-type", r.release_type]
+                input_args = [
+                    "release",
+                    "--repository",
+                    "foo/bar",
+                    "--release-type",
+                    r.release_type,
+                ]
                 if r.release_series:
                     input_args.extend(["--release-series", r.release_series])
 

--- a/tests/release/test_parser.py
+++ b/tests/release/test_parser.py
@@ -51,7 +51,6 @@ class CreateParseArgsTestCase(unittest.TestCase):
         _, _, args = parse_args(["create", "--release-type", "patch"])
 
         self.assertEqual(args.git_tag_prefix, "v")
-        self.assertEqual(args.space, "greenbone")
         self.assertFalse(args.local)
         self.assertFalse(args.github_pre_release)
 
@@ -88,19 +87,29 @@ class CreateParseArgsTestCase(unittest.TestCase):
 
         self.assertEqual(args.git_tag_prefix, "")
 
-    def test_space(self):
+    def test_repository(self):
         _, _, args = parse_args(
-            ["create", "--space", "foo", "--release-type", "patch"]
+            ["create", "--repository", "foo/bar", "--release-type", "patch"]
         )
 
-        self.assertEqual(args.space, "foo")
+        self.assertEqual(args.repository, "foo/bar")
 
-    def test_project(self):
-        _, _, args = parse_args(
-            ["create", "--project", "foo", "--release-type", "patch"]
-        )
+    def test_invalid_repository(self):
+        with redirect_stderr(StringIO()), self.assertRaises(SystemExit):
+            parse_args(
+                ["create", "--repository", "foo_bar", "--release-type", "patch"]
+            )
 
-        self.assertEqual(args.project, "foo")
+        with redirect_stderr(StringIO()), self.assertRaises(SystemExit):
+            parse_args(
+                [
+                    "sign",
+                    "--repository",
+                    "foo/bar/baz",
+                    "--release-type",
+                    "patch",
+                ]
+            )
 
     def test_next_version(self):
         _, _, args = parse_args(
@@ -124,7 +133,7 @@ class CreateParseArgsTestCase(unittest.TestCase):
                     "--release-type",
                     "patch",
                     "--no-next-version",
-                    "--next-verson",
+                    "--next-version",
                     "1.2.3",
                 ]
             )
@@ -275,18 +284,19 @@ class SignParseArgsTestCase(unittest.TestCase):
         _, _, args = parse_args(["sign"])
 
         self.assertEqual(args.git_tag_prefix, "v")
-        self.assertEqual(args.space, "greenbone")
         self.assertEqual(args.signing_key, DEFAULT_SIGNING_KEY)
 
-    def test_space(self):
-        _, _, args = parse_args(["sign", "--space", "foo"])
+    def test_repository(self):
+        _, _, args = parse_args(["sign", "--repository", "foo/bar"])
 
-        self.assertEqual(args.space, "foo")
+        self.assertEqual(args.repository, "foo/bar")
 
-    def test_project(self):
-        _, _, args = parse_args(["sign", "--project", "foo"])
+    def test_invalid_repository(self):
+        with redirect_stderr(StringIO()), self.assertRaises(SystemExit):
+            parse_args(["sign", "--repository", "foo_bar"])
 
-        self.assertEqual(args.project, "foo")
+        with redirect_stderr(StringIO()), self.assertRaises(SystemExit):
+            parse_args(["sign", "--repository", "foo/bar/baz"])
 
     def test_release_version(self):
         _, _, args = parse_args(["sign", "--release-version", "1.2.3"])


### PR DESCRIPTION


## What

Replace `--space` and `--project` with `--repository` argument

## Why

Drop the `--space` and `--project` in favor of the single `--repository` argument.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


