### PR TITLE
Fix: Fix pontos for dependabot - Ruff PLW1641 compliance

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,11 +16,12 @@
 import sys
 from pathlib import Path
 
+from pontos.version import __version__  # Moved to top for Ruff E402 compliance
+
 source_directory = str(Path(__file__).parent.absolute())
 
 sys.path.insert(0, source_directory)
 
-from pontos.version import __version__
 
 # -- Project information -----------------------------------------------------
 

--- a/pontos/version/_version.py
+++ b/pontos/version/_version.py
@@ -150,6 +150,11 @@ class Version(ABC):
     def __str__(self) -> str:
         """A string representation of the version"""
 
+    # --- Added for Ruff PLW1641 compliance ---
+    @abstractmethod
+    def __hash__(self) -> int:
+        pass
+
     def __repr__(self) -> str:
         """A representation of the Version"""
         return f"<{self.__class__.__name__}('{self}')>"

--- a/pontos/version/_version.py
+++ b/pontos/version/_version.py
@@ -153,7 +153,8 @@ class Version(ABC):
     # --- Added for Ruff PLW1641 compliance ---
     @abstractmethod
     def __hash__(self) -> int:
-        pass
+        raise NotImplementedError  # pragma: no cover
+
 
     def __repr__(self) -> str:
         """A representation of the Version"""

--- a/pontos/version/_version.py
+++ b/pontos/version/_version.py
@@ -155,7 +155,6 @@ class Version(ABC):
     def __hash__(self) -> int:
         raise NotImplementedError  # pragma: no cover
 
-
     def __repr__(self) -> str:
         """A representation of the Version"""
         return f"<{self.__class__.__name__}('{self}')>"

--- a/pontos/version/schemes/_pep440.py
+++ b/pontos/version/schemes/_pep440.py
@@ -237,6 +237,10 @@ class PEP440Version(Version):
     def __str__(self) -> str:
         return str(self._version)
 
+    # --- Added for Ruff PLW1641 compliance ---
+    def __hash__(self) -> int:
+        return hash(self._version)
+
 
 class PEP440VersionCalculator(VersionCalculator):
     version_cls = PEP440Version

--- a/pontos/version/schemes/_semantic.py
+++ b/pontos/version/schemes/_semantic.py
@@ -223,6 +223,10 @@ class SemanticVersion(Version):
         """A string representation of the version"""
         return str(self._version_info)
 
