### PR TITLE
Add: `multiline_output` for github actions

### DIFF
--- a/pontos/github/actions/core.py
+++ b/pontos/github/actions/core.py
@@ -4,6 +4,7 @@
 #
 
 import os
+import uuid
 from contextlib import contextmanager
 from io import TextIOWrapper
 from pathlib import Path
@@ -286,6 +287,37 @@ class ActionIO:
 
         with Path(output_filename).open("a", encoding="utf8") as f:
             f.write(f"{name}={value}\n")
+
+    @staticmethod
+    def multiline_output(name: str, value: SupportsStr):
+        """
+        Set an multiline action output
+
+        An action output can be consumed by another job
+
+        Example:
+            .. code-block:: python
+
+                from pontos.github.actions import ActionIO
+
+                ActionIO.output("foo", "bar")
+
+        Args:
+            name: Name of the output variable
+            value: Value of the output variable
+        """
+        output_filename = os.environ.get("GITHUB_OUTPUT")
+        if not output_filename:
+            raise GitHubActionsError(
+                "GITHUB_OUTPUT environment variable not set. Can't write "
+                "action output."
+            )
+
+        with Path(output_filename).open("a", encoding="utf8") as f:
+            delimiter = uuid.uuid1()
+            f.write(f"{name}<<{delimiter}")
+            f.write(f"{value}")
+            f.write(str(delimiter))
 
     @staticmethod
     def input(name: str, default: Optional[str] = None) -> Optional[str]:

--- a/tests/github/actions/test_core.py
+++ b/tests/github/actions/test_core.py
@@ -107,6 +107,27 @@ class ActionIOTestCase(unittest.TestCase):
 
                 self.assertEqual(output, "foo=bar\nlorem=ipsum\n")
 
+    @patch("uuid.uuid1")
+    def test_multiline_output(self, uuid_mock):
+        deadbeef = "deadbeef"
+        name = "foo"
+        ml_string = """bar
+baz
+boing"""
+        expected_output = f"{name}<<{deadbeef}{ml_string}{deadbeef}"
+        uuid_mock.return_value = deadbeef
+        with temp_directory() as temp_dir:
+            file_path = temp_dir / "github.output"
+
+            with patch.dict(
+                "os.environ", {"GITHUB_OUTPUT": str(file_path)}, clear=True
+            ):
+                ActionIO.multiline_output("foo", ml_string)
+
+                output = file_path.read_text(encoding="utf8")
+
+                self.assertEqual(output, expected_output)
+
     @patch.dict("os.environ", {}, clear=True)
     def test_output_no_env(self):
         with self.assertRaises(GitHubActionsError):


### PR DESCRIPTION
## What
add `multiline_output` for github actions

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
using this, makes it possible to store multiline values to a github action output
<!-- Describe why are these changes necessary? -->

## References
none
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


