### PR TITLE
Update header

### DIFF
--- a/pontos/testing/__init__.py
+++ b/pontos/testing/__init__.py
@@ -11,7 +11,15 @@ import os
 import tempfile
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Any, AsyncIterator, Awaitable, Generator, Iterable, Optional
+from typing import (
+    Any,
+    AsyncIterator,
+    Awaitable,
+    Generator,
+    Iterable,
+    Optional,
+    Union,
+)
 
 from pontos.git._git import exec_git
 from pontos.helper import add_sys_path, ensure_unload_module, unload_module
@@ -136,7 +144,7 @@ def temp_git_repository(
 
 @contextmanager
 def temp_file(
-    content: Optional[str] = None,
+    content: Optional[Union[str, bytes]] = None,
     *,
     name: str = "test.toml",
     change_into: bool = False,
@@ -166,7 +174,10 @@ def temp_file(
     with temp_directory(change_into=change_into) as tmp_dir:
         test_file = tmp_dir / name
         if content:
-            test_file.write_text(content, encoding="utf8")
+            if isinstance(content, bytes):
+                test_file.write_bytes(content)
+            else:
+                test_file.write_text(content, encoding="utf8")
         else:
             test_file.touch()
 

--- a/pontos/updateheader/_parser.py
+++ b/pontos/updateheader/_parser.py
@@ -47,7 +47,8 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
         default=False,
         help=(
             "Update modified year using git log modified year. "
-            "This will not changed all files to current year!"
+            "Used instead of --year. If the modified year could not be "
+            "determined via git it falls back to --year."
         ),
     )
     date_group.add_argument(
@@ -56,7 +57,7 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
         default=str(datetime.now().year),
         help=(
             "If year is set, modified year will be "
-            "set to the specified year."
+            "set to the specified year. Default is %(default)s."
         ),
     )
 
@@ -66,7 +67,7 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
         dest="license_id",
         choices=SUPPORTED_LICENSES,
         default="GPL-3.0-or-later",
-        help=("Use the passed license type"),
+        help="Use the passed license type. Default is %(default)s",
     )
 
     parser.add_argument(
@@ -74,7 +75,7 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
         default="Greenbone AG",
         help=(
             "If a header will be added to file, "
-            "it will be licensed by company."
+            "it will be licensed by company. Default is %(default)s"
         ),
     )
 

--- a/pontos/updateheader/_parser.py
+++ b/pontos/updateheader/_parser.py
@@ -39,8 +39,7 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
         help="Activate logging using the given file path",
     ).complete = shtab.FILE  # type: ignore[attr-defined]
 
-    date_group = parser.add_mutually_exclusive_group()
-    date_group.add_argument(
+    parser.add_argument(
         "-c",
         "--changed",
         action="store_true",
@@ -51,7 +50,7 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
             "determined via git it falls back to --year."
         ),
     )