+    # --- Added for Ruff PLW1641 compliance ---
+    def __hash__(self) -> int:
+        return hash(self._version_info)
+
     @classmethod
     def from_string(cls, version: str) -> "SemanticVersion":
         """

--- a/tests/version/schemes/test_pep440.py
+++ b/tests/version/schemes/test_pep440.py
@@ -1003,9 +1003,11 @@ class PEP440VersionCalculatorTestCase(unittest.TestCase):
                 f"{release_version} is not the next expected dev version "
                 f"{assert_version} for {current_version}",
             )
-    
+
     def test_hash(self):
-            self.assertEqual(hash(Version("22.2.2")), hash(Version("22.2.2")))
-            self.assertNotEqual(hash(Version("22.2.1")), hash(Version("22.2.2")))
-            self.assertNotEqual(hash(SemanticVersion("22.2.2")), hash("22.2.2"))
-            self.assertNotEqual(hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2")))
+        self.assertEqual(hash(Version("22.2.2")), hash(Version("22.2.2")))
+        self.assertNotEqual(hash(Version("22.2.1")), hash(Version("22.2.2")))
+        self.assertNotEqual(hash(SemanticVersion("22.2.2")), hash("22.2.2"))
+        self.assertNotEqual(
+            hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2"))
+        )

--- a/tests/version/schemes/test_pep440.py
+++ b/tests/version/schemes/test_pep440.py
@@ -1003,3 +1003,9 @@ class PEP440VersionCalculatorTestCase(unittest.TestCase):
                 f"{release_version} is not the next expected dev version "
                 f"{assert_version} for {current_version}",
             )
+    
+    def test_hash(self):
+            self.assertEqual(hash(Version("22.2.2")), hash(Version("22.2.2")))
+            self.assertNotEqual(hash(Version("22.2.1")), hash(Version("22.2.2")))
+            self.assertNotEqual(hash(SemanticVersion("22.2.2")), hash("22.2.2"))
+            self.assertNotEqual(hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2")))

--- a/tests/version/schemes/test_semantic.py
+++ b/tests/version/schemes/test_semantic.py
@@ -10,6 +10,8 @@ from pontos.version._errors import VersionError
 from pontos.version.schemes._pep440 import PEP440Version
 from pontos.version.schemes._semantic import (
     SemanticVersion,
+)
+from pontos.version.schemes._semantic import (
     SemanticVersion as Version,
 )
 from pontos.version.schemes._semantic import (

--- a/tests/version/schemes/test_semantic.py
+++ b/tests/version/schemes/test_semantic.py
@@ -8,7 +8,10 @@ from datetime import datetime
 
 from pontos.version._errors import VersionError
 from pontos.version.schemes._pep440 import PEP440Version
-from pontos.version.schemes._semantic import SemanticVersion, SemanticVersion as Version
+from pontos.version.schemes._semantic import (
+    SemanticVersion,
+    SemanticVersion as Version,
+)
 from pontos.version.schemes._semantic import (
     SemanticVersionCalculator as VersionCalculator,
 )
@@ -1026,9 +1029,15 @@ class SemanticVersionCalculatorTestCase(unittest.TestCase):
                 f"{release_version} is not the expected next development "
                 f"version {assert_version} for {current_version}",
             )
-    
+
     def test_hash(self):
-        self.assertEqual(hash(SemanticVersion("22.2.2")), hash(SemanticVersion("22.2.2")))
-        self.assertNotEqual(hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2")))
+        self.assertEqual(
+            hash(SemanticVersion("22.2.2")), hash(SemanticVersion("22.2.2"))
+        )
+        self.assertNotEqual(
+            hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2"))
+        )
         self.assertNotEqual(hash(SemanticVersion("22.2.2")), hash("22.2.2"))
-        self.assertNotEqual(hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2")))
+        self.assertNotEqual(
+            hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2"))
+        )

--- a/tests/version/schemes/test_semantic.py
+++ b/tests/version/schemes/test_semantic.py
@@ -8,7 +8,7 @@ from datetime import datetime
 
 from pontos.version._errors import VersionError
 from pontos.version.schemes._pep440 import PEP440Version
-from pontos.version.schemes._semantic import SemanticVersion as Version
+from pontos.version.schemes._semantic import SemanticVersion, SemanticVersion as Version
 from pontos.version.schemes._semantic import (
     SemanticVersionCalculator as VersionCalculator,
 )
@@ -1026,3 +1026,9 @@ class SemanticVersionCalculatorTestCase(unittest.TestCase):
                 f"{release_version} is not the expected next development "
                 f"version {assert_version} for {current_version}",
             )
+    
+    def test_hash(self):
+        self.assertEqual(hash(SemanticVersion("22.2.2")), hash(SemanticVersion("22.2.2")))
+        self.assertNotEqual(hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2")))
+        self.assertNotEqual(hash(SemanticVersion("22.2.2")), hash("22.2.2"))
+        self.assertNotEqual(hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2")))

--- a/tests/version/test_version.py
+++ b/tests/version/test_version.py
@@ -31,3 +31,14 @@ class VersionTestCase(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             self.assertNotEqual(PEP440Version("22.2.2"), 22)
+
+    def test_hash(self):
+        self.assertEqual(hash(PEP440Version("22.2.2")), hash(PEP440Version("22.2.2")))
+        self.assertNotEqual(hash(PEP440Version("22.2.1")), hash(PEP440Version("22.2.2")))
+        self.assertNotEqual(hash(SemanticVersion("22.2.2")), hash("22.2.2"))
+        self.assertNotEqual(hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2")))
+    
+    def test_hash_semantic(self):
+        self.assertEqual(hash(SemanticVersion("22.2.2")), hash(SemanticVersion("22.2.2")))
+        self.assertNotEqual(hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2")))
+        self.assertNotEqual(hash(SemanticVersion("22.2.2")), hash("22.2.2"))

--- a/tests/version/test_version.py
+++ b/tests/version/test_version.py
@@ -33,12 +33,22 @@ class VersionTestCase(unittest.TestCase):
             self.assertNotEqual(PEP440Version("22.2.2"), 22)
 
     def test_hash(self):
-        self.assertEqual(hash(PEP440Version("22.2.2")), hash(PEP440Version("22.2.2")))
-        self.assertNotEqual(hash(PEP440Version("22.2.1")), hash(PEP440Version("22.2.2")))
+        self.assertEqual(
+            hash(PEP440Version("22.2.2")), hash(PEP440Version("22.2.2"))
+        )
+        self.assertNotEqual(
+            hash(PEP440Version("22.2.1")), hash(PEP440Version("22.2.2"))
+        )
         self.assertNotEqual(hash(SemanticVersion("22.2.2")), hash("22.2.2"))
-        self.assertNotEqual(hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2")))
-    
+        self.assertNotEqual(
+            hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2"))
+        )
+
     def test_hash_semantic(self):
-        self.assertEqual(hash(SemanticVersion("22.2.2")), hash(SemanticVersion("22.2.2")))
-        self.assertNotEqual(hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2")))
+        self.assertEqual(
+            hash(SemanticVersion("22.2.2")), hash(SemanticVersion("22.2.2"))
+        )
+        self.assertNotEqual(
+            hash(SemanticVersion("22.2.1")), hash(SemanticVersion("22.2.2"))
+        )
         self.assertNotEqual(hash(SemanticVersion("22.2.2")), hash("22.2.2"))


### PR DESCRIPTION
## What

Add missing `__hash__` methods to classes that define `__eq__`, fixing Ruff PLW1641 errors and unblocking dependabot updates.

## Why

Recent Ruff versions introduced stricter checks (`PLW1641`). Dependabot PRs failed CI until this was fixed.

## References

- [DEVOPS-1577](https://jira.greenbone.net/browse/DEVOPS-1577)