### PR TITLE
Use version tags for greenbone actions

### DIFF
--- a/.github/workflows/ci-python.yml
+++ b/.github/workflows/ci-python.yml
@@ -23,7 +23,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install and check with black, pylint and pontos.version
-        uses: greenbone/actions/lint-python@027c80b4a1e454af192f93aa55cb2bc58ce44b66 #v3.27.7
+        uses: greenbone/actions/lint-python@v3
         with:
           packages: pontos tests
           python-version: ${{ matrix.python-version }}
@@ -42,7 +42,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install python, poetry and dependencies
-        uses: greenbone/actions/poetry@027c80b4a1e454af192f93aa55cb2bc58ce44b66 #v3.27.7
+        uses: greenbone/actions/poetry@v3
         with:
           python-version: ${{ matrix.python-version }}
       - name: Run unit tests
@@ -61,7 +61,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Run mypy
-        uses: greenbone/actions/mypy-python@027c80b4a1e454af192f93aa55cb2bc58ce44b66 #v3.27.7
+        uses: greenbone/actions/mypy-python@v3
         with:
           python-version: ${{ matrix.python-version }}
 
@@ -73,7 +73,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install and calculate and upload coverage to codecov.io
-        uses: greenbone/actions/coverage-python@027c80b4a1e454af192f93aa55cb2bc58ce44b66 #v3.27.7
+        uses: greenbone/actions/coverage-python@v3
         with:
           python-version: "3.10"
           token: ${{ secrets.CODECOV_TOKEN }}
@@ -84,7 +84,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Install python, poetry and dependencies
-        uses: greenbone/actions/poetry@027c80b4a1e454af192f93aa55cb2bc58ce44b66 #v3.27.7
+        uses: greenbone/actions/poetry@v3
       - name: Check version
         run: |
           poetry run pontos-version verify current

--- a/.github/workflows/conventional-commits.yml
+++ b/.github/workflows/conventional-commits.yml
@@ -13,4 +13,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Report Conventional Commits
-        uses: greenbone/actions/conventional-commits@027c80b4a1e454af192f93aa55cb2bc58ce44b66 #v3.27.7
+        uses: greenbone/actions/conventional-commits@v3

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -9,4 +9,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: 'Dependency Review'
-        uses: greenbone/actions/dependency-review@027c80b4a1e454af192f93aa55cb2bc58ce44b66 #v3.27.7
+        uses: greenbone/actions/dependency-review@v3

--- a/.github/workflows/deploy-pypi.yml
+++ b/.github/workflows/deploy-pypi.yml
@@ -18,7 +18,7 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
       - name: Set up Python
-        uses: greenbone/actions/poetry@027c80b4a1e454af192f93aa55cb2bc58ce44b66 #v3.27.7
+        uses: greenbone/actions/poetry@v3
         with:
           python-version: "3.10"
           install-dependencies: "false"

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 #v4.2.2
       - name: Install poetry and dependencies
-        uses: greenbone/actions/poetry@027c80b4a1e454af192f93aa55cb2bc58ce44b66 #v3.27.7
+        uses: greenbone/actions/poetry@v3
         with:
           python-version: "3.10"
       - name: Build Documentation

--- a/.github/workflows/sbom-upload.yml
+++ b/.github/workflows/sbom-upload.yml
@@ -15,4 +15,4 @@ jobs:
       contents: write
     steps:
       - name: 'SBOM upload'
-        uses: greenbone/actions/sbom-upload@027c80b4a1e454af192f93aa55cb2bc58ce44b66 #v3.27.7
+        uses: greenbone/actions/sbom-upload@v3


### PR DESCRIPTION
## What
Use version tags for greenbone actions

## Why
Using commit hashes is only required for third-party GitHub actions, so using version tags for our own actions makes them easier to keep up to date.

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


