### PR TITLE
Change: Fix broken event name

### DIFF
--- a/pontos/nvd/models/cve_change.py
+++ b/pontos/nvd/models/cve_change.py
@@ -11,7 +11,7 @@ from pontos.models import Model, StrEnum
 
 
 class EventName(StrEnum):
-    CVE_RECEIVED = "CVE Received"
+    NEW_CVE_RECEIVED = "New CVE Received"
     INITIAL_ANALYSIS = "Initial Analysis"
     REANALYSIS = "Reanalysis"
     CVE_MODIFIED = "CVE Modified"


### PR DESCRIPTION
## What
This PR fixes a now incorrect event name. It not only changes this string expected from the NVD, but also the Enum value on our side.

## Why
As announced in https://www.nist.gov/itl/nvd / https://groups.google.com/a/list.nist.gov/g/nvd-news/c/pTfvMzIWGxg, the `CVE Received` event has been renamed to `New CVE Received`.
Without this change the parsing fails:
```
pontos git:(main) poetry run pontos-nvd-cve-changes --cve-id CVE-2024-43530 -s 0
Traceback (most recent call last):
[...]
  File "/home/nthumann/Greenbone/pontos/pontos/models/__init__.py", line 152, in from_dict
    raise ModelError(
pontos.models.ModelError: Error while creating CVEChange model. Could not set value for property 'event_name' from 'New CVE Received'.
```
With this change this is now fixed:
```
pontos git:(fix_new_cve_received_event_name) poetry run pontos-nvd-cve-changes --cve-id CVE-2024-43530 -s 0
CVEChange(cve_id='CVE-2024-43530', event_name=<EventName.NEW_CVE_RECEIVED: 'New CVE Received'>, cve_change_id=...)
```

I also decided to adjust the Enum value accordingly. It is very likely not an issue, because IIRC only vt-cve-library is using the CVE Change History and no one is using the `CVE_RECEIVED` value anyways (see [here](https://github.com/search?q=org%3Agreenbone+CVE_RECEIVED&type=code)).

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


