### PR TITLE
Add: NVD Source API

### DIFF
--- a/pontos/nvd/models/source.py
+++ b/pontos/nvd/models/source.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2022-2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+from pontos.models import Model
+
+
+@dataclass
+class AcceptanceLevel(Model):
+    description: str
+    last_modified: datetime
+
+
+@dataclass
+class Source(Model):
+    last_modified: datetime
+    created: datetime
+    name: Optional[str] = None
+    source_identifiers: List[str] = field(default_factory=list)
+    contact_email: Optional[str] = None
+    v2_acceptance_level: Optional[AcceptanceLevel] = None
+    v3_acceptance_level: Optional[AcceptanceLevel] = None
+    cwe_acceptance_level: Optional[AcceptanceLevel] = None

--- a/pontos/nvd/models/source.py
+++ b/pontos/nvd/models/source.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2022-2023 Greenbone AG
+# SPDX-FileCopyrightText: 2022-2025 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-#
 
 from dataclasses import dataclass, field
 from datetime import datetime

--- a/pontos/nvd/source/__init__.py
+++ b/pontos/nvd/source/__init__.py
@@ -13,7 +13,7 @@ __all__ = ("SourceApi",)
 
 
 async def query_changes(args: Namespace) -> None:
-    async with SourceApi() as api:
+    async with SourceApi(token=args.token) as api:
         async for source in api.sources(
             source_identifier=args.source_identifier,
             request_results=args.number,

--- a/pontos/nvd/source/__init__.py
+++ b/pontos/nvd/source/__init__.py
@@ -1,0 +1,34 @@
+# SPDX-FileCopyrightText: 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+import asyncio
+from argparse import Namespace
+
+from pontos.nvd.source.api import SourceApi
+
+from ._parser import parse_args
+
+__all__ = ("SourceApi",)
+
+
+async def query_changes(args: Namespace) -> None:
+    async with SourceApi() as api:
+        async for source in api.sources(
+            source_identifier=args.source_identifier,
+            request_results=args.number,
+            start_index=args.start,
+        ):
+            print(source)
+
+
+def main() -> None:
+    try:
+        args = parse_args()
+        asyncio.run(query_changes(args))
+    except KeyboardInterrupt:
+        pass
+
+
+if __name__ == "__main__":
+    main()

--- a/pontos/nvd/source/__init__.py
+++ b/pontos/nvd/source/__init__.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2023 Greenbone AG
+# SPDX-FileCopyrightText: 2025 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/pontos/nvd/source/_parser.py
+++ b/pontos/nvd/source/_parser.py
@@ -11,6 +11,7 @@ import shtab
 def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
     parser = ArgumentParser()
     shtab.add_argument_to(parser)
+    parser.add_argument("--token", help="API key to use for querying.")
     parser.add_argument(
         "--source-identifier",
         help="Get sources record for this source identifier",

--- a/pontos/nvd/source/_parser.py
+++ b/pontos/nvd/source/_parser.py
@@ -1,4 +1,4 @@
-# SPDX-FileCopyrightText: 2024 Greenbone AG
+# SPDX-FileCopyrightText: 2025 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 

--- a/pontos/nvd/source/_parser.py
+++ b/pontos/nvd/source/_parser.py
@@ -1,0 +1,28 @@
+# SPDX-FileCopyrightText: 2024 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from argparse import ArgumentParser, Namespace
+from typing import Optional, Sequence
+
+import shtab
+
+
+def parse_args(args: Optional[Sequence[str]] = None) -> Namespace:
+    parser = ArgumentParser()
+    shtab.add_argument_to(parser)
+    parser.add_argument(
+        "--source-identifier",
+        help="Get sources record for this source identifier",
+    )
+    parser.add_argument(
+        "--number", "-n", metavar="N", help="Request only N sources", type=int
+    )
+    parser.add_argument(
+        "--start",
+        "-s",
+        help="Index of the first source to request.",
+        type=int,
+        default=0,
+    )
+    return parser.parse_args(args)

--- a/pontos/nvd/source/api.py
+++ b/pontos/nvd/source/api.py
@@ -1,7 +1,6 @@
-# SPDX-FileCopyrightText: 2022-2023 Greenbone AG
+# SPDX-FileCopyrightText: 2022-2025 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
-#
 
 from datetime import datetime
 from typing import (

--- a/pontos/nvd/source/api.py
+++ b/pontos/nvd/source/api.py
@@ -1,0 +1,144 @@
+# SPDX-FileCopyrightText: 2022-2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+#
+
+from datetime import datetime
+from typing import (
+    Iterable,
+    Iterator,
+    Optional,
+)
+
+from httpx import Timeout
+
+from pontos.nvd.api import (
+    DEFAULT_TIMEOUT_CONFIG,
+    JSON,
+    NVDApi,
+    NVDResults,
+    Params,
+    format_date,
+    now,
+)
+from pontos.nvd.models.source import Source
+
+__all__ = ("SourceApi",)
+
+DEFAULT_NIST_NVD_CVES_URL = "https://services.nvd.nist.gov/rest/json/source/2.0"
+MAX_SOURCES_PER_PAGE = 1000
+
+
+def _result_iterator(data: JSON) -> Iterator[Source]:
+    sources: Iterable = data.get("sources", [])  # type: ignore
+    return (Source.from_dict(source) for source in sources)
+
+
+class SourceApi(NVDApi):
+    """
+    API for querying the NIST NVD CVE Change History information.
+
+    Should be used as an async context manager.
+
+    Example:
+        .. code-block:: python
+
+            from pontos.nvd.source import SourceApi
+
+            async with SourceApi() as api:
+                async for source in api.source():
+                    print(source)
+    """
+
+    def __init__(
+        self,
+        *,
+        token: Optional[str] = None,
+        timeout: Optional[Timeout] = DEFAULT_TIMEOUT_CONFIG,
+        rate_limit: bool = True,
+        request_attempts: int = 1,
+    ) -> None:
+        """
+        Create a new instance of the CVE API.
+
+        Args:
+            token: The API key to use. Using an API key allows to run more
+                requests at the same time.
+            timeout: Timeout settings for the HTTP requests
+            rate_limit: Set to False to ignore rate limits. The public rate
+                limit (without an API key) is 5 requests in a rolling 30 second
+                window. The rate limit with an API key is 50 requests in a
+                rolling 30 second window.
+                See https://nvd.nist.gov/developers/start-here#divRateLimits
+                Default: True.
+            request_attempts: The number of attempts per HTTP request. Defaults to 1.
+        """
+        super().__init__(
+            DEFAULT_NIST_NVD_CVES_URL,
+            token=token,
+            timeout=timeout,
+            rate_limit=rate_limit,
+            request_attempts=request_attempts,
+        )
+
+    def sources(
+        self,
+        *,
+        last_modified_start_date: Optional[datetime] = None,
+        last_modified_end_date: Optional[datetime] = None,
+        source_identifier: Optional[str] = None,
+        request_results: Optional[int] = None,
+        start_index: int = 0,
+        results_per_page: Optional[int] = None,
+    ) -> NVDResults[Source]:
+        """
+        Get all sources for the provided arguments
+
+        https://nvd.nist.gov/developers/data-sources#divGetSource
+
+        Args:
+            last_modified_start_date: Return all CVEs modified after this date.
+            last_modified_end_date: Return all CVEs modified before this date.
+                If last_modified_start_date is set but no
+                last_modified_end_date is passed it is set to now.
+            source_identifier: Return all source records where the source identifier matches
+            start_index: Index of the first CVE to be returned. Useful only for
+                paginated requests that should not start at the first page.
+            results_per_page: Number of results in a single requests. Mostly
+                useful for paginated requests.
+
+        Returns:
+            A NVDResponse for sources
+
+        Examples:
+            .. code-block:: python
+
+                from pontos.nvd.source import SourceApi
+
+                async with SourceApi() as api:
+                    async for source in api.source(source_identifier="cve@mitre.org"):
+                        print(source)
+        """
+        params: Params = {}
+        if last_modified_start_date:
+            params["lastModStartDate"] = format_date(last_modified_start_date)
+            if not last_modified_end_date:
+                params["lastModEndDate"] = format_date(now())
+        if last_modified_end_date:
+            params["lastModEndDate"] = format_date(last_modified_end_date)
+
+        if source_identifier:
+            params["sourceIdentifier"] = source_identifier
+
+        results_per_page = min(
+            results_per_page or MAX_SOURCES_PER_PAGE,
+            request_results or MAX_SOURCES_PER_PAGE,
+        )
+        return NVDResults(
+            self,
+            params,
+            _result_iterator,
+            request_results=request_results,
+            results_per_page=results_per_page,
+            start_index=start_index,
+        )

--- a/pontos/nvd/source/api.py
+++ b/pontos/nvd/source/api.py
@@ -24,7 +24,9 @@ from pontos.nvd.models.source import Source
 
 __all__ = ("SourceApi",)
 
-DEFAULT_NIST_NVD_CVES_URL = "https://services.nvd.nist.gov/rest/json/source/2.0"
+DEFAULT_NIST_NVD_SOURCE_URL = (
+    "https://services.nvd.nist.gov/rest/json/source/2.0"
+)
 MAX_SOURCES_PER_PAGE = 1000
 
 
@@ -35,7 +37,7 @@ def _result_iterator(data: JSON) -> Iterator[Source]:
 
 class SourceApi(NVDApi):
     """
-    API for querying the NIST NVD CVE Change History information.
+    API for querying the NIST NVD source API.
 
     Should be used as an async context manager.
 
@@ -58,7 +60,7 @@ class SourceApi(NVDApi):
         request_attempts: int = 1,
     ) -> None:
         """
-        Create a new instance of the CVE API.
+        Create a new instance of the source API.
 
         Args:
             token: The API key to use. Using an API key allows to run more
@@ -73,7 +75,7 @@ class SourceApi(NVDApi):
             request_attempts: The number of attempts per HTTP request. Defaults to 1.
         """
         super().__init__(
-            DEFAULT_NIST_NVD_CVES_URL,
+            DEFAULT_NIST_NVD_SOURCE_URL,
             token=token,
             timeout=timeout,
             rate_limit=rate_limit,
@@ -96,12 +98,14 @@ class SourceApi(NVDApi):
         https://nvd.nist.gov/developers/data-sources#divGetSource
 
         Args:
-            last_modified_start_date: Return all CVEs modified after this date.
-            last_modified_end_date: Return all CVEs modified before this date.
+            last_modified_start_date: Return all sources modified after this date.
+            last_modified_end_date: Return all sources modified before this date.
                 If last_modified_start_date is set but no
                 last_modified_end_date is passed it is set to now.
-            source_identifier: Return all source records where the source identifier matches
-            start_index: Index of the first CVE to be returned. Useful only for
+            source_identifier: Return all source records where the source identifier matches.
+            request_results: Number of sources to download. Set to None
+                (default) to download all available CPEs.
+            start_index: Index of the first source to be returned. Useful only for
                 paginated requests that should not start at the first page.
             results_per_page: Number of results in a single requests. Mostly
                 useful for paginated requests.

--- a/pontos/nvd/source/api.py
+++ b/pontos/nvd/source/api.py
@@ -45,7 +45,7 @@ class SourceApi(NVDApi):
             from pontos.nvd.source import SourceApi
 
             async with SourceApi() as api:
-                async for source in api.source():
+                async for source in api.sources():
                     print(source)
     """
 
@@ -115,7 +115,7 @@ class SourceApi(NVDApi):
                 from pontos.nvd.source import SourceApi
 
                 async with SourceApi() as api:
-                    async for source in api.source(source_identifier="cve@mitre.org"):
+                    async for source in api.sources(source_identifier="cve@mitre.org"):
                         print(source)
         """
         params: Params = {}

--- a/pontos/nvd/source/api.py
+++ b/pontos/nvd/source/api.py
@@ -141,3 +141,7 @@ class SourceApi(NVDApi):
             results_per_page=results_per_page,
             start_index=start_index,
         )
+
+    async def __aenter__(self) -> "SourceApi":
+        await super().__aenter__()
+        return self

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,6 +124,7 @@ pontos-nvd-cpe = 'pontos.nvd.cpe:cpe_main'
 pontos-nvd-cpes = 'pontos.nvd.cpe:cpes_main'
 pontos-nvd-cpe-match = 'pontos.nvd.cpe_matches:cpe_match_main'
 pontos-nvd-cpe-matches = 'pontos.nvd.cpe_matches:cpe_matches_main'
+pontos-nvd-sources = 'pontos.nvd.source:main'
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/tests/nvd/__init__.py
+++ b/tests/nvd/__init__.py
@@ -127,3 +127,30 @@ def get_cve_change_data(
     if data:
         cve_changes.update(data)
     return cve_changes
+
+
+def get_source_data(
+    data: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    sources = {
+        "name": "MITRE",
+        "contact_email": "cve@mitre.org",
+        "source_identifiers": [
+            "cve@mitre.org",
+            "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+        ],
+        "last_modified": "2019-09-09T16:18:45.930",
+        "created": "2019-09-09T16:18:45.930",
+        "v3_acceptance_level": {
+            "description": "Contributor",
+            "last_modified": "2025-01-30T00:00:20.107",
+        },
+        "cwe_acceptance_level": {
+            "description": "Reference",
+            "last_modified": "2025-01-24T00:00:00.043",
+        },
+    }
+
+    if data:
+        sources.update(data)
+    return sources

--- a/tests/nvd/source/__init__.py
+++ b/tests/nvd/source/__init__.py
@@ -1,0 +1,3 @@
+# SPDX-FileCopyrightText: 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later

--- a/tests/nvd/source/test_api.py
+++ b/tests/nvd/source/test_api.py
@@ -1,0 +1,185 @@
+# SPDX-FileCopyrightText: 2023 Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+
+from datetime import datetime, timezone
+from typing import Any, Optional
+from unittest.mock import MagicMock, patch
+
+from httpx import AsyncClient, Response
+
+from pontos.nvd.models.source import AcceptanceLevel
+from pontos.nvd.source.api import MAX_SOURCES_PER_PAGE, SourceApi
+from tests import AsyncMock, IsolatedAsyncioTestCase, aiter, anext
+from tests.nvd import get_source_data
+
+
+def create_source_response(
+    name: str, update: Optional[dict[str, Any]] = None
+) -> MagicMock:
+    data = {
+        "sources": [get_source_data({"name": name})],
+        "results_per_page": 1,
+    }
+    if update:
+        data.update(update)
+
+    response = MagicMock(spec=Response)
+    response.json.return_value = data
+    return response
+
+
+def create_source_responses(count: int = 2) -> list[MagicMock]:
+    return [
+        create_source_response(f"MITRE-{i}", {"total_results": count})
+        for i in range(1, count + 1)
+    ]
+
+
+class SourceAPITestCase(IsolatedAsyncioTestCase):
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    def setUp(self, async_client: MagicMock) -> None:
+        self.http_client = AsyncMock()
+        async_client.return_value = self.http_client
+        self.api = SourceApi(token="token")
+
+    async def test_sources(self):
+        self.http_client.get.side_effect = create_source_responses()
+
+        it = aiter(self.api.sources())
+        source = await anext(it)
+
+        self.assertEqual(source.name, "MITRE-1")
+        self.assertEqual(
+            source.contact_email,
+            "cve@mitre.org",
+        )
+        self.assertEqual(
+            source.source_identifiers,
+            [
+                "cve@mitre.org",
+                "8254265b-2729-46b6-b9e3-3dfca2d5bfca",
+            ],
+        )
+        self.assertEqual(
+            source.last_modified,
+            datetime(2019, 9, 9, 16, 18, 45, 930000, tzinfo=timezone.utc),
+        )
+        self.assertEqual(
+            source.created,
+            datetime(2019, 9, 9, 16, 18, 45, 930000, tzinfo=timezone.utc),
+        )
+        self.assertIsNone(source.v2_acceptance_level)
+        self.assertEqual(
+            source.v3_acceptance_level,
+            AcceptanceLevel(
+                "Contributor",
+                datetime(2025, 1, 30, 0, 0, 20, 107000, tzinfo=timezone.utc),
+            ),
+        )
+        self.assertEqual(
+            source.cwe_acceptance_level,
+            AcceptanceLevel(
+                "Reference",
+                datetime(2025, 1, 24, 0, 0, 0, 43000, tzinfo=timezone.utc),
+            ),
+        )
+
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/source/2.0",
+            headers={"apiKey": "token"},
+            params={
+                "startIndex": 0,
+                "resultsPerPage": MAX_SOURCES_PER_PAGE,
+            },
+        )
+
+        self.http_client.get.reset_mock()
+
+        source = await anext(it)
+        self.assertEqual(source.name, "MITRE-2")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/source/2.0",
+            headers={"apiKey": "token"},
+            params={"startIndex": 1, "resultsPerPage": 1},
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            await anext(it)
+
+    async def test_cve_changes_change_dates(self):
+        self.http_client.get.side_effect = create_source_responses()
+
+        it = aiter(
+            self.api.sources(
+                last_modified_start_date=datetime(2025, 1, 1),
+                last_modified_end_date=datetime(2025, 1, 31),
+            )
+        )
+        source = await anext(it)
+
+        self.assertEqual(source.name, "MITRE-1")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/source/2.0",
+            headers={"apiKey": "token"},
+            params={
+                "startIndex": 0,
+                "lastModStartDate": "2025-01-01T00:00:00",
+                "lastModEndDate": "2025-01-31T00:00:00",
+                "resultsPerPage": MAX_SOURCES_PER_PAGE,
+            },
+        )
+
+        self.http_client.get.reset_mock()
+
+        source = await anext(it)
+
+        self.assertEqual(source.name, "MITRE-2")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/source/2.0",
+            headers={"apiKey": "token"},
+            params={
+                "startIndex": 1,
+                "lastModStartDate": "2025-01-01T00:00:00",
+                "lastModEndDate": "2025-01-31T00:00:00",
+                "resultsPerPage": 1,
+            },
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            source = await anext(it)
+
+    async def test_sources_source_identifier(self):
+        self.http_client.get.side_effect = create_source_responses()
+
+        it = aiter(self.api.sources(source_identifier="cve@mitre.org"))
+        source = await anext(it)
+        self.assertEqual(source.name, "MITRE-1")
+
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/source/2.0",
+            headers={"apiKey": "token"},
+            params={
+                "startIndex": 0,
+                "resultsPerPage": MAX_SOURCES_PER_PAGE,
+                "sourceIdentifier": "cve@mitre.org",
+            },
+        )
+
+        self.http_client.get.reset_mock()
+
+        source = await anext(it)
+        self.assertEqual(source.name, "MITRE-2")
+        self.http_client.get.assert_awaited_once_with(
+            "https://services.nvd.nist.gov/rest/json/source/2.0",
+            headers={"apiKey": "token"},
+            params={
+                "startIndex": 1,
+                "resultsPerPage": 1,
+                "sourceIdentifier": "cve@mitre.org",
+            },
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            await anext(it)

--- a/tests/nvd/source/test_api.py
+++ b/tests/nvd/source/test_api.py
@@ -108,7 +108,7 @@ class SourceAPITestCase(IsolatedAsyncioTestCase):
         with self.assertRaises(StopAsyncIteration):
             await anext(it)
 
-    async def test_cve_changes_change_dates(self):
+    async def test_sources_change_dates(self):
         self.http_client.get.side_effect = create_source_responses()
 
         it = aiter(

--- a/tests/nvd/source/test_api.py
+++ b/tests/nvd/source/test_api.py
@@ -183,3 +183,10 @@ class SourceAPITestCase(IsolatedAsyncioTestCase):
 
         with self.assertRaises(StopAsyncIteration):
             await anext(it)
+
+    async def test_context_manager(self):
+        async with self.api:
+            pass
+
+        self.http_client.__aenter__.assert_awaited_once()
+        self.http_client.__aexit__.assert_awaited_once()


### PR DESCRIPTION
## What
This PR adds support for the Source API (https://nvd.nist.gov/developers/data-sources).

## Why
Because we would benefit from it in https://github.com/greenbone/vt-cve-library/blob/ce838381167db66fbafcc66c136ebf39c5a44a5d/vt_cve_library/tools/updater.py#L42-L59 (mostly because of the then easy to use retrying of requests).

## References
Required for https://github.com/greenbone/vt-cve-library/pull/126.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