-    date_group.add_argument(
+    parser.add_argument(
         "-y",
         "--year",
         default=str(datetime.now().year),

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -12,7 +12,7 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List, Optional, Tuple, Union
+from typing import Optional, Union
 
 from pontos.errors import PontosError
 from pontos.git import Git
@@ -78,7 +78,7 @@ class CopyrightMatch:
 def _find_copyright(
     line: str,
     copyright_regex: re.Pattern,
-) -> Tuple[bool, Union[CopyrightMatch, None]]:
+) -> tuple[bool, Union[CopyrightMatch, None]]:
     """Match the line for the copyright_regex"""
     copyright_match = re.search(copyright_regex, line)
     if copyright_match:
@@ -117,7 +117,7 @@ def _add_header(
 
 
 def _remove_outdated_lines(
-    content: str, cleanup_regexes: List[re.Pattern]
+    content: str, cleanup_regexes: list[re.Pattern]
 ) -> Optional[str]:
     """Remove lines that contain outdated copyright header ..."""
     changed = False
@@ -145,7 +145,7 @@ def update_file(
     year: str,
     license_id: str,
     company: str,
-    cleanup_regexes: Optional[List[re.Pattern]] = None,
+    cleanup_regexes: Optional[list[re.Pattern]] = None,
 ) -> None:
     """Function to update the header of the given file
 
@@ -286,7 +286,7 @@ def _compile_outdated_regex() -> list[re.Pattern]:
     return [re.compile(rf"^(([#*]|//) ?)?{line}") for line in OLD_LINES]
 
 
-def _compile_copyright_regex(company: Union[str, List[str]]) -> re.Pattern:
+def _compile_copyright_regex(company: Union[str, list[str]]) -> re.Pattern:
     """prepare the copyright regex"""
     c_str = r"(SPDX-FileCopyrightText:|[Cc]opyright)"
     d_str = r"(19[0-9]{2}|20[0-9]{2})"
@@ -340,7 +340,7 @@ def main() -> None:
         term.error("Specify files to update!")
         sys.exit(1)
 
-    cleanup_regexes: Optional[List[re.Pattern]] = None
+    cleanup_regexes: Optional[list[re.Pattern]] = None
     if cleanup:
         cleanup_regexes = _compile_outdated_regex()
 

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -245,8 +245,8 @@ def update_file(
 
 
 def _get_exclude_list(
-    exclude_file: Path, directories: List[Path]
-) -> List[Path]:
+    exclude_file: Path, directories: list[Path]
+) -> list[Path]:
     """Tries to get the list of excluded files / directories.
     If a file is given, it will be used. Otherwise it will be searched
     in the executed root path.
@@ -256,11 +256,11 @@ def _get_exclude_list(
 
     if exclude_file is None:
         exclude_file = Path(".pontos-header-ignore")
-    try:
-        exclude_lines = exclude_file.read_text(encoding="utf-8").split("\n")
-    except FileNotFoundError:
-        print("No exclude list file found.")
+
+    if not exclude_file.is_file():
         return []
+
+    exclude_lines = exclude_file.read_text(encoding="utf-8").splitlines()
 
     expanded_globs = [
         directory.rglob(line.strip())

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -12,9 +12,10 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from subprocess import CalledProcessError, run
 from typing import List, Optional, Tuple, Union
 
+from pontos.errors import PontosError
+from pontos.git import Git
 from pontos.terminal.null import NullTerminal
 from pontos.terminal.rich import RichTerminal
 
@@ -64,18 +65,7 @@ OLD_COMPANY = "Greenbone Networks GmbH"
 
 def _get_modified_year(f: Path) -> str:
     """In case of the changed arg, update year to last modified year"""
-    try:
-        cmd = ["git", "log", "-1", "--format=%ad", "--date=format:%Y", str(f)]
-        proc = run(
-            cmd,
-            text=True,
-            capture_output=True,
-            check=True,
-            universal_newlines=True,
-        )
-        return proc.stdout.rstrip()
-    except CalledProcessError as e:
-        raise e
+    return Git().log("-1", "--date=format:%Y", str(f), format="%ad")[0]
 
 
 @dataclass
@@ -363,7 +353,7 @@ def main() -> None:
         if changed:
             try:
                 year = _get_modified_year(file)
-            except CalledProcessError:
+            except PontosError:
                 term.warning(
                     f"{file}: Could not get date of last modification"
                     f" using git, using {year} instead."

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -145,7 +145,6 @@ def update_file(
     year: str,
     license_id: str,
     company: str,
-    copyright_regex: re.Pattern,
     cleanup_regexes: Optional[List[re.Pattern]] = None,
 ) -> None:
     """Function to update the header of the given file
@@ -153,6 +152,9 @@ def update_file(
     Checks if header exists. If not it adds an header to that file, otherwise it
     checks if year is up to date
     """
+
+    copyright_regex = _compile_copyright_regex(company=[company, OLD_COMPANY])
+
     try:
         with file.open("r+") as fp:
             found = False
@@ -341,10 +343,6 @@ def main() -> None:
         term.error("Specify files to update!")
         sys.exit(1)
 
-    copyright_regex: re.Pattern = _compile_copyright_regex(
-        company=[parsed_args.company, OLD_COMPANY]
-    )
-
     cleanup_regexes: Optional[List[re.Pattern]] = None
     if cleanup:
         cleanup_regexes = _compile_outdated_regex()
@@ -368,7 +366,6 @@ def main() -> None:
                     year,
                     license_id,
                     company,
-                    copyright_regex,
                     cleanup_regexes,
                 )
         except (FileNotFoundError, UnicodeDecodeError, ValueError):

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -145,7 +145,8 @@ def update_file(
     year: str,
     license_id: str,
     company: str,
-    cleanup_regexes: Optional[list[re.Pattern]] = None,
+    *,
+    cleanup: bool = False,
 ) -> None:
     """Function to update the header of the given file
 
@@ -154,6 +155,7 @@ def update_file(
     """
 
     copyright_regex = _compile_copyright_regex(company=[company, OLD_COMPANY])
+    cleanup_regexes = _compile_outdated_regex() if cleanup else None
 
     try:
         with file.open("r+") as fp:
@@ -340,10 +342,6 @@ def main() -> None:
         term.error("Specify files to update!")
         sys.exit(1)
 
-    cleanup_regexes: Optional[list[re.Pattern]] = None
-    if cleanup:
-        cleanup_regexes = _compile_outdated_regex()
-
     for file in files:
         if changed:
             try:
@@ -363,7 +361,7 @@ def main() -> None:
                     year,
                     license_id,
                     company,
-                    cleanup_regexes,
+                    cleanup=cleanup,
                 )
         except (FileNotFoundError, UnicodeDecodeError, ValueError):
             continue

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -281,12 +281,9 @@ def _get_exclude_list(
     return exclude_list
 
 
-def _compile_outdated_regex() -> List[re.Pattern]:
+def _compile_outdated_regex() -> list[re.Pattern]:
     """prepare regex patterns to remove old copyright lines"""
-    regexes: List[re.Pattern] = []
-    for line in OLD_LINES:
-        regexes.append(re.compile(rf"^(([#*]|//) ?)?{line}"))
-    return regexes
+    return [re.compile(rf"^(([#*]|//) ?)?{line}") for line in OLD_LINES]
 
 
 def _compile_copyright_regex(company: Union[str, List[str]]) -> re.Pattern:

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -12,7 +12,7 @@ import re
 import sys
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Optional, Union
+from typing import Optional, Sequence, Union
 
 from pontos.errors import PontosError
 from pontos.git import Git
@@ -298,8 +298,8 @@ def _compile_copyright_regex(company: Union[str, list[str]]) -> re.Pattern:
     return re.compile(rf"{c_str}.*? {d_str}?-? ?{d_str}? ({'|'.join(company)})")
 
 
-def main() -> None:
-    parsed_args = parse_args()
+def main(args: Optional[Sequence[str]] = None) -> None:
+    parsed_args = parse_args(args)
     exclude_list = []
     year: str = parsed_args.year
     license_id: str = parsed_args.license_id
@@ -349,7 +349,7 @@ def main() -> None:
             except PontosError:
                 term.warning(
                     f"{file}: Could not get date of last modification"
-                    f" using git, using {year} instead."
+                    f" via git, using {year} instead."
                 )
 
         try:

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -60,7 +60,6 @@ OLD_LINES = [
     "along with this program; if not, write to the Free Software",
     "Foundation, Inc\., 51 Franklin St, Fifth Floor, Boston, MA 02110\-1301 USA\.",  # noqa: E501
 ]
-OLD_COMPANY = "Greenbone Networks GmbH"
 
 
 def _get_modified_year(f: Path) -> str:
@@ -154,7 +153,7 @@ def update_file(
     checks if year is up to date
     """
 
-    copyright_regex = _compile_copyright_regex(company=[company, OLD_COMPANY])
+    copyright_regex = _compile_copyright_regex()
     cleanup_regexes = _compile_outdated_regex() if cleanup else None
 
     try:
@@ -288,14 +287,12 @@ def _compile_outdated_regex() -> list[re.Pattern]:
     return [re.compile(rf"^(([#*]|//) ?)?{line}") for line in OLD_LINES]
 
 
-def _compile_copyright_regex(company: Union[str, list[str]]) -> re.Pattern:
+def _compile_copyright_regex() -> re.Pattern:
     """prepare the copyright regex"""
     c_str = r"(SPDX-FileCopyrightText:|[Cc]opyright)"
     d_str = r"(19[0-9]{2}|20[0-9]{2})"
 
-    if isinstance(company, str):
-        return re.compile(rf"{c_str}.*? {d_str}?-? ?{d_str}? ({company})")
-    return re.compile(rf"{c_str}.*? {d_str}?-? ?{d_str}? ({'|'.join(company)})")
+    return re.compile(rf"{c_str}.*? {d_str}?-? ?{d_str}? (.+)")
 
 
 def main(args: Optional[Sequence[str]] = None) -> None:

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -11,6 +11,7 @@ Also it appends a header if it is missing in the file.
 import re
 import sys
 from dataclasses import dataclass
+from functools import cache
 from pathlib import Path
 from typing import Optional, Sequence, Union
 
@@ -282,11 +283,13 @@ def _get_exclude_list(
     return exclude_list
 
 
+@cache
 def _compile_outdated_regex() -> list[re.Pattern]:
     """prepare regex patterns to remove old copyright lines"""
     return [re.compile(rf"^(([#*]|//) ?)?{line}") for line in OLD_LINES]
 
 
+@cache
 def _compile_copyright_regex() -> re.Pattern:
     """prepare the copyright regex"""
     c_str = r"(SPDX-FileCopyrightText:|[Cc]opyright)"

--- a/tests/testing/test_testing.py
+++ b/tests/testing/test_testing.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+import struct
 import unittest
 from pathlib import Path
 
@@ -106,6 +107,14 @@ class TempFileTestCase(unittest.TestCase):
         with temp_file("my content") as test_file:
             self.assertTrue(test_file.exists())
             self.assertEqual("my content", test_file.read_text(encoding="utf8"))
+
+        self.assertFalse(test_file.exists())
+
+    def test_temp_binary_file(self):
+        data = struct.pack(">if", 42, 2.71828182846)
+        with temp_file(data) as test_file:
+            self.assertTrue(test_file.exists())
+            self.assertEqual(data, test_file.read_bytes())
 
         self.assertFalse(test_file.exists())
 

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -430,6 +430,16 @@ class ParseArgsTestCase(TestCase):
         self.assertIsNone(args.exclude_file)
         self.assertFalse(args.cleanup)
 
+    def test_files_and_directories_mutual_exclusive(self):
+        args = ["--files", "foo", "--directories", "bar"]
+        with self.assertRaises(SystemExit) as cm:
+            args = parse_args(args)
+
+            self.assertIn(
+                "argument -d/--directories: not allowed with argument -f/--file",
+                cm.msg,
+            )
+
 
 class GetExcludeListTestCase(TestCase):
     def test_get_exclude_list(self):

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -427,53 +427,24 @@ foo.baz(bar.boing)
 
 
 class ParseArgsTestCase(TestCase):
-    def setUp(self) -> None:
-        self.args = Namespace()
-        self.args.company = "Greenbone AG"
-
     def test_argparser_files(self):
-        self.args.year = "2021"
-        self.args.changed = False
-        self.args.license_id = "AGPL-3.0-or-later"
-
         args = ["-f", "test.py", "-y", "2021", "-l", "AGPL-3.0-or-later"]
-
         args = parse_args(args)
-        self.assertIsNotNone(args)
-        self.assertEqual(args.company, self.args.company)
+
+        self.assertEqual(args.company, "Greenbone AG")
         self.assertEqual(args.files, ["test.py"])
-        self.assertEqual(args.year, self.args.year)
-        self.assertEqual(args.license_id, self.args.license_id)
+        self.assertEqual(args.year, "2021")
+        self.assertEqual(args.license_id, "AGPL-3.0-or-later")
 
     def test_argparser_dir(self):
-        self.args.year = "2020"
-        self.args.changed = False
-        self.args.license_id = "AGPL-3.0-or-later"
-
         args = ["-d", ".", "-c", "-l", "AGPL-3.0-or-later"]
-
         args = parse_args(args)
-        self.assertIsNotNone(args)
-        self.assertEqual(args.company, self.args.company)
+
         self.assertEqual(args.directories, ["."])
+        self.assertEqual(args.company, "Greenbone AG")
         self.assertTrue(args.changed)
         self.assertEqual(args.year, str(datetime.datetime.now().year))
-        self.assertEqual(args.license_id, self.args.license_id)
-
-    def test_get_exclude_list(self):
-        # Try to find the current file from two directories up...
-        test_dirname = Path(__file__).parent.parent.parent
-        # with a relative glob
-        test_ignore_file = Path("ignore.file")
-        test_ignore_file.write_text("*.py\n", encoding="utf-8")
-
-        exclude_list = get_exclude_list(
-            test_ignore_file, [test_dirname.resolve()]
-        )
-
-        self.assertIn(Path(__file__), exclude_list)
-
-        test_ignore_file.unlink()
+        self.assertEqual(args.license_id, "AGPL-3.0-or-later")
 
     def test_defaults(self):
         args = ["-f", "foo.txt"]
@@ -489,6 +460,23 @@ class ParseArgsTestCase(TestCase):
         self.assertIsNone(args.directories)
         self.assertIsNone(args.exclude_file)
         self.assertFalse(args.cleanup)
+
+
+class GetExcludeListTestCase(TestCase):
+    def test_get_exclude_list(self):
+        # Try to find the current file from two directories up...
+        test_dirname = Path(__file__).parent.parent.parent
+        # with a relative glob
+        test_ignore_file = Path("ignore.file")
+        test_ignore_file.write_text("*.py\n", encoding="utf-8")
+
+        exclude_list = get_exclude_list(
+            test_ignore_file, [test_dirname.resolve()]
+        )
+
+        self.assertIn(Path(__file__), exclude_list)
+
+        test_ignore_file.unlink()
 
 
 class MainTestCase(TestCase):

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -13,7 +13,6 @@ from unittest import TestCase
 from unittest.mock import MagicMock, patch
 
 from pontos.errors import PontosError
-from pontos.terminal.terminal import ConsoleTerminal
 from pontos.testing import temp_directory, temp_file
 from pontos.updateheader.updateheader import _add_header as add_header
 from pontos.updateheader.updateheader import (
@@ -39,15 +38,6 @@ from pontos.updateheader.updateheader import (
 HEADER = """# SPDX-FileCopyrightText: {date} Greenbone AG
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later"""
-
-
-_here_ = Path(__file__).parent
-
-
-class Terminal(ConsoleTerminal):
-    @staticmethod
-    def get_width() -> int:
-        return 999
 
 
 class GetModifiedYearTestCase(TestCase):

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -64,7 +64,7 @@ class GetModifiedYearTestCase(TestCase):
 class FindCopyRightTestCase(TestCase):
     def setUp(self) -> None:
         self.company = "Greenbone AG"
-        self.regex = _compile_copyright_regex(self.company)
+        self.regex = _compile_copyright_regex()
 
     def test_find_copyright(self):
         test_line = "# Copyright (C) 1995-2021 Greenbone AG"
@@ -420,6 +420,46 @@ foo.baz(bar.boing)
 """  # noqa: E501
 
         company = "Greenbone AG"
+        year = str(datetime.datetime.now().year)
+        license_id = "GPL-3.0-or-later"
+
+        with temp_file(content=test_content, name="foo.py") as tmp:
+
+            update_file(
+                tmp,
+                year,
+                license_id,
+                company,
+                cleanup=True,
+            )
+
+            new_content = tmp.read_text(encoding="utf-8")
+            self.assertEqual(expected_content, new_content)
+
+    def test_cleanup_file_changed_company(self):
+        test_content = """
+# SPDX-FileCopyrightText: 2021 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import foo
+import bar
+
+foo.baz(bar.boing)
+"""  # noqa: E501
+
+        expected_content = f"""
+# SPDX-FileCopyrightText: 2021-{str(datetime.datetime.now().year)} ACME Inc.
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import foo
+import bar
+
+foo.baz(bar.boing)
+"""  # noqa: E501
+
+        company = "ACME Inc."
         year = str(datetime.datetime.now().year)
         license_id = "GPL-3.0-or-later"
 

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -4,7 +4,6 @@
 #
 
 import datetime
-import re
 import struct
 from argparse import Namespace
 from contextlib import redirect_stdout
@@ -16,14 +15,13 @@ from unittest.mock import MagicMock, patch
 from pontos.errors import PontosError
 from pontos.terminal.terminal import ConsoleTerminal
 from pontos.testing import temp_directory, temp_file
+from pontos.updateheader.updateheader import _add_header as add_header
 from pontos.updateheader.updateheader import (
-    OLD_COMPANY,
     _compile_copyright_regex,
     main,
     parse_args,
     update_file,
 )
-from pontos.updateheader.updateheader import _add_header as add_header
 from pontos.updateheader.updateheader import (
     _compile_outdated_regex as compile_outdated_regex,
 )
@@ -74,12 +72,9 @@ class GetModifiedYearTestCase(TestCase):
 
 
 class FindCopyRightTestCase(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         self.company = "Greenbone AG"
-        self.regex = re.compile(
-            "(SPDX-FileCopyrightText:|[Cc]opyright).*?(19[0-9]{2}|20[0-9]{2}) "
-            f"?-? ?(19[0-9]{{2}}|20[0-9]{{2}})? ({self.company})"
-        )
+        self.regex = _compile_copyright_regex(self.company)
 
     def test_find_copyright(self):
         test_line = "# Copyright (C) 1995-2021 Greenbone AG"
@@ -193,11 +188,6 @@ class UpdateFileTestCase(TestCase):
 
         self.path = Path(__file__).parent
 
-        self.regex = re.compile(
-            "(SPDX-FileCopyrightText:|[Cc]opyright).*?(19[0-9]{2}|20[0-9]{2}) "
-            f"?-? ?(19[0-9]{{2}}|20[0-9]{{2}})? ({self.company})"
-        )
-
     @patch("sys.stdout", new_callable=StringIO)
     def test_update_file_not_existing(self, mock_stdout):
         year = "2020"
@@ -212,7 +202,6 @@ class UpdateFileTestCase(TestCase):
                     year,
                     license_id,
                     self.company,
-                    copyright_regex=self.regex,
                 )
 
             ret = mock_stdout.getvalue()
@@ -232,7 +221,6 @@ class UpdateFileTestCase(TestCase):
                 year,
                 license_id,
                 self.company,
-                copyright_regex=self.regex,
             )
 
             ret = mock_stdout.getvalue()
@@ -253,7 +241,6 @@ class UpdateFileTestCase(TestCase):
                 year,
                 license_id,
                 self.company,
-                copyright_regex=self.regex,
             )
 
             ret = mock_stdout.getvalue()
@@ -280,7 +267,6 @@ class UpdateFileTestCase(TestCase):
                 year,
                 license_id,
                 self.company,
-                copyright_regex=self.regex,
             )
 
         ret = mock_stdout.getvalue()
@@ -302,7 +288,6 @@ class UpdateFileTestCase(TestCase):
                 year,
                 license_id,
                 self.company,
-                copyright_regex=self.regex,
             )
 
             ret = mock_stdout.getvalue()
@@ -328,7 +313,6 @@ class UpdateFileTestCase(TestCase):
                 year,
                 license_id,
                 self.company,
-                copyright_regex=self.regex,
             )
 
             ret = mock_stdout.getvalue()
