### PR TITLE
Change: Align CVE with specification by making fields optional

### DIFF
--- a/pontos/nvd/models/cve.py
+++ b/pontos/nvd/models/cve.py
@@ -268,12 +268,12 @@ class CVE(Model):
     """
 
     id: str
-    source_identifier: str
     published: datetime
     last_modified: datetime
-    vuln_status: str
     descriptions: List[Description]
     references: List[Reference]
+    source_identifier: Optional[str] = None
+    vuln_status: Optional[str] = None
     weaknesses: List[Weakness] = field(default_factory=list)
     configurations: List[Configuration] = field(default_factory=list)
     vendor_comments: List[VendorComment] = field(default_factory=list)


### PR DESCRIPTION
## What
CVE-2025-2682 has no `vulnStatus` field, which is actually allowed as per https://csrc.nist.gov/schema/nvd/api/2.0/cve_api_json_2.0.schema.

## Why
CVE Feeder is currently failing because of `TypeError: CVE.__init__() missing 1 required positional argument: 'vuln_status'` (see https://github.com/greenbone/gretl/actions/runs/14120091570/job/39559249476).

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist
```
➜  pontos git:(fix_optional_fields) pontos-nvd-cve CVE-2025-2682
Traceback (most recent call last):
  File "/home/nthumann/Greenbone/pontos/.venv/bin/pontos-nvd-cve", line 6, in <module>
    sys.exit(cve_main())
             ^^^^^^^^^^
  File "/home/nthumann/Greenbone/pontos/pontos/nvd/cve/__init__.py", line 44, in cve_main
    main(cve_parser(), query_cve)
  File "/home/nthumann/Greenbone/pontos/pontos/nvd/cve/__init__.py", line 49, in main
    asyncio.run(func(args))
  File "/usr/lib/python3.12/asyncio/runners.py", line 194, in run
    return runner.run(main)
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.12/asyncio/base_events.py", line 687, in run_until_complete
    return future.result()
           ^^^^^^^^^^^^^^^
  File "/home/nthumann/Greenbone/pontos/pontos/nvd/cve/__init__.py", line 35, in query_cve
    cve = await api.cve(args.cve_id)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nthumann/Greenbone/pontos/pontos/nvd/cve/api.py", line 297, in cve
    return CVE.from_dict(vulnerability["cve"])
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/nthumann/Greenbone/pontos/pontos/models/__init__.py", line 162, in from_dict
    instance = cls(**kwargs)
               ^^^^^^^^^^^^^
TypeError: CVE.__init__() missing 1 required positional argument: 'vuln_status'
➜  pontos git:(fix_optional_fields) pontos-nvd-cve CVE-2025-2682
CVE(id='CVE-2025-2682', published=datetime.datetime(2025, 3, 24, 4, 15, 14, 6430...
```
