### PR TITLE
Add: Retrying for NVDApi

### DIFF
--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -343,7 +343,7 @@ class NVDApi(ABC):
         token: Optional[str] = None,
         timeout: Optional[Timeout] = DEFAULT_TIMEOUT_CONFIG,
         rate_limit: bool = True,
-        attempts: int = 1,
+        request_attempts: int = 1,
     ) -> None:
         """
         Create a new instance of the CVE API.
@@ -359,7 +359,7 @@ class NVDApi(ABC):
                 rolling 30 second window.
                 See https://nvd.nist.gov/developers/start-here#divRateLimits
                 Default: True.
-            attempts: The number of attempts per HTTP request. Defaults to 1.
+            request_attempts: The number of attempts per HTTP request. Defaults to 1.
         """
         self._url = url
         self._token = token
@@ -373,7 +373,7 @@ class NVDApi(ABC):
         self._request_count = 0
         self._last_sleep = time.monotonic()
 
-        self._attempts = attempts
+        self._request_attempts = request_attempts
 
     def _request_headers(self) -> Headers:
         """
@@ -414,9 +414,9 @@ class NVDApi(ABC):
         """
         headers = self._request_headers()
 
-        for retry in range(self._attempts):
-            if retry > 0:
-                delay = RETRY_DELAY**retry
+        for attempt in range(self._request_attempts):
+            if attempt > 0:
+                delay = RETRY_DELAY**attempt
                 await asyncio.sleep(delay)
 
             await self._consider_rate_limit()

--- a/pontos/nvd/cpe/api.py
+++ b/pontos/nvd/cpe/api.py
@@ -61,7 +61,7 @@ class CPEApi(NVDApi):
         token: Optional[str] = None,
         timeout: Optional[Timeout] = DEFAULT_TIMEOUT_CONFIG,
         rate_limit: bool = True,
-        attempts: int = 1,
+        request_attempts: int = 1,
     ) -> None:
         """
         Create a new instance of the CPE API.
@@ -76,14 +76,14 @@ class CPEApi(NVDApi):
                 rolling 30 second window.
                 See https://nvd.nist.gov/developers/start-here#divRateLimits
                 Default: True.
-            attempts: The number of attempts per HTTP request. Defaults to 1.
+            request_attempts: The number of attempts per HTTP request. Defaults to 1.
         """
         super().__init__(
             DEFAULT_NIST_NVD_CPES_URL,
             token=token,
             timeout=timeout,
             rate_limit=rate_limit,
-            attempts=attempts,
+            request_attempts=request_attempts,
         )
 
     async def cpe(self, cpe_name_id: Union[str, UUID]) -> CPE:

--- a/pontos/nvd/cpe/api.py
+++ b/pontos/nvd/cpe/api.py
@@ -61,6 +61,7 @@ class CPEApi(NVDApi):
         token: Optional[str] = None,
         timeout: Optional[Timeout] = DEFAULT_TIMEOUT_CONFIG,
         rate_limit: bool = True,
+        attempts: int = 1,
     ) -> None:
         """
         Create a new instance of the CPE API.
@@ -75,12 +76,14 @@ class CPEApi(NVDApi):
                 rolling 30 second window.
                 See https://nvd.nist.gov/developers/start-here#divRateLimits
                 Default: True.
+            attempts: The number of attempts per HTTP request. Defaults to 1.
         """
         super().__init__(
             DEFAULT_NIST_NVD_CPES_URL,
             token=token,
             timeout=timeout,
             rate_limit=rate_limit,
+            attempts=attempts,
         )
 
     async def cpe(self, cpe_name_id: Union[str, UUID]) -> CPE:

--- a/pontos/nvd/cve/api.py
+++ b/pontos/nvd/cve/api.py
@@ -65,7 +65,7 @@ class CVEApi(NVDApi):
         token: Optional[str] = None,
         timeout: Optional[Timeout] = DEFAULT_TIMEOUT_CONFIG,
         rate_limit: bool = True,
