### PR TITLE
Add: delete_all on labels

### DIFF
--- a/pontos/github/api/labels.py
+++ b/pontos/github/api/labels.py
@@ -45,11 +45,31 @@ class GitHubAsyncRESTLabels(GitHubAsyncREST):
             for label in data:
                 yield label["name"]  # type: ignore
 
+    async def delete_all(self, repo: str, issue: Union[int, str]) -> None:
+        """
+        Deletes all labels in the issue/pr.
+
+        Args:
+            repo:   GitHub repository (owner/name) to use
+            issue:  Issue/Pull request number
+
+        Example:
+            .. code-block:: python
+
+                from pontos.github.api import GitHubAsyncRESTApi
+
+                async with GitHubAsyncRESTApi(token) as api:
+                    await api.labels.delete_all("foo/bar", 123)
+        """
+        api = f"/repos/{repo}/issues/{issue}/labels"
+        response = await self._client.delete(api)
+        response.raise_for_status()
+
     async def set_all(
         self, repo: str, issue: Union[int, str], labels: Iterable[str]
     ) -> None:
         """
-        Set labels in the issue/pr. Existing labels will be overwritten
+        Set labels in the issue/pr.
 
         Args:
             repo:   GitHub repository (owner/name) to use

--- a/tests/github/api/test_labels.py
+++ b/tests/github/api/test_labels.py
@@ -46,6 +46,16 @@ class GitHubAsyncRESTLabelsTestCase(GitHubAsyncRESTTestCase):
             params={"per_page": "100"},
         )
 
+    async def test_delete_all(self):
+        response = create_response()
+        self.client.delete.return_value = response
+
+        await self.api.delete_all("foo/bar", 123)
+
+        self.client.delete.assert_awaited_once_with(
+            "/repos/foo/bar/issues/123/labels"
+        )
+
     async def test_set_all(self):
         response = create_response()
         self.client.post.return_value = response


### PR DESCRIPTION
Unlike the description says within set_all labels are not overriden but
labels that are not within the POST data but are on the PR stay.

For the use case that an action wants to override managed labels it
needs the possibility to delete previous labels. 

For that the delete_all method is introduced.