@@ -356,7 +340,6 @@ class UpdateFileTestCase(TestCase):
                 year,
                 license_id,
                 self.company,
-                copyright_regex=self.regex,
             )
 
             ret = mock_stdout.getvalue()
@@ -416,9 +399,6 @@ foo.baz(bar.boing)
                 year,
                 license_id,
                 company,
-                copyright_regex=_compile_copyright_regex(
-                    ["Greenbone AG", OLD_COMPANY]
-                ),
                 cleanup_regexes=compiled_regexes,
             )
 

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -173,6 +173,8 @@ class AddHeaderTestCase(TestCase):
 
 
 class UpdateFileTestCase(TestCase):
+    maxDiff = None
+
     def setUp(self):
         self.company = "Greenbone AG"
 
@@ -370,6 +372,46 @@ foo.baz(bar.boing)
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
+
+import foo
+import bar
+
+foo.baz(bar.boing)
+"""  # noqa: E501
+
+        company = "Greenbone AG"
+        year = str(datetime.datetime.now().year)
+        license_id = "GPL-3.0-or-later"
+
+        with temp_file(content=test_content, name="foo.py") as tmp:
+
+            update_file(
+                tmp,
+                year,
+                license_id,
+                company,
+                cleanup=True,
+            )
+
+            new_content = tmp.read_text(encoding="utf-8")
+            self.assertEqual(expected_content, new_content)
+
+    def test_cleanup_file_spdx_header(self):
+        test_content = """
+# SPDX-FileCopyrightText: 2021 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import foo
+import bar
+
+foo.baz(bar.boing)
+"""  # noqa: E501
+
+        expected_content = f"""
+# SPDX-FileCopyrightText: 2021-{str(datetime.datetime.now().year)} Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
 
 import foo
 import bar

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -475,6 +475,21 @@ class ParseArgsTestCase(TestCase):
 
         test_ignore_file.unlink()
 
