### PR TITLE
updateheader dry mode

### DIFF
--- a/pontos/updateheader/_parser.py
+++ b/pontos/updateheader/_parser.py
@@ -109,4 +109,13 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
         help="Do a cleanup: Remove lines from outdated header format",
     )
 
+    parser.add_argument(
+        "--dry",
+        action="store_true",
+        default=False,
+        help=(
+            "Perform a dry run: list files that would be updated without making changes."
+        )
+    )
+
     return parser.parse_args(args)

--- a/pontos/updateheader/_parser.py
+++ b/pontos/updateheader/_parser.py
@@ -114,7 +114,7 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
         action="store_true",
         default=False,
         help=(
-            "Perform a dry run: list files that would be updated without making changes."
+            "Perform a dry run: list files that do not have a license header."
         ),
     )
 

--- a/pontos/updateheader/_parser.py
+++ b/pontos/updateheader/_parser.py
@@ -115,7 +115,7 @@ def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
         default=False,
         help=(
             "Perform a dry run: list files that would be updated without making changes."
-        )
+        ),
     )
 
     return parser.parse_args(args)

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -309,6 +309,7 @@ def main(args: Optional[Sequence[str]] = None) -> None:
     changed: bool = parsed_args.changed
     quiet: bool = parsed_args.quiet
     cleanup: bool = parsed_args.cleanup
+    dry: bool = parsed_args.dry
 
     if quiet:
         term: Union[NullTerminal, RichTerminal] = NullTerminal()
@@ -358,6 +359,11 @@ def main(args: Optional[Sequence[str]] = None) -> None:
             if file.absolute() in exclude_list:
                 term.warning(f"{file}: Ignoring file from exclusion list.")
             else:
+                # do not update files in dry run mode
+                if dry:
+                    term.warning(f"'{file}' does not contain a license header.")
+                    continue
+
                 update_file(
                     file,
                     year,

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -361,7 +361,7 @@ def main(args: Optional[Sequence[str]] = None) -> None:
             else:
                 # do not update files in dry run mode
                 if dry:
-                    term.warning(f"'{file}' does not contain a license header.")
+                    term.warning(f"{file}")
                     continue
 
                 update_file(

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -16,10 +16,10 @@ from pontos.errors import PontosError
 from pontos.testing import temp_directory, temp_file
 from pontos.updateheader.updateheader import (
     _add_header as add_header,
-    has_license_header,
 )
 from pontos.updateheader.updateheader import (
     _compile_copyright_regex,
+    has_license_header,
     main,
     parse_args,
     update_file,

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -609,6 +609,29 @@ class MainTestCase(TestCase):
                 ret.replace("\n", ""),
             )
 
+    def test_update_file_changed_dry(self):
+        args = [
+            "--dry",
+            "--files",
+            "test.py",
+        ]
+
+        with (
+            redirect_stdout(StringIO()) as out,
+            temp_directory(change_into=True) as temp_dir,
+        ):
+            test_file = temp_dir / "test.py"
+            args.append(str(test_file))
+
+            main(args)
+
+            ret = out.getvalue()
+
+            self.assertIn(
+                f"{test_file}",
+                ret.replace("\n", ""),
+            )
+
 
 class RemoveOutdatedLinesTestCase(TestCase):
     def setUp(self) -> None:

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -511,6 +511,7 @@ class ParseArgsTestCase(TestCase):
         self.assertIsNone(args.directories)
         self.assertIsNone(args.exclude_file)
         self.assertFalse(args.cleanup)
+        self.assertFalse(args.dry)
 
     def test_files_and_directories_mutual_exclusive(self):
         args = ["--files", "foo", "--directories", "bar"]

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -616,6 +616,8 @@ class MainTestCase(TestCase):
 
 package main
 """
+        with temp_file(content='', name='testing_is_fun.gif') as tmp:
+            self.assertRaises(ValueError, has_license_header, tmp)
 
         with temp_file(content="", name="test.py") as tmp:
             found = has_license_header(tmp)

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -14,7 +14,10 @@ from unittest.mock import MagicMock, patch
 
 from pontos.errors import PontosError
 from pontos.testing import temp_directory, temp_file
-from pontos.updateheader.updateheader import _add_header as add_header, has_license_header
+from pontos.updateheader.updateheader import (
+    _add_header as add_header,
+    has_license_header,
+)
 from pontos.updateheader.updateheader import (
     _compile_copyright_regex,
     main,
@@ -298,7 +301,7 @@ class UpdateFileTestCase(TestCase):
 
         header = HEADER.format(date="2020")
         with temp_file(
-                content=header, name="test.py", change_into=True
+            content=header, name="test.py", change_into=True
         ) as test_file:
             update_file(
                 test_file,
@@ -325,7 +328,7 @@ class UpdateFileTestCase(TestCase):
 
         header = HEADER.format(date="2021")
         with temp_file(
-                content=header, name="test.py", change_into=True
+            content=header, name="test.py", change_into=True
         ) as test_file:
             update_file(
                 test_file,
@@ -614,7 +617,7 @@ class MainTestCase(TestCase):
 package main
 """
 
-        with temp_file(content='', name="test.py") as tmp:
+        with temp_file(content="", name="test.py") as tmp:
             found = has_license_header(tmp)
             self.assertFalse(found)
 
@@ -637,8 +640,10 @@ package main
 
         with (
             redirect_stdout(StringIO()) as out,
-            temp_file(content='', name="no_header.go") as test_file_no_header,
-            temp_file(content=test_content, name="has_header.go") as test_file_has_header,
+            temp_file(content="", name="no_header.go") as test_file_no_header,
+            temp_file(
+                content=test_content, name="has_header.go"
+            ) as test_file_has_header,
         ):
             args.append(str(test_file_no_header))
             args.append(str(test_file_has_header))

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -570,6 +570,7 @@ class MainTestCase(TestCase):
         self.args.log_file = None
         self.args.quiet = False
         self.args.cleanup = False
+        self.args.dry = False
 
         argparser_mock.return_value = self.args
 

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -616,7 +616,7 @@ class MainTestCase(TestCase):
 
 package main
 """
-        with temp_file(content='', name='testing_is_fun.gif') as tmp:
+        with temp_file(content="", name="testing_is_fun.gif") as tmp:
             self.assertRaises(ValueError, has_license_header, tmp)
 
         with temp_file(content="", name="test.py") as tmp:

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -622,7 +622,7 @@ package main
             found = has_license_header(tmp)
             self.assertTrue(found)
 
-    def test_update_file_dry(self):
+    def test_dry(self):
         args = [
             "--dry",
             "--files",


### PR DESCRIPTION
## What

- Adds `--dry` to `update-header`, list files that would need a header update.

e.g.

```
> poetry run pontos-update-header --dry -d /tmp/foo/
 ℹ pontos-update-header
 ⚠ /tmp/foo/test2.go does not have a license header.
 ⚠ /tmp/foo/test4.c does not have a license header.
```

## Why

- I want to create a CI workflow that warns the committer of missing headers instead of making the changes directly.

## References

https://jira.greenbone.net/browse/AT-1426

