### PR TITLE
Change: Fix endless loop in GitHubAsyncRESTClient.get_all

### DIFF
--- a/pontos/github/api/client.py
+++ b/pontos/github/api/client.py
@@ -155,7 +155,9 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
 
         while next_url:
             # Workaround for https://github.com/encode/httpx/issues/3433
-            new_params = httpx.URL(next_url).params.merge(params)
+            new_params = (
+                httpx.URL(next_url).params.merge(params) if params else None
+            )
             response = await self.get(next_url, params=new_params)
 
             yield response

--- a/pontos/github/api/client.py
+++ b/pontos/github/api/client.py
@@ -154,7 +154,9 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
         next_url = _get_next_url(response)
 
         while next_url:
-            response = await self.get(next_url, params=params)
+            # Workaround for https://github.com/encode/httpx/issues/3433
+            new_params = httpx.URL(next_url).params.merge(params)
+            response = await self.get(next_url, params=new_params)
 
             yield response
 


### PR DESCRIPTION
## What
This PR fixes an endless loop in `GitHubAsyncRESTClient.get_all`, caused by unexpected behavior of httpx.

## Why
In the current release httpx doesn't _merge_ the params of the URL and the ones in `params`, but `params` will replace the URL. This causes us to request the first page over and over again, because `params=params` will replace `page` parameter, which is part of the string that `_get_next_url` returns.
This has been introduced by https://github.com/encode/httpx/issues/3433. Because this seems to be [expected behavior](https://github.com/encode/httpx/issues/3433#issuecomment-2514327255) (debatable IMHO), I opted to work around this instead of just pinning the httpx version to the previously working one.

You can confirm this fix by using e.g. [download-artifact](https://github.com/greenbone/actions/tree/main/download-artifact) and using this branch for pontos. Without this fix, it'll take forever and at some point likely exceed out API quota.

## References
Jira: https://jira.greenbone.net/browse/VTA-630

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


