### PR TITLE
NVD breaking datetime changes

### DIFF
--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -57,6 +57,7 @@ def now() -> datetime:
 
 def format_date(
     date: datetime,
+    *,
     fallback_timezone: timezone = timezone.utc,
     timespec: str = "milliseconds",
 ) -> str:

--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -55,17 +55,28 @@ def now() -> datetime:
     return datetime.now(tz=timezone.utc)
 
 
-def format_date(date: datetime) -> str:
+def format_date(
+    date: datetime,
+    fallback_timezone: timezone = timezone.utc,
+    timespec: str = "milliseconds",
+) -> str:
     """
     Format date matching to NVD api
 
     Args:
         date: Date to format
+        fallback_timezone: The timezone to attach if date
+                           is not timezone aware
+        timespec: Timespec to pass to datetime.isoformat
 
     Returns:
         Formatted date as string
     """
-    return date.isoformat(timespec="seconds")
+
+    if not date.tzinfo:
+        date = date.astimezone(fallback_timezone)
+
+    return date.isoformat(timespec=timespec)
 
 
 def convert_camel_case(dct: Dict[str, Any]) -> Dict[str, Any]:

--- a/tests/nvd/cpe/test_api.py
+++ b/tests/nvd/cpe/test_api.py
@@ -159,11 +159,15 @@ class CPEApiTestCase(IsolatedAsyncioTestCase):
     @patch("pontos.nvd.cpe.api.now", spec=now)
     async def test_cves_last_modified_start_date(self, now_mock: MagicMock):
         uuid = uuid4()
-        now_mock.return_value = datetime(2022, 12, 31)
+        now_mock.return_value = datetime(2022, 12, 31, tzinfo=timezone.utc)
         self.http_client.get.side_effect = create_cpes_responses(uuid)
 
         it = aiter(
-            self.api.cpes(last_modified_start_date=datetime(2022, 12, 1))
+            self.api.cpes(
+                last_modified_start_date=datetime(
+                    2022, 12, 1, tzinfo=timezone.utc
+                )
+            )
         )
         cve = await anext(it)
 
@@ -173,8 +177,8 @@ class CPEApiTestCase(IsolatedAsyncioTestCase):
             headers={},
             params={
                 "startIndex": 0,
-                "lastModStartDate": "2022-12-01T00:00:00",
-                "lastModEndDate": "2022-12-31T00:00:00",
+                "lastModStartDate": "2022-12-01T00:00:00.000+00:00",
+                "lastModEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CPES_PER_PAGE,
             },
         )
@@ -189,8 +193,8 @@ class CPEApiTestCase(IsolatedAsyncioTestCase):
             headers={},
             params={
                 "startIndex": 1,
-                "lastModStartDate": "2022-12-01T00:00:00",
-                "lastModEndDate": "2022-12-31T00:00:00",
+                "lastModStartDate": "2022-12-01T00:00:00.000+00:00",
+                "lastModEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": 1,
             },
         )
@@ -204,8 +208,12 @@ class CPEApiTestCase(IsolatedAsyncioTestCase):
 
         it = aiter(
             self.api.cpes(
-                last_modified_start_date=datetime(2022, 12, 1),
-                last_modified_end_date=datetime(2022, 12, 31),
+                last_modified_start_date=datetime(
+                    2022, 12, 1, tzinfo=timezone.utc
+                ),
+                last_modified_end_date=datetime(
+                    2022, 12, 31, tzinfo=timezone.utc
+                ),
             )
         )
         cve = await anext(it)
@@ -216,8 +224,8 @@ class CPEApiTestCase(IsolatedAsyncioTestCase):
             headers={},
             params={
                 "startIndex": 0,
-                "lastModStartDate": "2022-12-01T00:00:00",
-                "lastModEndDate": "2022-12-31T00:00:00",
+                "lastModStartDate": "2022-12-01T00:00:00.000+00:00",
+                "lastModEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CPES_PER_PAGE,
             },
         )
