### PR TITLE
Fix loading of NVD API results when there are none

### DIFF
--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -267,7 +267,7 @@ class NVDResults(Generic[T], AsyncIterable[T], Awaitable["NVDResults"]):
 
     async def _load_next_data(self) -> None:
         if (
-            not self._current_request_results
+            self._current_request_results is None
             or self._downloaded_results < self._current_request_results
         ):
             params = self._params

--- a/tests/nvd/test_api.py
+++ b/tests/nvd/test_api.py
@@ -186,6 +186,29 @@ class NVDResultsTestCase(IsolatedAsyncioTestCase):
         with self.assertRaises(StopAsyncIteration):
             await anext(it)
 
+    async def test_items_no_results(self):
+        response_mock = MagicMock(spec=Response)
+        response_mock.json.side_effect = [
+            {
+                "values": [],
+                "total_results": 0,
+                "results_per_page": 0,
+            },
+        ]
+        api_mock = AsyncMock(spec=NVDApi)
+        api_mock._get.return_value = response_mock
+
+        results: NVDResults[Result] = NVDResults(
+            api_mock,
+            {},
+            result_func,
+        )
+
+        it = aiter(results.items())
+
+        with self.assertRaises(StopAsyncIteration):
+            await anext(it)
+
     async def test_aiter(self):
         response_mock = MagicMock(spec=Response)
         response_mock.json.side_effect = [


### PR DESCRIPTION
## What
This PR fixes the loading of NVD API results when there are none.

## Why
E.g. https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2024-08-13T11%3A29%3A45%2B00%3A00&lastModEndDate=2024-08-13T11%3A30%3A15%2B00%3A00&startIndex=0&resultsPerPage=2000 returns an empty list of results.
This caused `self._current_request_results` to be `0` (because there are `0` total results available), so `raise NoMoreResults()` will be never called. This results in the same request being made over and over again indefinitely.

I added a test case to demonstrate the expected behavior.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


