### PR TITLE
update-header TS/TSX support

### DIFF
--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.ts
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.ts
@@ -1,0 +1,4 @@
+/* SPDX-FileCopyrightText: <year> <company>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.tsx
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.tsx
@@ -1,0 +1,4 @@
+/* SPDX-FileCopyrightText: <year> <company>
+ *
+ * SPDX-License-Identifier: AGPL-3.0-or-later
+ */

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.ts
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.ts
@@ -1,0 +1,4 @@
+/* SPDX-FileCopyrightText: <year> <company>
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.tsx
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.tsx
@@ -1,0 +1,4 @@
+/* SPDX-FileCopyrightText: <year> <company>
+ *
+ * SPDX-License-Identifier: GPL-2.0-or-later
+ */

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.ts
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.ts
@@ -1,0 +1,4 @@
+/* SPDX-FileCopyrightText: <year> <company>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.tsx
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.tsx
@@ -1,0 +1,4 @@
+/* SPDX-FileCopyrightText: <year> <company>
+ *
+ * SPDX-License-Identifier: GPL-3.0-or-later
+ */

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -33,6 +33,8 @@ SUPPORTED_FILE_TYPES = [
     ".po",
     ".py",
     ".sh",
+    ".ts",
+    ".tsx",
     ".txt",
     ".xml",
     ".xsl",


### PR DESCRIPTION
## What

- Adds TS and TSX support for update-header

## Why

- We want to be able to add license headers to a front-end project automatically

## References

https://jira.greenbone.net/browse/AT-1427

