### PR TITLE
Support standard project.version field in pyproject.toml

### DIFF
--- a/pontos/version/commands/_python.py
+++ b/pontos/version/commands/_python.py
@@ -34,6 +34,14 @@ class PythonVersionCommand(VersionCommand):
         """
 
         if (
+            "project" in self.pyproject_toml
+            and "version" in self.pyproject_toml["project"]  # type: ignore[operator]
+        ):
+            return PEP440VersioningScheme.parse_version(
+                str(self.pyproject_toml["project"]["version"])  # type: ignore[operator, index]
+            )
+
+        if (
             "tool" in self.pyproject_toml
             and "poetry" in self.pyproject_toml["tool"]  # type: ignore[operator] # noqa: E501
             and "version" in self.pyproject_toml["tool"]["poetry"]  # type: ignore[operator,index] # noqa: E501
@@ -43,8 +51,7 @@ class PythonVersionCommand(VersionCommand):
             )
 
         raise VersionError(
-            "Version information not found in "
-            f"{self.project_file_path} file."
+            f"Version information not found in {self.project_file_path} file."
         )
 
     def _update_version_file(self, new_version: Version) -> None:
@@ -66,16 +73,23 @@ class PythonVersionCommand(VersionCommand):
             self.project_file_path.read_text(encoding="utf-8")
         )
 
-        if "tool" not in pyproject_toml:
-            tool_table = tomlkit.table()
-            pyproject_toml["tool"] = tool_table
+        poetry_lock_file_path = self.project_file_path.parent / "poetry.lock"
+        if poetry_lock_file_path.exists():
+            if "tool" not in pyproject_toml:
+                tool_table = tomlkit.table()
+                pyproject_toml["tool"] = tool_table
 
-        if "poetry" not in pyproject_toml["tool"]:  # type: ignore
-            poetry_table = tomlkit.table()
-            # pylint: disable=line-too-long, no-member # ignore pylint (2.13.9) error: pontos/version/python.py:128:12: E1101: Instance of 'OutOfOrderTableProxy' has no 'add' member (no-member) # noqa: E501
-            pyproject_toml["tool"].add("poetry", poetry_table)  # type: ignore
+            if "poetry" not in pyproject_toml["tool"]:  # type: ignore
+                poetry_table = tomlkit.table()
+                pyproject_toml["tool"].add("poetry", poetry_table)  # type: ignore
 
-        pyproject_toml["tool"]["poetry"]["version"] = str(new_version)  # type: ignore # pylint: disable=line-too-long # noqa: E501
+            pyproject_toml["tool"]["poetry"]["version"] = str(new_version)  # type: ignore
+        else:
+            if "project" not in pyproject_toml:
+                project_table = tomlkit.table()
+                pyproject_toml["project"] = project_table
+
+            pyproject_toml["project"]["version"] = str(new_version)  # type: ignore
 
         self.project_file_path.write_text(
             tomlkit.dumps(pyproject_toml), encoding="utf-8"

--- a/tests/version/commands/test_python.py
+++ b/tests/version/commands/test_python.py
@@ -177,6 +177,8 @@ class UpdatePythonVersionTestCase(unittest.TestCase):
     def test_empty_tool_poetry_section(self):
         content = "__version__ = '22.1'"
         with temp_python_module(content, name="foo", change_into=True) as temp:
+            temp_poetry_lock = temp.parent / "poetry.lock"
+            temp_poetry_lock.touch()
             tmp_file = temp.parent / "pyproject.toml"
             tmp_file.write_text(
                 "[tool.poetry]\n"
@@ -200,12 +202,38 @@ class UpdatePythonVersionTestCase(unittest.TestCase):
 
             self.assertEqual(toml["tool"]["poetry"]["version"], "22.2")
 
+    def test_empty_project_section(self):
+        content = "__version__ = '22.1'"
+        with temp_python_module(content, name="foo", change_into=True) as temp:
+            tmp_file = temp.parent / "pyproject.toml"
+            tmp_file.write_text(
+                "[project]\n"
+                '[tool.pontos.version]\nversion-module-file = "foo.py"',
+                encoding="utf8",
+            )
+            cmd = PythonVersionCommand(PEP440VersioningScheme)
+            new_version = PEP440VersioningScheme.parse_version("22.2")
+            previous_version = PEP440VersioningScheme.parse_version("22.1")
+            updated = cmd.update_version(new_version)
+
+            self.assertEqual(updated.new, new_version)
+            self.assertEqual(updated.previous, previous_version)
+            self.assertEqual(
+                updated.changed_files, [Path("foo.py"), tmp_file.resolve()]
+            )
+
+            text = tmp_file.read_text(encoding="utf8")
+
+            toml = tomlkit.parse(text)
+
+            self.assertEqual(toml["project"]["version"], "22.2")
+
     def test_override_existing_version(self):
         content = "__version__ = '1.2.3'"
         with temp_python_module(content, name="foo", change_into=True) as temp:
             tmp_file = temp.parent / "pyproject.toml"
             tmp_file.write_text(
-                '[tool.poetry]\nversion = "1.2.3"\n'
+                '[project]\nversion = "1.2.3"\n'
                 '[tool.pontos.version]\nversion-module-file = "foo.py"',
                 encoding="utf8",
             )
@@ -224,14 +252,14 @@ class UpdatePythonVersionTestCase(unittest.TestCase):
 
             toml = tomlkit.parse(text)
 
-            self.assertEqual(toml["tool"]["poetry"]["version"], "22.2")
+            self.assertEqual(toml["project"]["version"], "22.2")
 
     def test_development_version(self):
         content = "__version__ = '1.2.3'"
         with temp_python_module(content, name="foo", change_into=True) as temp:
             tmp_file = temp.parent / "pyproject.toml"
             tmp_file.write_text(
-                '[tool.poetry]\nversion = "1.2.3"\n'
+                '[project]\nversion = "1.2.3"\n'
                 '[tool.pontos.version]\nversion-module-file = "foo.py"',
                 encoding="utf8",
             )
@@ -250,7 +278,7 @@ class UpdatePythonVersionTestCase(unittest.TestCase):
 
             toml = tomlkit.parse(text)
 
-            self.assertEqual(toml["tool"]["poetry"]["version"], "22.2.dev1")
+            self.assertEqual(toml["project"]["version"], "22.2.dev1")
 
     def test_no_update(self):
         content = "__version__ = '1.2.3'"
@@ -320,7 +348,32 @@ class VerifyVersionTestCase(unittest.TestCase):
             version = PEP440VersioningScheme.parse_version("1.2.3")
             cmd.verify_version(version)
 
-    def test_current_version(self):
+    def test_current_version_with_project_version(self):
+        fake_version_py = Path("foo.py")
+        content = (
+            '[project]\nversion = "1.2.3"\n'
+            '[tool.pontos.version]\nversion-module-file = "foo.py"'
+        )
+
+        with (
+            temp_file(content, name="pyproject.toml", change_into=True),
+            patch.object(
+                PythonVersionCommand,
+                "get_current_version",
+                MagicMock(
+                    return_value=PEP440VersioningScheme.parse_version("1.2.3")
+                ),
+            ),
+            patch.object(
+                PythonVersionCommand,
+                "version_file_path",
+                new=PropertyMock(return_value=fake_version_py),
+            ),
+        ):
+            cmd = PythonVersionCommand(PEP440VersioningScheme)
+            cmd.verify_version("current")
+
+    def test_current_version_with_poetry_version(self):
         fake_version_py = Path("foo.py")
         content = (
             '[tool.poetry]\nversion = "1.2.3"\n'
@@ -345,7 +398,36 @@ class VerifyVersionTestCase(unittest.TestCase):
             cmd = PythonVersionCommand(PEP440VersioningScheme)
             cmd.verify_version("current")
 
-    def test_current_failure(self):
+    def test_current_failure_with_project_version(self):
+        fake_version_py = Path("foo.py")
+        content = (
+            '[project]\nversion = "1.2.4"\n'
+            '[tool.pontos.version]\nversion-module-file = "foo.py"'
+        )
+
+        with (
+            temp_file(content, name="pyproject.toml", change_into=True),
+            patch.object(
+                PythonVersionCommand,
+                "get_current_version",
+                MagicMock(
+                    return_value=PEP440VersioningScheme.parse_version("1.2.3")
+                ),
+            ),
+            patch.object(
+                PythonVersionCommand,
+                "version_file_path",
+                new=PropertyMock(return_value=fake_version_py),
+            ),
+            self.assertRaisesRegex(
+                VersionError,
+                "The version .* in .* doesn't match the current version .*.",
+            ),
+        ):
+            cmd = PythonVersionCommand(PEP440VersioningScheme)
+            cmd.verify_version("current")
+
+    def test_current_failure_with_poetry_version(self):
         fake_version_py = Path("foo.py")
         content = (
             '[tool.poetry]\nversion = "1.2.4"\n'
@@ -374,7 +456,37 @@ class VerifyVersionTestCase(unittest.TestCase):
             cmd = PythonVersionCommand(PEP440VersioningScheme)
             cmd.verify_version("current")
 
-    def test_provided_version_mismatch(self):
+    def test_provided_version_mismatch_with_project_version(self):
+        fake_version_py = Path("foo.py")
+        content = (
+            '[project]\nversion = "1.2.3"\n'
+            '[tool.pontos.version]\nversion-module-file = "foo.py"'
+        )
+
+        with (
+            temp_file(content, name="pyproject.toml", change_into=True),
+            patch.object(
+                PythonVersionCommand,
+                "get_current_version",
+                MagicMock(
+                    return_value=PEP440VersioningScheme.parse_version("1.2.3")
+                ),
+            ),
+            patch.object(
+                PythonVersionCommand,
+                "version_file_path",
+                new=PropertyMock(return_value=fake_version_py),
+            ),
+        ):
+            with self.assertRaisesRegex(
+                VersionError,
+                "Provided version .* does not match the current version .*.",
+            ):
+                cmd = PythonVersionCommand(PEP440VersioningScheme)
+                version = PEP440VersioningScheme.parse_version("1.2.4")
+                cmd.verify_version(version)
+
+    def test_provided_version_mismatch_with_poetry_version(self):
         fake_version_py = Path("foo.py")
         content = (
             '[tool.poetry]\nversion = "1.2.3"\n'
@@ -404,7 +516,34 @@ class VerifyVersionTestCase(unittest.TestCase):
                 version = PEP440VersioningScheme.parse_version("1.2.4")
                 cmd.verify_version(version)
 
-    def test_verify_success(self):
+    def test_verify_success_with_project_version(self):
+        fake_version_py = Path("foo.py")
+        content = (
+            '[project]\nversion = "1.2.3"\n'
+            '[tool.pontos.version]\nversion-module-file = "foo.py"'
+        )
+
+        with (
+            temp_file(content, name="pyproject.toml", change_into=True),
+            patch.object(
+                PythonVersionCommand,
+                "get_current_version",
+                MagicMock(
+                    return_value=PEP440VersioningScheme.parse_version("1.2.3")
+                ),
+            ),
+            patch.object(
+                PythonVersionCommand,
+                "version_file_path",
+                new=PropertyMock(return_value=fake_version_py),
+            ),
+        ):
+            cmd = PythonVersionCommand(PEP440VersioningScheme)
+            version = PEP440VersioningScheme.parse_version("1.2.3")
+
+            cmd.verify_version(version)
+
+    def test_verify_success_with_poetry_version(self):
         fake_version_py = Path("foo.py")
         content = (
             '[tool.poetry]\nversion = "1.2.3"\n'


### PR DESCRIPTION


## What

Support standard project.version field in pyproject.toml

## Why

Since we started pontos the fields in pyproject.toml got more and more standardized. Nowadays the version information can be found at the `project.version` field. For example

```toml
[project]
version = "1.2.3"
```

This change considers this version field now and also falls back to `tools.poetry.version` if it is not available. It also fixes release issues with other tools then poetry.

## References

https://github.com/greenbone/python-gvm/issues/1319

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


