### PR TITLE
Add single year parameter flag to pontos-update-header

### DIFF
--- a/pontos/updateheader/_parser.py
+++ b/pontos/updateheader/_parser.py
@@ -109,4 +109,15 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
         help="Do a cleanup: Remove lines from outdated header format",
     )
 
+    parser.add_argument(
+        "--single-year",
+        action="store_true",
+        default=False,
+        help=(
+            "If set, will not update license with from-to years format "
+            "(YYYY-YYYY) if it has single (only creation) year format (YYYY). "
+            "Default is %(default)s."
+        ),
+    )
+
     return parser.parse_args(args)

--- a/pontos/updateheader/_parser.py
+++ b/pontos/updateheader/_parser.py
@@ -114,8 +114,8 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
         action="store_true",
         default=False,
         help=(
-            "If set, will not update license with from-to years format "
-            "(YYYY-YYYY) if it has single (only creation) year format (YYYY). "
+            "If set, will format license headers in from-to year format "
+            "into single (creation) year format. "
             "Default is %(default)s."
         ),
     )

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -67,7 +67,12 @@ OLD_LINES = [
 
 def _get_modified_year(f: Path) -> str:
     """In case of the changed arg, update year to last modified year"""
-    return Git().log("-1", "--date=format:%Y", str(f), format="%ad")[0]
+    try:
+        ret = Git().log("-1", "--date=format:%Y", str(f), format="%ad")[0]
+    except IndexError:
+        raise PontosError(f"Empty \"git log -1\" output for {f}.")
+
+    return ret
 
 
 @dataclass

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -350,19 +350,20 @@ def main(args: Optional[Sequence[str]] = None) -> None:
         sys.exit(1)
 
     for file in files:
-        if changed:
-            try:
-                year = _get_modified_year(file)
-            except PontosError:
-                term.warning(
-                    f"{file}: Could not get date of last modification"
-                    f" via git, using {year} instead."
-                )
 
         try:
             if file.absolute() in exclude_list:
                 term.warning(f"{file}: Ignoring file from exclusion list.")
             else:
+                if changed:
+                    try:
+                        year = _get_modified_year(file)
+                    except PontosError:
+                        term.warning(
+                            f"{file}: Could not get date of last modification"
+                            f" via git, using {year} instead."
+                        )
+
                 update_file(
                     file,
                     year,

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -70,7 +70,7 @@ def _get_modified_year(f: Path) -> str:
     try:
         ret = Git().log("-1", "--date=format:%Y", str(f), format="%ad")[0]
     except IndexError:
-        raise PontosError(f"Empty \"git log -1\" output for {f}.")
+        raise PontosError(f'Empty "git log -1" output for {f}.')
 
     return ret
 
@@ -154,6 +154,7 @@ def update_file(
     company: str,
     *,
     cleanup: bool = False,
+    single_year: bool = False,
 ) -> None:
     """Function to update the header of the given file
 
@@ -213,6 +214,10 @@ def update_file(
                 or copyright_match.modification_year
                 and copyright_match.modification_year < year
             ):
+                if single_year:
+                    # In case of single year updating the license with modification date doesn't make sense.
+                    # Changing the existing license header with created-modified years to single year is not supported.
+                    return
                 copyright_term = (
                     f"SPDX-FileCopyrightText: "
                     f"{copyright_match.creation_year}"
@@ -314,6 +319,7 @@ def main(args: Optional[Sequence[str]] = None) -> None:
     changed: bool = parsed_args.changed
     quiet: bool = parsed_args.quiet
     cleanup: bool = parsed_args.cleanup
+    single_year: bool = parsed_args.single_year
 
     if quiet:
         term: Union[NullTerminal, RichTerminal] = NullTerminal()
@@ -370,6 +376,7 @@ def main(args: Optional[Sequence[str]] = None) -> None:
                     license_id,
                     company,
                     cleanup=cleanup,
+                    single_year=single_year,
                 )
         except (FileNotFoundError, UnicodeDecodeError, ValueError):
             continue

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -226,8 +226,8 @@ def update_file(
                     )
 
                 with_multi_year = copyright_match.creation_year and copyright_match.modification_year
-                with_single_year_outdated = not copyright_match.modification_year and copyright_match.creation_year < year
-                with_multi_year_outdated = with_multi_year and copyright_match.modification_year < year
+                with_single_year_outdated = not copyright_match.modification_year and int(copyright_match.creation_year) < int(year)
+                with_multi_year_outdated = with_multi_year and int(copyright_match.modification_year) < int(year)
 
                 if single_year and with_multi_year:
                     _substitute_license_text(fp, line, copyright_regex, copyright_term)

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -225,19 +225,38 @@ def update_file(
                         f"-{year} {company}"
                     )
 
-                with_multi_year = copyright_match.creation_year and copyright_match.modification_year
-                with_single_year_outdated = not copyright_match.modification_year and int(copyright_match.creation_year) < int(year)
-                with_multi_year_outdated = with_multi_year and int(copyright_match.modification_year) < int(year)
+                with_multi_year = (
+                    copyright_match.creation_year
+                    and copyright_match.modification_year
+                )
+                with_single_year_outdated = (
+                    not copyright_match.modification_year
+                    and int(copyright_match.creation_year) < int(year)
+                )
+
+                with_multi_year_outdated = False
+                if with_multi_year:
+                    # assert to silence mypy
+                    assert isinstance(copyright_match.modification_year, str)
+                    with_multi_year_outdated = int(
+                        copyright_match.modification_year
+                    ) < int(year)
 
                 if single_year and with_multi_year:
-                    _substitute_license_text(fp, line, copyright_regex, copyright_term)
+                    _substitute_license_text(
+                        fp, line, copyright_regex, copyright_term
+                    )
                     print(
                         f"{file}: Changed License Header Copyright Year format to single year "
                         f"{copyright_match.creation_year}-{year} -> "
                         f"{copyright_match.creation_year}"
                     )
-                elif not single_year and (with_multi_year_outdated or with_single_year_outdated):
-                    _substitute_license_text(fp, line, copyright_regex, copyright_term)
+                elif not single_year and (
+                    with_multi_year_outdated or with_single_year_outdated
+                ):
+                    _substitute_license_text(
+                        fp, line, copyright_regex, copyright_term
+                    )
                     print(
                         f"{file}: Changed License Header Copyright Year "
                         f"{copyright_match.modification_year} -> "

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -343,7 +343,7 @@ class UpdateFileTestCase(TestCase):
         year = "2021"
         license_id = "AGPL-3.0-or-later"
 
-        header = HEADER.format(date="2020")
+        header = HEADER.format(date="2020-2021")
         with temp_file(
             content=header, name="test.py", change_into=True
         ) as test_file:
@@ -353,6 +353,13 @@ class UpdateFileTestCase(TestCase):
                 license_id,
                 self.company,
                 single_year=True,
+            )
+
+            ret = mock_stdout.getvalue()
+            self.assertEqual(
+                ret,
+                f"{test_file}: Changed License Header Copyright Year format to single year "
+                "2020-2021 -> 2020\n",
             )
 
             self.assertIn(

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -292,6 +292,26 @@ class UpdateFileTestCase(TestCase):
             )
 
     @patch("sys.stdout", new_callable=StringIO)
+    def test_update_create_header_single_year(self, mock_stdout):
+        year = "1995"
+        license_id = "AGPL-3.0-or-later"
+
+        expected_header = HEADER.format(date="1995") + "\n\n"
+
+        with temp_file(name="test.py", change_into=True) as test_file:
+            update_file(
+                test_file, year, license_id, self.company, single_year=True
+            )
+            ret = mock_stdout.getvalue()
+            self.assertEqual(
+                f"{test_file}: Added license header.\n",
+                ret,
+            )
+            self.assertEqual(
+                expected_header, test_file.read_text(encoding="utf-8")
+            )
+
+    @patch("sys.stdout", new_callable=StringIO)
     def test_update_header_in_file(self, mock_stdout):
         year = "2021"
         license_id = "AGPL-3.0-or-later"
@@ -315,6 +335,28 @@ class UpdateFileTestCase(TestCase):
             )
             self.assertIn(
                 "# SPDX-FileCopyrightText: 2020-2021 Greenbone AG",
+                test_file.read_text(encoding="utf-8"),
+            )
+
+    @patch("sys.stdout", new_callable=StringIO)
+    def test_update_header_in_file_single_year(self, mock_stdout):
+        year = "2021"
+        license_id = "AGPL-3.0-or-later"
+
+        header = HEADER.format(date="2020")
+        with temp_file(
+            content=header, name="test.py", change_into=True
+        ) as test_file:
+            update_file(
+                test_file,
+                year,
+                license_id,
+                self.company,
+                single_year=True,
+            )
+
+            self.assertIn(
+                "# SPDX-FileCopyrightText: 2020 Greenbone AG",
                 test_file.read_text(encoding="utf-8"),
             )
 
@@ -510,6 +552,7 @@ class ParseArgsTestCase(TestCase):
         self.assertEqual(args.files, ["foo.txt"])
         self.assertIsNone(args.directories)
         self.assertIsNone(args.exclude_file)
+        self.assertFalse(args.single_year)
         self.assertFalse(args.cleanup)
 
     def test_files_and_directories_mutual_exclusive(self):
@@ -569,6 +612,7 @@ class MainTestCase(TestCase):
         self.args.log_file = None
         self.args.quiet = False
         self.args.cleanup = False
+        self.args.single_year = False
 
         argparser_mock.return_value = self.args
 


### PR DESCRIPTION
## What

Add single_year flag to pontos-update-header that skips updating headers with additional modified year (YYYY-YYYY) and retains only creation year. 

## Why

To be able to use the tool and adhering to internal requirements (that discourage using from-to years), which makes licenses easier to maintain.
