### PR TITLE
Change: Improve error handling of all exists() API methods

### DIFF
--- a/pontos/github/api/branch.py
+++ b/pontos/github/api/branch.py
@@ -266,7 +266,7 @@ def update_from_applied_settings(
 
 
 class GitHubAsyncRESTBranches(GitHubAsyncREST):
-    async def exists(self, repo: str, branch: str) -> bool:
+    async def exists(self, repo: str, branch: str) -> bool:  # type: ignore[return]
         """
         Check if a single branch in a repository exists
 
@@ -295,7 +295,6 @@ class GitHubAsyncRESTBranches(GitHubAsyncREST):
             return False
 
         response.raise_for_status()
-        assert False, "unreachable"  # assert to silence mypy
 
     async def delete(self, repo: str, branch: str) -> None:
         """

--- a/pontos/github/api/branch.py
+++ b/pontos/github/api/branch.py
@@ -287,7 +287,15 @@ class GitHubAsyncRESTBranches(GitHubAsyncREST):
         """
         api = f"/repos/{repo}/branches/{branch}"
         response = await self._client.get(api)
-        return response.is_success
+
+        if response.is_success:
+            return True
+
+        if response.status_code == 404:
+            return False
+
+        response.raise_for_status()
+        assert False, "unreachable"  # assert to silence mypy
 
     async def delete(self, repo: str, branch: str) -> None:
         """

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -19,7 +19,7 @@ from pontos.helper import enum_or_value
 
 
 class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
-    async def exists(self, organization: str) -> bool:
+    async def exists(self, organization: str) -> bool:  # type: ignore[return]
         """
         Check if an organization exists
 
@@ -47,7 +47,6 @@ class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
             return False
 
         response.raise_for_status()
-        assert False, "unreachable"  # assert to silence mypy
 
     async def get_repositories(
         self,

--- a/pontos/github/api/organizations.py
+++ b/pontos/github/api/organizations.py
@@ -39,7 +39,15 @@ class GitHubAsyncRESTOrganizations(GitHubAsyncREST):
         """
         api = f"/orgs/{organization}"
         response = await self._client.get(api)
-        return response.is_success
+
+        if response.is_success:
+            return True
+
+        if response.status_code == 404:
+            return False
+
+        response.raise_for_status()
+        assert False, "unreachable"  # assert to silence mypy
 
     async def get_repositories(
         self,

--- a/pontos/github/api/packages.py
+++ b/pontos/github/api/packages.py
@@ -11,7 +11,7 @@ from pontos.github.models.packages import Package, PackageType, PackageVersion
 
 
 class GitHubAsyncRESTPackages(GitHubAsyncREST):
-    async def exists(
+    async def exists(  # type: ignore[return]
         self, organization: str, package_type: PackageType, package_name: str
     ) -> bool:
         """
@@ -41,7 +41,6 @@ class GitHubAsyncRESTPackages(GitHubAsyncREST):
             return False
 
         response.raise_for_status()
-        assert False, "unreachable"  # assert to silence mypy
 
     async def package(
         self, organization: str, package_type: PackageType, package_name: str

--- a/pontos/github/api/packages.py
+++ b/pontos/github/api/packages.py
@@ -33,7 +33,15 @@ class GitHubAsyncRESTPackages(GitHubAsyncREST):
         """
         api = f"/orgs/{organization}/packages/{package_type}/{package_name}"
         response = await self._client.get(api)
-        return response.is_success
+
+        if response.is_success:
+            return True
+
+        if response.status_code == 404:
+            return False
+
+        response.raise_for_status()
+        assert False, "unreachable"  # assert to silence mypy
 
     async def package(
         self, organization: str, package_type: PackageType, package_name: str

--- a/pontos/github/api/pull_requests.py
+++ b/pontos/github/api/pull_requests.py
@@ -39,7 +39,15 @@ class GitHubAsyncRESTPullRequests(GitHubAsyncREST):
         """
         api = f"/repos/{repo}/pulls/{pull_request}"
         response = await self._client.get(api)
-        return response.is_success
+
+        if response.is_success:
+            return True
+
+        if response.status_code == 404:
+            return False
+
+        response.raise_for_status()
+        assert False, "unreachable"  # assert to silence mypy
 
     async def get(
         self, repo: str, pull_request: Union[int, str]

--- a/pontos/github/api/pull_requests.py
+++ b/pontos/github/api/pull_requests.py
@@ -18,7 +18,7 @@ from pontos.github.models.pull_request import (
 
 
 class GitHubAsyncRESTPullRequests(GitHubAsyncREST):
-    async def exists(self, repo: str, pull_request: Union[int, str]) -> bool:
+    async def exists(self, repo: str, pull_request: Union[int, str]) -> bool:  # type: ignore[return]
         """
         Check if a single branch in a repository exists
 
@@ -47,7 +47,6 @@ class GitHubAsyncRESTPullRequests(GitHubAsyncREST):
             return False
 
         response.raise_for_status()
-        assert False, "unreachable"  # assert to silence mypy
 
     async def get(
         self, repo: str, pull_request: Union[int, str]

--- a/pontos/github/api/release.py
+++ b/pontos/github/api/release.py
@@ -81,7 +81,7 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
         response.raise_for_status()
         return Release.from_dict(response.json())
 
-    async def exists(self, repo: str, tag: str) -> bool:
+    async def exists(self, repo: str, tag: str) -> bool:  # type: ignore[return]
         """
         Check wether a GitHub release exists by tag
 
@@ -110,7 +110,6 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
             return False
 
         response.raise_for_status()
-        assert False, "unreachable"  # assert to silence mypy
 
     async def get(self, repo: str, tag: str) -> Release:
         """

--- a/pontos/github/api/release.py
+++ b/pontos/github/api/release.py
@@ -102,7 +102,15 @@ class GitHubAsyncRESTReleases(GitHubAsyncREST):
         """
         api = f"/repos/{repo}/releases/tags/{tag}"
         response = await self._client.get(api)
-        return response.is_success
+
+        if response.is_success:
+            return True
+
+        if response.status_code == 404:
+            return False
+
+        response.raise_for_status()
+        assert False, "unreachable"  # assert to silence mypy
 
     async def get(self, repo: str, tag: str) -> Release:
         """

--- a/tests/github/api/test_branch.py
+++ b/tests/github/api/test_branch.py
@@ -91,7 +91,7 @@ class GitHubAsyncRESTBranchesTestCase(GitHubAsyncRESTTestCase):
         self.client.get.assert_awaited_once_with("/repos/foo/bar/branches/baz")
 
     async def test_not_exists(self):
-        response = create_response(is_success=False)
+        response = create_response(is_success=False, status_code=404)
         self.client.get.return_value = response
 
         self.assertFalse(await self.api.exists("foo/bar", "baz"))

--- a/tests/github/api/test_branch.py
+++ b/tests/github/api/test_branch.py
@@ -97,6 +97,17 @@ class GitHubAsyncRESTBranchesTestCase(GitHubAsyncRESTTestCase):
         self.assertFalse(await self.api.exists("foo/bar", "baz"))
         self.client.get.assert_awaited_once_with("/repos/foo/bar/branches/baz")
 
+    async def test_exists_error(self):
+        response = create_response(is_success=False, status_code=403)
+        error = HTTPStatusError("403", request=MagicMock(), response=response)
+        response.raise_for_status.side_effect = error
+
+        self.client.get.return_value = response
+
+        with self.assertRaises(HTTPStatusError):
+            await self.api.exists("foo/bar", "baz")
+        self.client.get.assert_awaited_once_with("/repos/foo/bar/branches/baz")
+
     async def test_delete_branch(self):
         response = create_response()
         self.client.delete.return_value = response

--- a/tests/github/api/test_organizations.py
+++ b/tests/github/api/test_organizations.py
@@ -157,7 +157,7 @@ class GitHubAsyncRESTOrganizationsTestCase(GitHubAsyncRESTTestCase):
         self.client.get.assert_awaited_once_with("/orgs/foo")
 
     async def test_not_exists(self):
-        response = create_response(is_success=False)
+        response = create_response(is_success=False, status_code=404)
         self.client.get.return_value = response
 
         self.assertFalse(await self.api.exists("foo"))

--- a/tests/github/api/test_organizations.py
+++ b/tests/github/api/test_organizations.py
@@ -164,6 +164,19 @@ class GitHubAsyncRESTOrganizationsTestCase(GitHubAsyncRESTTestCase):
 
         self.client.get.assert_awaited_once_with("/orgs/foo")
 
+    async def test_exists_error(self):
+        response = create_response(is_success=False, status_code=403)
+        error = httpx.HTTPStatusError(
+            "403", request=MagicMock(), response=response
+        )
+        response.raise_for_status.side_effect = error
+
+        self.client.get.return_value = response
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            await self.api.exists("foo")
+        self.client.get.assert_awaited_once_with("/orgs/foo")
+
     async def test_get_repositories(self):
         response1 = create_response()
         response1.json.return_value = [REPOSITORY_DICT]

--- a/tests/github/api/test_pull_requests.py
+++ b/tests/github/api/test_pull_requests.py
@@ -587,7 +587,7 @@ class GitHubAsyncRESTPullRequestsTestCase(GitHubAsyncRESTTestCase):
         self.client.get.assert_awaited_once_with("/repos/foo/bar/pulls/123")
 
     async def test_not_exists(self):
-        response = create_response(is_success=False)
+        response = create_response(is_success=False, status_code=404)
         self.client.get.return_value = response
 
         self.assertFalse(await self.api.exists("foo/bar", 123))

--- a/tests/github/api/test_pull_requests.py
+++ b/tests/github/api/test_pull_requests.py
@@ -594,6 +594,17 @@ class GitHubAsyncRESTPullRequestsTestCase(GitHubAsyncRESTTestCase):
 
         self.client.get.assert_awaited_once_with("/repos/foo/bar/pulls/123")
 
+    async def test_exists_error(self):
+        response = create_response(is_success=False, status_code=403)
+        error = HTTPStatusError("403", request=MagicMock(), response=response)
+        response.raise_for_status.side_effect = error
+
+        self.client.get.return_value = response
+
+        with self.assertRaises(HTTPStatusError):
+            await self.api.exists("foo/bar", 123)
+        self.client.get.assert_awaited_once_with("/repos/foo/bar/pulls/123")
+
     async def test_commits(self):
         response1 = create_response()
         response1.json.return_value = [

--- a/tests/github/api/test_release.py
+++ b/tests/github/api/test_release.py
@@ -107,7 +107,7 @@ class GitHubAsyncRESTReleasesTestCase(GitHubAsyncRESTTestCase):
         )
 
     async def test_not_exists(self):
-        response = create_response(is_success=False)
+        response = create_response(is_success=False, status_code=404)
         self.client.get.return_value = response
 
         self.assertFalse(await self.api.exists("foo/bar", "v1.2.3"))

--- a/tests/github/api/test_release.py
+++ b/tests/github/api/test_release.py
@@ -116,6 +116,21 @@ class GitHubAsyncRESTReleasesTestCase(GitHubAsyncRESTTestCase):
             "/repos/foo/bar/releases/tags/v1.2.3"
         )
 
+    async def test_exists_error(self):
+        response = create_response(is_success=False, status_code=403)
+        error = httpx.HTTPStatusError(
+            "403", request=MagicMock(), response=response
+        )
+        response.raise_for_status.side_effect = error
+
+        self.client.get.return_value = response
+
+        with self.assertRaises(httpx.HTTPStatusError):
+            await self.api.exists("foo/bar", "v1.2.3")
+        self.client.get.assert_awaited_once_with(
+            "/repos/foo/bar/releases/tags/v1.2.3"
+        )
+
     async def test_create(self):
         response = create_response()
         response.json.return_value = RELEASE_JSON


### PR DESCRIPTION
## What
This PR improves the error handling of all five `exists()` methods of the GitHub API to raise an error, if an unexpected status code occurred.

## Why
Currently, the methods also `False` when the request itself failed, e.g. due to rate limit. The caller however will never notice and will assume that e.g. the branch actually doesn't exist.

As a developer, I expect this methods to return `True` or `False`, when the library is able to make a clear statement. If there was an error, I want to know :) 

Example:
```
import asyncio

from pontos.github.api import GitHubAsyncRESTApi


async def foo():
    async with GitHubAsyncRESTApi() as api:
        while await api.branches.exists("greenbone/pontos", "main"):
            print("Branch exists")

        print("Branch does not exist")


asyncio.run(foo())
```
Without this change:
```
pontos git:(main) ✗ poetry run python test.py
Branch exists
[...takes only a few sec, because it's unauthenticated...]
Branch exists
Branch does not exist
```
With this change:
```
pontos git:(main) ✗ poetry run python test.py
Branch exists
[...takes only a few sec, because it's unauthenticated...]
Branch exists
Traceback (most recent call last):
[...]
httpx.HTTPStatusError: Client error '403 Forbidden' for url 'https://api.github.com/repos/greenbone/pontos/branches/main'
For more information check: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/403
```

## References
I stumbled upon this during investigation of https://github.com/greenbone/notus-generator/actions/runs/15770975917/job/44455761725 (we push a branch and try to create PR immediately after). I assume this could be caused by the error handling, because I can't find a different reason.
```
[...]
remote: 
remote: Create a pull request for '[redacted]' on GitHub by visiting:        
remote:      https://github.com/greenbone/[redacted]/pull/new/[redacted]        
remote: 
To https://github.com/greenbone/[redacted]
 * [new branch]          [redacted] -> [redacted]
Creating PR for [redacted]
 ℹ pontos-github => pull_request
     × Head branch [redacted] is not existing or authorisation 
failed.
```

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