@@ -232,8 +240,8 @@ class CPEApiTestCase(IsolatedAsyncioTestCase):
             headers={},
             params={
                 "startIndex": 1,
-                "lastModStartDate": "2022-12-01T00:00:00",
-                "lastModEndDate": "2022-12-31T00:00:00",
+                "lastModStartDate": "2022-12-01T00:00:00.000+00:00",
+                "lastModEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": 1,
             },
         )

--- a/tests/nvd/cpe_match/test_api.py
+++ b/tests/nvd/cpe_match/test_api.py
@@ -6,7 +6,7 @@
 # pylint: disable=line-too-long, arguments-differ, redefined-builtin
 # ruff: noqa: E501
 
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Optional
 from unittest.mock import MagicMock, patch
 from uuid import UUID, uuid4
@@ -154,13 +154,17 @@ class CPEMatchApiTestCase(IsolatedAsyncioTestCase):
         match_criteria_id = uuid4()
         cpe_name_id = uuid4()
 
-        now_mock.return_value = datetime(2019, 8, 30)
+        now_mock.return_value = datetime(2019, 8, 30, tzinfo=timezone.utc)
         self.http_client.get.side_effect = create_cpe_match_responses(
             match_criteria_id, cpe_name_id
         )
 
         it = aiter(
-            self.api.cpe_matches(last_modified_start_date=datetime(2019, 6, 1))
+            self.api.cpe_matches(
+                last_modified_start_date=datetime(
+                    2019, 6, 1, tzinfo=timezone.utc
+                )
+            )
         )
         cpe_match = await anext(it)
 
@@ -172,8 +176,8 @@ class CPEMatchApiTestCase(IsolatedAsyncioTestCase):
             headers={},
             params={
                 "startIndex": 0,
-                "lastModStartDate": "2019-06-01T00:00:00",
-                "lastModEndDate": "2019-08-30T00:00:00",
+                "lastModStartDate": "2019-06-01T00:00:00.000+00:00",
+                "lastModEndDate": "2019-08-30T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CPE_MATCHES_PER_PAGE,
             },
         )
@@ -190,8 +194,8 @@ class CPEMatchApiTestCase(IsolatedAsyncioTestCase):
             headers={},
             params={
                 "startIndex": 1,
-                "lastModStartDate": "2019-06-01T00:00:00",
-                "lastModEndDate": "2019-08-30T00:00:00",
+                "lastModStartDate": "2019-06-01T00:00:00.000+00:00",
+                "lastModEndDate": "2019-08-30T00:00:00.000+00:00",
                 "resultsPerPage": 1,
             },
         )
@@ -206,13 +210,15 @@ class CPEMatchApiTestCase(IsolatedAsyncioTestCase):
         match_criteria_id = uuid4()
         cpe_name_id = uuid4()
 
-        now_mock.return_value = datetime(2019, 8, 30)
+        now_mock.return_value = datetime(2019, 8, 30, tzinfo=timezone.utc)
         self.http_client.get.side_effect = create_cpe_match_responses(
             match_criteria_id, cpe_name_id
         )
 
         it = aiter(
-            self.api.cpe_matches(last_modified_end_date=datetime(2019, 8, 1))
+            self.api.cpe_matches(
+                last_modified_end_date=datetime(2019, 8, 1, tzinfo=timezone.utc)
+            )
         )
         cpe_match = await anext(it)
 
@@ -224,7 +230,7 @@ class CPEMatchApiTestCase(IsolatedAsyncioTestCase):
             headers={},
             params={
                 "startIndex": 0,
-                "lastModEndDate": "2019-08-01T00:00:00",
+                "lastModEndDate": "2019-08-01T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CPE_MATCHES_PER_PAGE,
             },
         )
@@ -241,7 +247,7 @@ class CPEMatchApiTestCase(IsolatedAsyncioTestCase):
             headers={},
             params={
                 "startIndex": 1,
-                "lastModEndDate": "2019-08-01T00:00:00",
+                "lastModEndDate": "2019-08-01T00:00:00.000+00:00",
                 "resultsPerPage": 1,
             },
         )

--- a/tests/nvd/cve/test_api.py
+++ b/tests/nvd/cve/test_api.py
@@ -152,11 +152,15 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
 
     @patch("pontos.nvd.cve.api.now", spec=now)
     async def test_cves_last_modified_start_date(self, now_mock: MagicMock):
