### PR TITLE
Add: Undocumented "Reference Tag Update" event

### DIFF
--- a/pontos/nvd/models/cve_change.py
+++ b/pontos/nvd/models/cve_change.py
@@ -24,6 +24,7 @@ class EventName(StrEnum):
     CVE_REJECTED = "CVE Rejected"
     CVE_UNREJECTED = "CVE Unrejected"
     CVE_CISA_KEV_UPDATE = "CVE CISA KEV Update"
+    REFERENCE_TAG_UPDATE = "Reference Tag Update"
 
 
 @dataclass


### PR DESCRIPTION
## What
This PR adds the (undocumented) "Reference Tag Update" event. According to NVD this event is expected, but yet to be documented (see linked ticket).

## Why
To be able to handle events like https://services.nvd.nist.gov/rest/json/cvehistory/2.0?eventName=Reference%20Tag%20Update.

## References
https://jira.greenbone.net/browse/VTA-495

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


