### PR TITLE
Change: Fix endless loop in NVDApi

### DIFF
--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -272,6 +272,12 @@ class NVDResults(Generic[T], AsyncIterable[T], Awaitable["NVDResults"]):
         ):
             raise NoMoreResults()
 
+        if (
+            self._total_results is not None
+            and self._current_index >= self._total_results
+        ):
+            raise NoMoreResults()
+
         params = self._params
         params["startIndex"] = self._current_index
 


### PR DESCRIPTION
## What
This PR fixes the endless loop of requests.
Note: The diff looks more complicated than it is. It's actually just changing indentation + inverting an if-clause + the actual fix. I recommend checking the commits separately.

## Why
Because we should stop requesting results when there aren't any more available.

You can reproduce the issue with:
```
import logging
from pontos.nvd.cve import CVEApi
import asyncio
from datetime import datetime

logging.basicConfig(level=logging.INFO)


async def foo():
    async with CVEApi() as api:
        cves = await api.cves(
            last_modified_start_date=datetime(2024, 11, 19),
            last_modified_end_date=datetime(2024, 12, 9),
            start_index=244000,
        )

        async for _ in cves:
            pass


asyncio.run(foo())
```
It is expected that this will send two requests: One returning 2.000 results and another one returning 1.625 results.

Pontos however keeps sending requests, because `self._downloaded_result` (2.000 + 1.625) < `self._current_request_results` (247.625), even though the API doesn't return any more:
```
➜  pontos git:(main) ✗ poetry run python foo.py
INFO:httpx:HTTP Request: GET https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2024-11-19T00%3A00%3A00&lastModEndDate=2024-12-09T00%3A00%3A00&startIndex=244000&resultsPerPage=2000 "HTTP/1.1 200 OK"
INFO:httpx:HTTP Request: GET https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2024-11-19T00%3A00%3A00&lastModEndDate=2024-12-09T00%3A00%3A00&startIndex=246000&resultsPerPage=2000 "HTTP/1.1 200 OK"
INFO:httpx:HTTP Request: GET https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2024-11-19T00%3A00%3A00&lastModEndDate=2024-12-09T00%3A00%3A00&startIndex=247435&resultsPerPage=1435 "HTTP/1.1 200 OK"
INFO:httpx:HTTP Request: GET https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2024-11-19T00%3A00%3A00&lastModEndDate=2024-12-09T00%3A00%3A00&startIndex=247435&resultsPerPage=0 "HTTP/1.1 200 OK"
INFO:httpx:HTTP Request: GET https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2024-11-19T00%3A00%3A00&lastModEndDate=2024-12-09T00%3A00%3A00&startIndex=247435&resultsPerPage=0 "HTTP/1.1 200 OK"
INFO:httpx:HTTP Request: GET https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2024-11-19T00%3A00%3A00&lastModEndDate=2024-12-09T00%3A00%3A00&startIndex=247435&resultsPerPage=0 "HTTP/1.1 200 OK"
INFO:httpx:HTTP Request: GET https://services.nvd.nist.gov/rest/json/cves/2.0?lastModStartDate=2024-11-19T00%3A00%3A00&lastModEndDate=2024-12-09T00%3A00%3A00&startIndex=247435&resultsPerPage=0 "HTTP/1.1 200 OK"
[...]
```

## How
Tested using the Python snippet above and using CVE DB Updater of vt-cve-library. 

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