-        now_mock.return_value = datetime(2022, 12, 31)
+        now_mock.return_value = datetime(2022, 12, 31, tzinfo=timezone.utc)
         self.http_client.get.side_effect = create_cves_responses()
 
         it = aiter(
-            self.api.cves(last_modified_start_date=datetime(2022, 12, 1))
+            self.api.cves(
+                last_modified_start_date=datetime(
+                    2022, 12, 1, tzinfo=timezone.utc
+                )
+            )
         )
         cve = await anext(it)
 
@@ -166,8 +170,8 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 0,
-                "lastModStartDate": "2022-12-01T00:00:00",
-                "lastModEndDate": "2022-12-31T00:00:00",
+                "lastModStartDate": "2022-12-01T00:00:00.000+00:00",
+                "lastModEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CVES_PER_PAGE,
             },
         )
@@ -182,8 +186,8 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 1,
-                "lastModStartDate": "2022-12-01T00:00:00",
-                "lastModEndDate": "2022-12-31T00:00:00",
+                "lastModStartDate": "2022-12-01T00:00:00.000+00:00",
+                "lastModEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": 1,
             },
         )
@@ -196,8 +200,12 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
 
         it = aiter(
             self.api.cves(
-                last_modified_start_date=datetime(2022, 12, 1),
-                last_modified_end_date=datetime(2022, 12, 31),
+                last_modified_start_date=datetime(
+                    2022, 12, 1, tzinfo=timezone.utc
+                ),
+                last_modified_end_date=datetime(
+                    2022, 12, 31, tzinfo=timezone.utc
+                ),
             )
         )
         cve = await anext(it)
@@ -208,8 +216,8 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 0,
-                "lastModStartDate": "2022-12-01T00:00:00",
-                "lastModEndDate": "2022-12-31T00:00:00",
+                "lastModStartDate": "2022-12-01T00:00:00.000+00:00",
+                "lastModEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CVES_PER_PAGE,
             },
         )
@@ -224,8 +232,8 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 1,
-                "lastModStartDate": "2022-12-01T00:00:00",
-                "lastModEndDate": "2022-12-31T00:00:00",
+                "lastModStartDate": "2022-12-01T00:00:00.000+00:00",
+                "lastModEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": 1,
             },
         )
@@ -235,10 +243,14 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
 
     @patch("pontos.nvd.cve.api.now", spec=now)
     async def test_cves_published_start_date(self, now_mock: MagicMock):
-        now_mock.return_value = datetime(2022, 12, 31)
+        now_mock.return_value = datetime(2022, 12, 31, tzinfo=timezone.utc)
         self.http_client.get.side_effect = create_cves_responses()
 
-        it = aiter(self.api.cves(published_start_date=datetime(2022, 12, 1)))
+        it = aiter(
+            self.api.cves(
+                published_start_date=datetime(2022, 12, 1, tzinfo=timezone.utc)
+            )
+        )
         cve = await anext(it)
 
         self.assertEqual(cve.id, "CVE-1-1")
@@ -247,8 +259,8 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 0,
-                "pubStartDate": "2022-12-01T00:00:00",
-                "pubEndDate": "2022-12-31T00:00:00",
+                "pubStartDate": "2022-12-01T00:00:00.000+00:00",
+                "pubEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CVES_PER_PAGE,
             },
         )
@@ -263,8 +275,8 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 1,
-                "pubStartDate": "2022-12-01T00:00:00",
-                "pubEndDate": "2022-12-31T00:00:00",
+                "pubStartDate": "2022-12-01T00:00:00.000+00:00",
+                "pubEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": 1,
             },
         )
@@ -277,8 +289,8 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
 
         it = aiter(
             self.api.cves(
-                published_start_date=datetime(2022, 12, 1),
-                published_end_date=datetime(2022, 12, 31),
+                published_start_date=datetime(2022, 12, 1, tzinfo=timezone.utc),
+                published_end_date=datetime(2022, 12, 31, tzinfo=timezone.utc),
             )
         )
         cve = await anext(it)
