### PR TITLE
Change: Make`enum_choice` and `enum_type` accessible for other projects

### DIFF
--- a/pontos/__init__.py
+++ b/pontos/__init__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+from .enum import enum_choice, enum_type
 from .pontos import main
 
-__all__ = ["main"]
+__all__ = ["enum_choice", "enum_type", "main"]


### PR DESCRIPTION
## What

Make`enum_choice` and `enum_type` accessible for other projects

Can be accessed via 
```python
from pontos import enum_choice, enum_type
```

<!--
  Describe what changes are being made, e.g. which feature/bug is being
  developed/fixed in this PR? How did you verify the changes in this PR?
-->

## Why
Need it for other repository ... for `argparser` argument
<!-- Describe why are these changes necessary? -->

## References
DEVOPS-889
<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