+    def test_defaults(self):
+        args = ["-f", "foo.txt"]
+        args = parse_args(args)
+
+        self.assertFalse(args.quiet)
+        self.assertIsNone(args.log_file)
+        self.assertFalse(args.changed)
+        self.assertEqual(args.year, str(datetime.date.today().year))
+        self.assertEqual(args.license_id, "GPL-3.0-or-later")
+        self.assertEqual(args.company, "Greenbone AG")
+        self.assertEqual(args.files, ["foo.txt"])
+        self.assertIsNone(args.directories)
+        self.assertIsNone(args.exclude_file)
+        self.assertFalse(args.cleanup)
+
 
 class MainTestCase(TestCase):
     def setUp(self) -> None:

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -380,7 +380,6 @@ foo.baz(bar.boing)
         company = "Greenbone AG"
         year = str(datetime.datetime.now().year)
         license_id = "GPL-3.0-or-later"
-        compiled_regexes = compile_outdated_regex()
 
         with temp_file(content=test_content, name="foo.py") as tmp:
 
@@ -389,7 +388,7 @@ foo.baz(bar.boing)
                 year,
                 license_id,
                 company,
-                cleanup_regexes=compiled_regexes,
+                cleanup=True,
             )
 
             new_content = tmp.read_text(encoding="utf-8")


### PR DESCRIPTION
## What

Improve `pontos-update-header` CLI

## Why

Currently it's not possible to overwrite the company in copyright headers if it doesn't fit to Greenbone.

## References

DOS-175

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