@@ -289,8 +301,8 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 0,
-                "pubStartDate": "2022-12-01T00:00:00",
-                "pubEndDate": "2022-12-31T00:00:00",
+                "pubStartDate": "2022-12-01T00:00:00.000+00:00",
+                "pubEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CVES_PER_PAGE,
             },
         )
@@ -305,8 +317,8 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 1,
-                "pubStartDate": "2022-12-01T00:00:00",
-                "pubEndDate": "2022-12-31T00:00:00",
+                "pubStartDate": "2022-12-01T00:00:00.000+00:00",
+                "pubEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": 1,
             },
         )

--- a/tests/nvd/cve_changes/test_api.py
+++ b/tests/nvd/cve_changes/test_api.py
@@ -113,8 +113,8 @@ class CVEChangesApiTestCase(IsolatedAsyncioTestCase):
 
         it = aiter(
             self.api.changes(
-                change_start_date=datetime(2022, 12, 1),
-                change_end_date=datetime(2022, 12, 31),
+                change_start_date=datetime(2022, 12, 1, tzinfo=timezone.utc),
+                change_end_date=datetime(2022, 12, 31, tzinfo=timezone.utc),
             )
         )
         cve_changes = await anext(it)
@@ -125,8 +125,8 @@ class CVEChangesApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 0,
-                "changeStartDate": "2022-12-01T00:00:00",
-                "changeEndDate": "2022-12-31T00:00:00",
+                "changeStartDate": "2022-12-01T00:00:00.000+00:00",
+                "changeEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CVE_CHANGES_PER_PAGE,
             },
         )
@@ -141,8 +141,8 @@ class CVEChangesApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 1,
-                "changeStartDate": "2022-12-01T00:00:00",
-                "changeEndDate": "2022-12-31T00:00:00",
+                "changeStartDate": "2022-12-01T00:00:00.000+00:00",
+                "changeEndDate": "2022-12-31T00:00:00.000+00:00",
                 "resultsPerPage": 1,
             },
         )
@@ -238,8 +238,8 @@ class CVEChangesApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 0,
-                "changeStartDate": "2023-01-01T00:00:00+00:00",
-                "changeEndDate": "2023-01-02T00:00:00+00:00",
+                "changeStartDate": "2023-01-01T00:00:00.000+00:00",
+                "changeEndDate": "2023-01-02T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CVE_CHANGES_PER_PAGE,
             },
         )
@@ -264,8 +264,8 @@ class CVEChangesApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 0,
-                "changeStartDate": "2023-01-01T00:00:00+00:00",
-                "changeEndDate": "2023-05-01T00:00:00+00:00",
+                "changeStartDate": "2023-01-01T00:00:00.000+00:00",
+                "changeEndDate": "2023-05-01T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CVE_CHANGES_PER_PAGE,
             },
         )
@@ -286,8 +286,8 @@ class CVEChangesApiTestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 0,
-                "changeStartDate": "2023-01-01T00:00:00+00:00",
-                "changeEndDate": "2023-05-01T00:00:00+00:00",
+                "changeStartDate": "2023-01-01T00:00:00.000+00:00",
+                "changeEndDate": "2023-05-01T00:00:00.000+00:00",
                 "resultsPerPage": MAX_CVE_CHANGES_PER_PAGE,
             },
         )

--- a/tests/nvd/source/test_api.py
+++ b/tests/nvd/source/test_api.py
@@ -113,8 +113,12 @@ class SourceAPITestCase(IsolatedAsyncioTestCase):
 
         it = aiter(
             self.api.sources(
-                last_modified_start_date=datetime(2025, 1, 1),
-                last_modified_end_date=datetime(2025, 1, 31),
+                last_modified_start_date=datetime(
+                    2025, 1, 1, tzinfo=timezone.utc
+                ),
+                last_modified_end_date=datetime(
+                    2025, 1, 31, tzinfo=timezone.utc
+                ),
             )
         )
         source = await anext(it)
@@ -125,8 +129,8 @@ class SourceAPITestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 0,
-                "lastModStartDate": "2025-01-01T00:00:00",
-                "lastModEndDate": "2025-01-31T00:00:00",
+                "lastModStartDate": "2025-01-01T00:00:00.000+00:00",
+                "lastModEndDate": "2025-01-31T00:00:00.000+00:00",
                 "resultsPerPage": MAX_SOURCES_PER_PAGE,
             },
         )
