### PR TITLE
Fix: Invalid CVE configurations data for node schema

### DIFF
--- a/pontos/models/__init__.py
+++ b/pontos/models/__init__.py
@@ -3,6 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from inspect import isclass
@@ -19,6 +20,8 @@ __all__ = (
     "StrEnum",
     "dotted_attributes",
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ModelError(PontosError):
@@ -149,10 +152,18 @@ class Model:
                     model_field_cls = type_hints.get(name)
                     value = _get_value(model_field_cls, value)  # type: ignore # pylint: disable=line-too-long # noqa: E501,PLW2901
             except (ValueError, TypeError) as e:
-                raise ModelError(
-                    f"Error while creating {cls.__name__} model. Could not set "
-                    f"value for property '{name}' from '{value}'."
-                ) from e
+                # NVD data error, monitor for fixed source data
+                # and remove this fix
+                if name == "configurations" and value == [{}]:
+                    value = []  # noqa: PLW2901
+                    logger.warning(
+                        "Empty node configuration for %s", data["id"]
+                    )
+                else:
+                    raise ModelError(
+                        f"Error while creating {cls.__name__} model. Could not set "  # pylint: disable=line-too-long # noqa: E501
+                        f"value for property '{name}' from '{value}'."
+                    ) from e
 
             if name in type_hints:
                 kwargs[name] = value

--- a/tests/nvd/models/test_cve.py
+++ b/tests/nvd/models/test_cve.py
@@ -151,6 +151,19 @@ class CVETestCase(unittest.TestCase):
         self.assertIsNone(cpe_match.version_end_including)
         self.assertIsNone(cpe_match.version_end_excluding)
 
+    def test_configuration_node_empty_object(self):
+        # Once this is fixed from NVD side, implement a test
+        # that checks assertRaises(ModelError)
+        cve = CVE.from_dict(
+            get_cve_data(
+                {
+                    "configurations": [{}],
+                }
+            )
+        )
+
+        self.assertEqual(len(cve.configurations), 0)
+
     def test_metrics_v2(self):
         cve = CVE.from_dict(
             get_cve_data(


### PR DESCRIPTION
## What

There is currently a data error in the NVD CVE response for [CVE-2024-12345](https://services.nvd.nist.gov/rest/json/cves/2.0?cveid=CVE-2024-32849). This leads to pontos breaking when trying to parse the `nodes` in the `configurations` field.

NVD has been contacted about a fix.
We should monitor this CVE and probably remove the workaround once the data is stable again.

## Why

<!-- Describe why are these changes necessary? -->

## References

Jira: DevOps-1617
NVD: [CVE-2024-12345](https://services.nvd.nist.gov/rest/json/cves/2.0?cveid=CVE-2024-32849)

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