-        attempts: int = 1,
+        request_attempts: int = 1,
     ) -> None:
         """
         Create a new instance of the CVE API.
@@ -80,14 +80,14 @@ class CVEApi(NVDApi):
                 rolling 30 second window.
                 See https://nvd.nist.gov/developers/start-here#divRateLimits
                 Default: True.
-            attempts: The number of attempts per HTTP request. Defaults to 1.
+            request_attempts: The number of attempts per HTTP request. Defaults to 1.
         """
         super().__init__(
             DEFAULT_NIST_NVD_CVES_URL,
             token=token,
             timeout=timeout,
             rate_limit=rate_limit,
-            attempts=attempts,
+            request_attempts=request_attempts,
         )
 
     def cves(

--- a/pontos/nvd/cve/api.py
+++ b/pontos/nvd/cve/api.py
@@ -65,6 +65,7 @@ class CVEApi(NVDApi):
         token: Optional[str] = None,
         timeout: Optional[Timeout] = DEFAULT_TIMEOUT_CONFIG,
         rate_limit: bool = True,
+        attempts: int = 1,
     ) -> None:
         """
         Create a new instance of the CVE API.
@@ -79,12 +80,14 @@ class CVEApi(NVDApi):
                 rolling 30 second window.
                 See https://nvd.nist.gov/developers/start-here#divRateLimits
                 Default: True.
+            attempts: The number of attempts per HTTP request. Defaults to 1.
         """
         super().__init__(
             DEFAULT_NIST_NVD_CVES_URL,
             token=token,
             timeout=timeout,
             rate_limit=rate_limit,
+            attempts=attempts,
         )
 
     def cves(

--- a/pontos/nvd/cve_changes/api.py
+++ b/pontos/nvd/cve_changes/api.py
@@ -55,6 +55,7 @@ class CVEChangesApi(NVDApi):
         token: Optional[str] = None,
         timeout: Optional[Timeout] = DEFAULT_TIMEOUT_CONFIG,
         rate_limit: bool = True,
+        attempts: int = 1,
     ) -> None:
         """
         Create a new instance of the CVE Change History API.
@@ -69,12 +70,14 @@ class CVEChangesApi(NVDApi):
                 rolling 30 second window.
                 See https://nvd.nist.gov/developers/start-here#divRateLimits
                 Default: True.
+            attempts: The number of attempts per HTTP request. Defaults to 1.
         """
         super().__init__(
             DEFAULT_NIST_NVD_CVE_HISTORY_URL,
             token=token,
             timeout=timeout,
             rate_limit=rate_limit,
+            attempts=attempts,
         )
 
     def changes(

--- a/pontos/nvd/cve_changes/api.py
+++ b/pontos/nvd/cve_changes/api.py
@@ -55,7 +55,7 @@ class CVEChangesApi(NVDApi):
         token: Optional[str] = None,
         timeout: Optional[Timeout] = DEFAULT_TIMEOUT_CONFIG,
         rate_limit: bool = True,
-        attempts: int = 1,
+        request_attempts: int = 1,
     ) -> None:
         """
         Create a new instance of the CVE Change History API.
@@ -70,14 +70,14 @@ class CVEChangesApi(NVDApi):
                 rolling 30 second window.
                 See https://nvd.nist.gov/developers/start-here#divRateLimits
                 Default: True.
-            attempts: The number of attempts per HTTP request. Defaults to 1.
+            request_attempts: The number of attempts per HTTP request. Defaults to 1.
         """
         super().__init__(
             DEFAULT_NIST_NVD_CVE_HISTORY_URL,
             token=token,
             timeout=timeout,
             rate_limit=rate_limit,
-            attempts=attempts,
+            request_attempts=request_attempts,
         )
 
     def changes(

--- a/tests/nvd/test_api.py
+++ b/tests/nvd/test_api.py
@@ -137,10 +137,10 @@ class NVDApiTestCase(IsolatedAsyncioTestCase):
         sleep_mock: MagicMock,
     ):
         response_mocks = [
-            MagicMock(spec=Response, status_code=500),
-            MagicMock(spec=Response, status_code=500),
-            MagicMock(spec=Response, status_code=500),
-            MagicMock(spec=Response, status_code=200),
+            MagicMock(spec=Response, is_server_error=True),
+            MagicMock(spec=Response, is_server_error=True),
+            MagicMock(spec=Response, is_server_error=True),
+            MagicMock(spec=Response, is_server_error=False),
         ]
         http_client = AsyncMock()
         http_client.get.side_effect = response_mocks
@@ -152,7 +152,7 @@ class NVDApiTestCase(IsolatedAsyncioTestCase):
 
         calls = [call(2.0), call(4.0), call(8.0)]
         sleep_mock.assert_has_calls(calls)
-        self.assertEqual(result.status_code, 200)
+        self.assertFalse(result.is_server_error)
 
     @patch("pontos.nvd.api.asyncio.sleep", autospec=True)
     @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
@@ -162,7 +162,7 @@ class NVDApiTestCase(IsolatedAsyncioTestCase):
         sleep_mock: MagicMock,
     ):
         response_mock = MagicMock(spec=Response)
-        response_mock.status_code = 200
+        response_mock.is_server_error = False
 
         http_client = AsyncMock()
         http_client.get.return_value = response_mock
@@ -173,7 +173,7 @@ class NVDApiTestCase(IsolatedAsyncioTestCase):
         result = await api._get()
 
         sleep_mock.assert_not_called()
-        self.assertEqual(result.status_code, 200)
+        self.assertFalse(result.is_server_error)
 
 
 class Result:


### PR DESCRIPTION
## What
This PR adds the retrying of requests to `NVDApi` and the inheriting classes.

## Why
NVD is super unstable lately, so it's nearly impossible to retrieve a large response, because one of the HTTP requests will very likely fail. This caused vt-cve-library to be broken right now and cve-feeder to occasionally fail.

The current behavior on `main` is that the caller needs to handle those errors. However, the caller doesn't know which request (the offset of the paginated response) exactly failed, so send a new request starting from failed requests offset.
One option would be to somehow pass this offset to the caller, however I opted for the approach to handle retries directly inside Pontos, just like rate-limiting also is for a more out-of-the-box developer experience.

This implementation is backwards-compatible and assumes one attempt, if not specified otherwise.
If `attempts` is greater than `1` and there is a server-side (HTTP 5xx) error in the response, the request will be retried after a delay of 2 seconds, exponentially backing off.

In my tests for vt-cve-library I was finally able to request data from NVD again, which failed after a few minutes before this change.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