@@ -141,8 +145,8 @@ class SourceAPITestCase(IsolatedAsyncioTestCase):
             headers={"apiKey": "token"},
             params={
                 "startIndex": 1,
-                "lastModStartDate": "2025-01-01T00:00:00",
-                "lastModEndDate": "2025-01-31T00:00:00",
+                "lastModStartDate": "2025-01-01T00:00:00.000+00:00",
+                "lastModEndDate": "2025-01-31T00:00:00.000+00:00",
                 "resultsPerPage": 1,
             },
         )

--- a/tests/nvd/test_api.py
+++ b/tests/nvd/test_api.py
@@ -6,7 +6,7 @@
 # pylint: disable=protected-access
 
 import unittest
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Iterator
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -42,6 +42,19 @@ class FormatDateTestCase(unittest.TestCase):
         fd = format_date(dt)
 
         self.assertEqual(fd, "2022-12-10T10:00:12.000+00:00")
+
+    def test_format_date_timespec_microseconds(self):
+        dt = datetime(2022, 12, 10, 10, 0, 12, 123, tzinfo=timezone.utc)
+        fd = format_date(dt, timespec="microseconds")
+
+        self.assertEqual(fd, "2022-12-10T10:00:12.000123+00:00")
+
+    def test_format_date_timezone(self):
+        tz = timezone(timedelta(hours=5))
+        dt = datetime(2022, 12, 10, 10, 0, 12, 123, tz)
+        fd = format_date(dt)
+
+        self.assertEqual(fd, "2022-12-10T10:00:12.000+05:00")
 
 
 class NVDApiTestCase(IsolatedAsyncioTestCase):

--- a/tests/nvd/test_api.py
+++ b/tests/nvd/test_api.py
@@ -6,7 +6,7 @@
 # pylint: disable=protected-access
 
 import unittest
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Iterator
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
@@ -38,10 +38,10 @@ class ConvertCamelCaseTestCase(unittest.TestCase):
 
 class FormatDateTestCase(unittest.TestCase):
     def test_format_date(self):
-        dt = datetime(2022, 12, 10, 10, 0, 12, 123)
+        dt = datetime(2022, 12, 10, 10, 0, 12, 123, tzinfo=timezone.utc)
         fd = format_date(dt)
 
-        self.assertEqual(fd, "2022-12-10T10:00:12")
+        self.assertEqual(fd, "2022-12-10T10:00:12.000+00:00")
 
 
 class NVDApiTestCase(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## What

Adjusts the `format_date` method with 2 arguments:

- `timespec` which is a pass through to the `datetime.isoformat` function with default value `milliseconds`
- `fallback_timezone` which attaches a timezone to the passed `date` if its not timezone aware already

The `timespec` parameter allows for easy adjustment of the required timespec on `datetime.isoformat`, if required on a per API level.

The `fallback_timezone` parameter is convenience because I have no idea where all these APIs are consumed and if the dates passed in are timezone aware or not. From the state of the unittests I would assume most are not timezone aware

I tested multiple APIs and all of them were affected.

## Why

[NVD](https://www.nist.gov/itl/nvd) recently (announced 24th july, implemented on 25th :roll_eyes:) rolled out changes to their API spec. This also affects the `published` and `lastmodification` date parameters passed to their API endpoints, as stated in their docs. 

Each datetime passed as these paramters now require milliseconds and timezone to be accepted by their APIs.

## Test examples

Worked previously: https://services.nvd.nist.gov/rest/json/cves/2.0/?lastModStartDate=2025-07-22T07:18:39&lastModEndDate=2025-07-24T13:36:00

Works now: https://services.nvd.nist.gov/rest/json/cves/2.0/?lastModStartDate=2025-07-22T07:18:39.324%2B00:00&lastModEndDate=2025-07-24T13:36:00.000%2B01:00

## References

- [NVD announcement](https://www.nist.gov/itl/nvd)
- Ticket: DOS-436

## Checklist

- [x] Tests


