### PR TITLE
Add: Consumer-side exception handling for NVD APIs

### DIFF
--- a/pontos/models/__init__.py
+++ b/pontos/models/__init__.py
@@ -7,12 +7,21 @@ import logging
 from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from inspect import isclass
-from typing import Any, Dict, Type, Union, get_args, get_origin, get_type_hints
+from typing import (
+    Any,
+    Dict,
+    Type,
+    Union,
+    get_args,
+    get_origin,
+    get_type_hints,
+)
 
 from dateutil import parser as dateparser
 
 from pontos.enum import StrEnum
 from pontos.errors import PontosError
+from pontos.nvd.api import JSON
 
 __all__ = (
     "Model",
@@ -28,6 +37,10 @@ class ModelError(PontosError):
     """
     Errors raised for Models
     """
+
+    def __init__(self, message: str, data: JSON):
+        super().__init__(message)
+        self.data = data
 
 
 def dotted_attributes(obj: Any, data: Dict[str, Any]) -> Any:
@@ -162,7 +175,8 @@ class Model:
                 else:
                     raise ModelError(
                         f"Error while creating {cls.__name__} model. Could not set "  # pylint: disable=line-too-long # noqa: E501
-                        f"value for property '{name}' from '{value}'."
+                        f"value for property '{name}' from '{value}'.",
+                        data,
                     ) from e
 
             if name in type_hints:

--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -110,7 +110,7 @@ class InvalidState(PontosError):
 
 T = TypeVar("T")
 
-result_iterator_func = Callable[[JSON], Iterator[T]]
+result_iterator_func = Callable[[JSON, bool], Iterator[T]]
 
 
 class NVDResults(Generic[T], AsyncIterable[T], Awaitable["NVDResults"]):
@@ -129,6 +129,7 @@ class NVDResults(Generic[T], AsyncIterable[T], Awaitable["NVDResults"]):
         request_results: Optional[int] = None,
         results_per_page: Optional[int] = None,
         start_index: int = 0,
+        return_exceptions: bool = False,
     ) -> None:
         self._api = api
         self._params = params
@@ -148,6 +149,7 @@ class NVDResults(Generic[T], AsyncIterable[T], Awaitable["NVDResults"]):
         self._current_results_per_page = results_per_page
 
         self._result_func = result_func
+        self._return_exceptions = return_exceptions
 
     async def chunks(self) -> AsyncIterator[Sequence[T]]:
         """
@@ -324,7 +326,7 @@ class NVDResults(Generic[T], AsyncIterable[T], Awaitable["NVDResults"]):
 
     async def _get_next_iterator(self) -> Iterator[T]:
         await self._load_next_data()
-        return self._result_func(self._data)  # type: ignore
+        return self._result_func(self._data, self._return_exceptions)  # type: ignore
 
     async def _next_iterator(self) -> "NVDResults":
         self._it = await self._get_next_iterator()

--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -110,7 +110,7 @@ class InvalidState(PontosError):
 
 T = TypeVar("T")
 
-result_iterator_func = Callable[[JSON, bool], Iterator[T]]
+result_iterator_func = Callable[[JSON, bool], Iterator[T | Exception]]
 
 
 class NVDResults(Generic[T], AsyncIterable[T], Awaitable["NVDResults"]):

--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -43,6 +43,7 @@ __all__ = (
     "convert_camel_case",
     "format_date",
     "now",
+    "return_or_raise",
     "NVDApi",
     "NVDResults",
 )
@@ -111,6 +112,29 @@ class InvalidState(PontosError):
 T = TypeVar("T")
 
 result_iterator_func = Callable[[JSON, bool], Iterator[T | Exception]]
+
+
+def return_or_raise(
+    func: Callable[[], T],
+    return_exceptions: bool,
+) -> T | Exception:
+    """
+    Execute a function and return the result or the exception or raise the exception.
+
+    Args:
+        func: Callable to execute.
+        return_exceptions: If True, return exceptions. If False, raise them.
+
+    Returns:
+        The result of the function or the exception if return_exceptions is True.
+    """
+    try:
+        return func()
+    except Exception as exception:
+        if return_exceptions:
+            return exception
+
+        raise exception
 
 
 class NVDResults(Generic[T], AsyncIterable[T], Awaitable["NVDResults"]):

--- a/pontos/nvd/cpe/api.py
+++ b/pontos/nvd/cpe/api.py
@@ -35,9 +35,16 @@ DEFAULT_NIST_NVD_CPES_URL = "https://services.nvd.nist.gov/rest/json/cpes/2.0"
 MAX_CPES_PER_PAGE = 10000
 
 
-def _result_iterator(data: JSON) -> Iterator[CPE]:
+def _result_iterator(data: JSON, return_exceptions: bool) -> Iterator[CPE]:
     results: list[dict[str, Any]] = data.get("products", [])  # type: ignore
-    return (CPE.from_dict(result["cpe"]) for result in results)
+    for result in results:
+        try:
+            yield CPE.from_dict(result["cpe"])
+        except Exception as exception:
+            if return_exceptions:
+                yield exception  # type: ignore
+            else:
+                raise exception
 
 
 class CPEApi(NVDApi):
@@ -133,6 +140,7 @@ class CPEApi(NVDApi):
         request_results: Optional[int] = None,
         start_index: int = 0,
         results_per_page: Optional[int] = None,
+        return_exceptions: bool = False,
     ) -> NVDResults[CPE]:
         """
         Get all CPEs for the provided arguments
@@ -156,6 +164,8 @@ class CPEApi(NVDApi):
                 paginated requests that should not start at the first page.
             results_per_page: Number of results in a single requests. Mostly
                 useful for paginated requests.
+            return_exceptions: If True, exceptions during parsing of API
+                response will be returned instead of raised. Default: False.
 
         Returns:
             A NVDResponse for CPEs
@@ -211,6 +221,7 @@ class CPEApi(NVDApi):
             request_results=request_results,
             results_per_page=results_per_page,
             start_index=start_index,
+            return_exceptions=return_exceptions,
         )
 
     async def __aenter__(self) -> "CPEApi":

--- a/pontos/nvd/cpe/api.py
+++ b/pontos/nvd/cpe/api.py
@@ -35,7 +35,9 @@ DEFAULT_NIST_NVD_CPES_URL = "https://services.nvd.nist.gov/rest/json/cpes/2.0"
 MAX_CPES_PER_PAGE = 10000
 
 
-def _result_iterator(data: JSON, return_exceptions: bool) -> Iterator[CPE]:
+def _result_iterator(
+    data: JSON, return_exceptions: bool
+) -> Iterator[CPE | Exception]:
     results: list[dict[str, Any]] = data.get("products", [])  # type: ignore
     for result in results:
         try:

--- a/pontos/nvd/cpe/api.py
+++ b/pontos/nvd/cpe/api.py
@@ -28,6 +28,7 @@ from pontos.nvd.api import (
     convert_camel_case,
     format_date,
     now,
+    return_or_raise,
 )
 from pontos.nvd.models.cpe import CPE
 
@@ -40,13 +41,10 @@ def _result_iterator(
 ) -> Iterator[CPE | Exception]:
     results: list[dict[str, Any]] = data.get("products", [])  # type: ignore
     for result in results:
-        try:
-            yield CPE.from_dict(result["cpe"])
-        except Exception as exception:
-            if return_exceptions:
-                yield exception  # type: ignore
-            else:
-                raise exception
+        yield return_or_raise(
+            lambda: CPE.from_dict(result["cpe"]),
+            return_exceptions,
+        )
 
 
 class CPEApi(NVDApi):

--- a/pontos/nvd/cpe_match/api.py
+++ b/pontos/nvd/cpe_match/api.py
@@ -163,7 +163,7 @@ class CPEMatchApi(NVDApi):
 
     def _result_iterator(
         self, data: JSON, return_exceptions: bool
-    ) -> Iterator[CPEMatchString]:
+    ) -> Iterator[CPEMatchString | Exception]:
         """
         Creates an iterator of all the CPEMatchStrings in given API response JSON
 

--- a/pontos/nvd/cpe_match/api.py
+++ b/pontos/nvd/cpe_match/api.py
@@ -23,6 +23,7 @@ from pontos.nvd.api import (
     convert_camel_case,
     format_date,
     now,
+    return_or_raise,
 )
 from pontos.nvd.models.cpe_match_string import CPEMatchString
 
@@ -175,15 +176,12 @@ class CPEMatchApi(NVDApi):
         """
         results: list[dict[str, Any]] = data.get("match_strings", [])  # type: ignore
         for result in results:
-            try:
-                yield CPEMatchString.from_dict_with_cache(
+            yield return_or_raise(
+                lambda: CPEMatchString.from_dict_with_cache(
                     result["match_string"], self._cpe_match_cache
-                )
-            except Exception as exception:
-                if return_exceptions:
-                    yield exception  # type: ignore
-                else:
-                    raise exception
+                ),
+                return_exceptions,
+            )
 
     async def cpe_match(self, match_criteria_id: str) -> CPEMatchString:
         """

--- a/pontos/nvd/cpe_match/api.py
+++ b/pontos/nvd/cpe_match/api.py
@@ -88,6 +88,7 @@ class CPEMatchApi(NVDApi):
         request_results: Optional[int] = None,
         start_index: int = 0,
         results_per_page: Optional[int] = None,
+        return_exceptions: bool = False,
     ) -> NVDResults[CPEMatchString]:
         """
         Get all CPE matches for the provided arguments
@@ -106,6 +107,8 @@ class CPEMatchApi(NVDApi):
                 page.
             results_per_page: Number of results in a single requests. Mostly
                 useful for paginated requests.
+            return_exceptions: If True, exceptions during parsing of API
+                response will be returned instead of raised. Default: False.
 
         Returns:
             A NVDResponse for CPE matches
@@ -155,9 +158,12 @@ class CPEMatchApi(NVDApi):
             request_results=request_results,
             results_per_page=results_per_page,
             start_index=start_index,
+            return_exceptions=return_exceptions,
         )
 
-    def _result_iterator(self, data: JSON) -> Iterator[CPEMatchString]:
+    def _result_iterator(
+        self, data: JSON, return_exceptions: bool
+    ) -> Iterator[CPEMatchString]:
         """
         Creates an iterator of all the CPEMatchStrings in given API response JSON
 
@@ -168,12 +174,16 @@ class CPEMatchApi(NVDApi):
             An iterator over the CPEMatchStrings
         """
         results: list[dict[str, Any]] = data.get("match_strings", [])  # type: ignore
-        return (
-            CPEMatchString.from_dict_with_cache(
-                result["match_string"], self._cpe_match_cache
-            )
-            for result in results
-        )
+        for result in results:
+            try:
+                yield CPEMatchString.from_dict_with_cache(
+                    result["match_string"], self._cpe_match_cache
+                )
+            except Exception as exception:
+                if return_exceptions:
+                    yield exception  # type: ignore
+                else:
+                    raise exception
 
     async def cpe_match(self, match_criteria_id: str) -> CPEMatchString:
         """

--- a/pontos/nvd/cve/api.py
+++ b/pontos/nvd/cve/api.py
@@ -37,11 +37,16 @@ DEFAULT_NIST_NVD_CVES_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 MAX_CVES_PER_PAGE = 2000
 
 
-def _result_iterator(data: JSON) -> Iterator[CVE]:
+def _result_iterator(data: JSON, return_exceptions: bool) -> Iterator[CVE]:
     vulnerabilities: Iterable = data.get("vulnerabilities", [])  # type: ignore
-    return (
-        CVE.from_dict(vulnerability["cve"]) for vulnerability in vulnerabilities
-    )
+    for vulnerability in vulnerabilities:
+        try:
+            yield CVE.from_dict(vulnerability["cve"])
+        except Exception as exception:
+            if return_exceptions:
+                yield exception  # type: ignore
+            else:
+                raise exception
 
 
 class CVEApi(NVDApi):
@@ -114,6 +119,7 @@ class CVEApi(NVDApi):
         request_results: Optional[int] = None,
         start_index: int = 0,
         results_per_page: Optional[int] = None,
+        return_exceptions: bool = False,
     ) -> NVDResults[CVE]:
         """
         Get all CVEs for the provided arguments
@@ -168,6 +174,8 @@ class CVEApi(NVDApi):
                 paginated requests that should not start at the first page.
             results_per_page: Number of results in a single requests. Mostly
                 useful for paginated requests.
+            return_exceptions: If True, exceptions during parsing of API
+                response will be returned instead of raised. Default: False.
 
         Returns:
             A NVDResponse for CVEs
@@ -257,6 +265,7 @@ class CVEApi(NVDApi):
             request_results=request_results,
             results_per_page=results_per_page,
             start_index=start_index,
+            return_exceptions=return_exceptions,
         )
 
     async def cve(self, cve_id: str) -> CVE:

--- a/pontos/nvd/cve/api.py
+++ b/pontos/nvd/cve/api.py
@@ -37,7 +37,9 @@ DEFAULT_NIST_NVD_CVES_URL = "https://services.nvd.nist.gov/rest/json/cves/2.0"
 MAX_CVES_PER_PAGE = 2000
 
 
-def _result_iterator(data: JSON, return_exceptions: bool) -> Iterator[CVE]:
+def _result_iterator(
+    data: JSON, return_exceptions: bool
+) -> Iterator[CVE | Exception]:
     vulnerabilities: Iterable = data.get("vulnerabilities", [])  # type: ignore
     for vulnerability in vulnerabilities:
         try:

--- a/pontos/nvd/cve/api.py
+++ b/pontos/nvd/cve/api.py
@@ -26,6 +26,7 @@ from pontos.nvd.api import (
     convert_camel_case,
     format_date,
     now,
+    return_or_raise,
 )
 from pontos.nvd.models.cve import CVE
 from pontos.nvd.models.cvss_v2 import Severity as CVSSv2Severity
@@ -42,13 +43,10 @@ def _result_iterator(
 ) -> Iterator[CVE | Exception]:
     vulnerabilities: Iterable = data.get("vulnerabilities", [])  # type: ignore
     for vulnerability in vulnerabilities:
-        try:
-            yield CVE.from_dict(vulnerability["cve"])
-        except Exception as exception:
-            if return_exceptions:
-                yield exception  # type: ignore
-            else:
-                raise exception
+        yield return_or_raise(
+            lambda: CVE.from_dict(vulnerability["cve"]),
+            return_exceptions,
+        )
 
 
 class CVEApi(NVDApi):

--- a/pontos/nvd/cve_changes/api.py
+++ b/pontos/nvd/cve_changes/api.py
@@ -16,6 +16,7 @@ from pontos.nvd.api import (
     Params,
     format_date,
     now,
+    return_or_raise,
 )
 from pontos.nvd.models.cve_change import CVEChange, EventName
 
@@ -33,13 +34,10 @@ def _result_iterator(
 ) -> Iterator[CVEChange | Exception]:
     results: list[dict[str, Any]] = data.get("cve_changes", [])  # type: ignore
     for result in results:
-        try:
-            yield CVEChange.from_dict(result["change"])
-        except Exception as exception:
-            if return_exceptions:
-                yield exception  # type: ignore
-            else:
-                raise exception
+        yield return_or_raise(
+            lambda: CVEChange.from_dict(result["change"]),
+            return_exceptions,
+        )
 
 
 class CVEChangesApi(NVDApi):

--- a/pontos/nvd/cve_changes/api.py
+++ b/pontos/nvd/cve_changes/api.py
@@ -35,11 +35,11 @@ def _result_iterator(
     for result in results:
         try:
             yield CVEChange.from_dict(result["change"])
-        except Exception as e:
+        except Exception as exception:
             if return_exceptions:
-                yield e  # type: ignore
+                yield exception  # type: ignore
             else:
-                raise e
+                raise exception
 
 
 class CVEChangesApi(NVDApi):

--- a/pontos/nvd/cve_changes/api.py
+++ b/pontos/nvd/cve_changes/api.py
@@ -28,9 +28,18 @@ DEFAULT_NIST_NVD_CVE_HISTORY_URL = (
 MAX_CVE_CHANGES_PER_PAGE = 5000
 
 
-def _result_iterator(data: JSON) -> Iterator[CVEChange]:
+def _result_iterator(
+    data: JSON, return_exceptions: bool
+) -> Iterator[CVEChange]:
     results: list[dict[str, Any]] = data.get("cve_changes", [])  # type: ignore
-    return (CVEChange.from_dict(result["change"]) for result in results)
+    for result in results:
+        try:
+            yield CVEChange.from_dict(result["change"])
+        except Exception as e:
+            if return_exceptions:
+                yield e  # type: ignore
+            else:
+                raise e
 
 
 class CVEChangesApi(NVDApi):
@@ -90,6 +99,7 @@ class CVEChangesApi(NVDApi):
         request_results: Optional[int] = None,
         start_index: int = 0,
         results_per_page: Optional[int] = None,
+        return_exceptions: bool = False,
     ) -> NVDResults[CVEChange]:
         """
         Get all CVEs for the provided arguments
@@ -108,6 +118,8 @@ class CVEChangesApi(NVDApi):
                 page.
             results_per_page: Number of results in a single requests. Mostly
                 useful for paginated requests.
+            return_exceptions: If True, exceptions during parsing of API response will be
+                returned instead of raised. Default: False.
 
         Returns:
             A NVDResponse for CVE changes
@@ -163,6 +175,7 @@ class CVEChangesApi(NVDApi):
             request_results=request_results,
             results_per_page=results_per_page,
             start_index=start_index,
+            return_exceptions=return_exceptions,
         )
 
     async def __aenter__(self) -> "CVEChangesApi":

--- a/pontos/nvd/cve_changes/api.py
+++ b/pontos/nvd/cve_changes/api.py
@@ -30,7 +30,7 @@ MAX_CVE_CHANGES_PER_PAGE = 5000
 
 def _result_iterator(
     data: JSON, return_exceptions: bool
-) -> Iterator[CVEChange]:
+) -> Iterator[CVEChange | Exception]:
     results: list[dict[str, Any]] = data.get("cve_changes", [])  # type: ignore
     for result in results:
         try:

--- a/pontos/nvd/source/api.py
+++ b/pontos/nvd/source/api.py
@@ -30,9 +30,16 @@ DEFAULT_NIST_NVD_SOURCE_URL = (
 MAX_SOURCES_PER_PAGE = 1000
 
 
-def _result_iterator(data: JSON) -> Iterator[Source]:
+def _result_iterator(data: JSON, return_exceptions: bool) -> Iterator[Source]:
     sources: Iterable = data.get("sources", [])  # type: ignore
-    return (Source.from_dict(source) for source in sources)
+    for source in sources:
+        try:
+            yield Source.from_dict(source)
+        except Exception as exception:
+            if return_exceptions:
+                yield exception  # type: ignore
+            else:
+                raise exception
 
 
 class SourceApi(NVDApi):
@@ -91,6 +98,7 @@ class SourceApi(NVDApi):
         request_results: Optional[int] = None,
         start_index: int = 0,
         results_per_page: Optional[int] = None,
+        return_exceptions: bool = False,
     ) -> NVDResults[Source]:
         """
         Get all sources for the provided arguments
@@ -109,6 +117,8 @@ class SourceApi(NVDApi):
                 paginated requests that should not start at the first page.
             results_per_page: Number of results in a single requests. Mostly
                 useful for paginated requests.
+            return_exceptions: If True, exceptions during parsing of API
+                response will be returned instead of raised. Default: False.
 
         Returns:
             A NVDResponse for sources
@@ -144,6 +154,7 @@ class SourceApi(NVDApi):
             request_results=request_results,
             results_per_page=results_per_page,
             start_index=start_index,
+            return_exceptions=return_exceptions,
         )
 
     async def __aenter__(self) -> "SourceApi":

--- a/pontos/nvd/source/api.py
+++ b/pontos/nvd/source/api.py
@@ -19,6 +19,7 @@ from pontos.nvd.api import (
     Params,
     format_date,
     now,
+    return_or_raise,
 )
 from pontos.nvd.models.source import Source
 
@@ -35,13 +36,10 @@ def _result_iterator(
 ) -> Iterator[Source | Exception]:
     sources: Iterable = data.get("sources", [])  # type: ignore
     for source in sources:
-        try:
-            yield Source.from_dict(source)
-        except Exception as exception:
-            if return_exceptions:
-                yield exception  # type: ignore
-            else:
-                raise exception
+        yield return_or_raise(
+            lambda: Source.from_dict(source),
+            return_exceptions,
+        )
 
 
 class SourceApi(NVDApi):

--- a/pontos/nvd/source/api.py
+++ b/pontos/nvd/source/api.py
@@ -30,7 +30,9 @@ DEFAULT_NIST_NVD_SOURCE_URL = (
 MAX_SOURCES_PER_PAGE = 1000
 
 
-def _result_iterator(data: JSON, return_exceptions: bool) -> Iterator[Source]:
+def _result_iterator(
+    data: JSON, return_exceptions: bool
+) -> Iterator[Source | Exception]:
     sources: Iterable = data.get("sources", [])  # type: ignore
     for source in sources:
         try:

--- a/tests/nvd/cpe/test_api.py
+++ b/tests/nvd/cpe/test_api.py
@@ -15,6 +15,7 @@ from uuid import UUID, uuid4
 from httpx import AsyncClient, Response
 
 from pontos.errors import PontosError
+from pontos.models import ModelError
 from pontos.nvd.api import now
 from pontos.nvd.cpe.api import MAX_CPES_PER_PAGE, CPEApi
 from tests import AsyncMock, IsolatedAsyncioTestCase, aiter, anext
@@ -455,3 +456,41 @@ class CPEApiTestCase(IsolatedAsyncioTestCase):
 
         self.http_client.__aenter__.assert_awaited_once()
         self.http_client.__aexit__.assert_awaited_once()
+
+    async def test_cpes_broken_response_return_exceptions(self):
+        uuid = uuid4()
+        responses = create_cpes_responses(uuid, 3)
+        responses[1].json.return_value["products"][0]["cpe"][
+            "cpe_name_id"
+        ] = "I'm an invalid UUID"
+        self.http_client.get.side_effect = responses
+
+        it = aiter(self.api.cpes(return_exceptions=True))
+
+        cpe = await anext(it)
+        self.assertEqual(cpe.cpe_name_id, uuid_replace(uuid, 1, 1))
+
+        cpe = await anext(it)
+        self.assertIsInstance(cpe, ModelError)
+
+        cpe = await anext(it)
+        self.assertEqual(cpe.cpe_name_id, uuid_replace(uuid, 3, 1))
+
+        with self.assertRaises(StopAsyncIteration):
+            await anext(it)
+
+    async def test_cpes_broken_response(self):
+        uuid = uuid4()
+        responses = create_cpes_responses(uuid, 3)
+        responses[1].json.return_value["products"][0]["cpe"][
+            "cpe_name_id"
+        ] = "I'm an invalid UUID"
+        self.http_client.get.side_effect = responses
+
+        it = aiter(self.api.cpes(return_exceptions=False))
+
+        cpe = await anext(it)
+        self.assertEqual(cpe.cpe_name_id, uuid_replace(uuid, 1, 1))
+
+        with self.assertRaises(ModelError):
+            await anext(it)

--- a/tests/nvd/cpe_match/test_api.py
+++ b/tests/nvd/cpe_match/test_api.py
@@ -14,6 +14,7 @@ from uuid import UUID, uuid4
 from httpx import AsyncClient, Response
 
 from pontos.errors import PontosError
+from pontos.models import ModelError
 from pontos.nvd.api import now
 from pontos.nvd.cpe_match.api import MAX_CPE_MATCHES_PER_PAGE, CPEMatchApi
 from tests import AsyncMock, IsolatedAsyncioTestCase, aiter, anext
@@ -563,3 +564,56 @@ class CPEMatchApiWithTokenTestCase(IsolatedAsyncioTestCase):
         await anext(it)
 
         sleep_mock.assert_not_called()
+
+    async def test_cpe_matches_broken_response_return_exceptions(self):
+        match_criteria_id = uuid4()
+        cpe_name_id = uuid4()
+        responses = create_cpe_match_responses(
+            match_criteria_id, cpe_name_id, 3
+        )
+        responses[1].json.return_value["match_strings"][0]["match_string"][
+            "match_criteria_id"
+        ] = "I'm an invalid UUID"
+        self.http_client.get.side_effect = responses
+
+        it = aiter(self.api.cpe_matches(return_exceptions=True))
+
+        cpe_match = await anext(it)
+        self.assertEqual(
+            cpe_match.match_criteria_id,
+            uuid_replace(match_criteria_id, 1, 1),
+        )
+
+        cpe_match = await anext(it)
+        self.assertIsInstance(cpe_match, ModelError)
+
+        cpe_match = await anext(it)
+        self.assertEqual(
+            cpe_match.match_criteria_id,
+            uuid_replace(match_criteria_id, 3, 1),
+        )
+
+        with self.assertRaises(StopAsyncIteration):
+            await anext(it)
+
+    async def test_cpe_matches_broken_response(self):
+        match_criteria_id = uuid4()
+        cpe_name_id = uuid4()
+        responses = create_cpe_match_responses(
+            match_criteria_id, cpe_name_id, 3
+        )
+        responses[1].json.return_value["match_strings"][0]["match_string"][
+            "match_criteria_id"
+        ] = "I'm an invalid UUID"
+        self.http_client.get.side_effect = responses
+
+        it = aiter(self.api.cpe_matches(return_exceptions=False))
+
+        cpe_match = await anext(it)
+        self.assertEqual(
+            cpe_match.match_criteria_id,
+            uuid_replace(match_criteria_id, 1, 1),
+        )
+
+        with self.assertRaises(ModelError):
+            await anext(it)

--- a/tests/nvd/cve/test_api.py
+++ b/tests/nvd/cve/test_api.py
@@ -12,6 +12,7 @@ from unittest.mock import MagicMock, patch
 from httpx import AsyncClient, Response
 
 from pontos.errors import PontosError
+from pontos.models import ModelError
 from pontos.nvd.api import now
 from pontos.nvd.cve.api import MAX_CVES_PER_PAGE, CVEApi
 from pontos.nvd.models import cvss_v2, cvss_v3
@@ -930,3 +931,39 @@ class CVEApiTestCase(IsolatedAsyncioTestCase):
         await anext(it)
 
         sleep_mock.assert_called_once_with(20.0)
+
+    async def test_cves_broken_response_return_exceptions(self):
+        responses = create_cves_responses(3)
+        responses[1].json.return_value["vulnerabilities"][0]["cve"][
+            "published"
+        ] = "I'm an invalid date"
+        self.http_client.get.side_effect = responses
+
+        it = aiter(self.api.cves(return_exceptions=True))
+
+        cve = await anext(it)
+        self.assertEqual(cve.id, "CVE-1-1")
+
+        cve = await anext(it)
+        self.assertIsInstance(cve, ModelError)
+
+        cve = await anext(it)
+        self.assertEqual(cve.id, "CVE-3-1")
+
+        with self.assertRaises(StopAsyncIteration):
+            await anext(it)
+
+    async def test_cves_broken_response(self):
+        responses = create_cves_responses(3)
+        responses[1].json.return_value["vulnerabilities"][0]["cve"][
+            "published"
+        ] = "I'm an invalid date"
+        self.http_client.get.side_effect = responses
+
+        it = aiter(self.api.cves(return_exceptions=False))
+
+        cve = await anext(it)
+        self.assertEqual(cve.id, "CVE-1-1")
+
+        with self.assertRaises(ModelError):
+            await anext(it)

--- a/tests/nvd/cve_changes/test_api.py
+++ b/tests/nvd/cve_changes/test_api.py
@@ -11,6 +11,7 @@ from uuid import UUID
 from httpx import AsyncClient, Response
 
 from pontos.errors import PontosError
+from pontos.models import ModelError
 from pontos.nvd.api import now
 from pontos.nvd.cve_changes.api import MAX_CVE_CHANGES_PER_PAGE, CVEChangesApi
 from pontos.nvd.models.cve_change import Detail, EventName
@@ -321,3 +322,53 @@ class CVEChangesApiTestCase(IsolatedAsyncioTestCase):
 
         self.http_client.__aenter__.assert_awaited_once()
         self.http_client.__aexit__.assert_awaited_once()
+
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    async def test_cve_changes_broken_response_return_exceptions(
+        self, async_client: MagicMock
+    ):
+        self.http_client = AsyncMock()
+        async_client.return_value = self.http_client
+
+        responses = create_cve_changes_responses(3)
+        responses[1].json.return_value["cve_changes"][0]["change"][
+            "event_name"
+        ] = "I'm an invalid event name"
+        self.http_client.get.side_effect = responses
+
+        self.api = CVEChangesApi(token="token")
+
+        it = aiter(self.api.changes(return_exceptions=True))
+
+        cve_change = await anext(it)
+        self.assertEqual(cve_change.cve_id, "CVE-1")
+
+        cve_change = await anext(it)
+        self.assertIsInstance(cve_change, ModelError)
+
+        cve_change = await anext(it)
+        self.assertEqual(cve_change.cve_id, "CVE-3")
+
+        with self.assertRaises(StopAsyncIteration):
+            cve_change = await anext(it)
+
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    async def test_cve_changes_broken_response(self, async_client: MagicMock):
+        self.http_client = AsyncMock()
+        async_client.return_value = self.http_client
+
+        responses = create_cve_changes_responses(3)
+        responses[1].json.return_value["cve_changes"][0]["change"][
+            "event_name"
+        ] = "I'm an invalid event name"
+        self.http_client.get.side_effect = responses
+
+        self.api = CVEChangesApi(token="token")
+
+        it = aiter(self.api.changes(return_exceptions=False))
+
+        cve_change = await anext(it)
+        self.assertEqual(cve_change.cve_id, "CVE-1")
+
+        with self.assertRaises(ModelError):
+            cve_change = await anext(it)

--- a/tests/nvd/source/test_api.py
+++ b/tests/nvd/source/test_api.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 
 from httpx import AsyncClient, Response
 
+from pontos.models import ModelError
 from pontos.nvd.models.source import AcceptanceLevel
 from pontos.nvd.source.api import MAX_SOURCES_PER_PAGE, SourceApi
 from tests import AsyncMock, IsolatedAsyncioTestCase, aiter, anext
@@ -194,3 +195,39 @@ class SourceAPITestCase(IsolatedAsyncioTestCase):
 
         self.http_client.__aenter__.assert_awaited_once()
         self.http_client.__aexit__.assert_awaited_once()
+
+    async def test_sources_broken_response_return_exceptions(self):
+        responses = create_source_responses(3)
+        responses[1].json.return_value["sources"][0][
+            "published"
+        ] = "I'm an invalid date"
+        self.http_client.get.side_effect = responses
+
+        it = aiter(self.api.sources(return_exceptions=True))
+
+        source = await anext(it)
+        self.assertEqual(source.name, "MITRE-1")
+
+        source = await anext(it)
+        self.assertIsInstance(source, ModelError)
+
+        source = await anext(it)
+        self.assertEqual(source.name, "MITRE-3")
+
+        with self.assertRaises(StopAsyncIteration):
+            await anext(it)
+
+    async def test_sources_broken_response(self):
+        responses = create_source_responses(3)
+        responses[1].json.return_value["sources"][0][
+            "published"
+        ] = "I'm an invalid date"
+        self.http_client.get.side_effect = responses
+
+        it = aiter(self.api.sources(return_exceptions=False))
+
+        source = await anext(it)
+        self.assertEqual(source.name, "MITRE-1")
+
+        with self.assertRaises(ModelError):
+            await anext(it)

--- a/tests/nvd/source/test_api.py
+++ b/tests/nvd/source/test_api.py
@@ -38,7 +38,7 @@ def create_source_responses(count: int = 2) -> list[MagicMock]:
     ]
 
 
-class SourceAPITestCase(IsolatedAsyncioTestCase):
+class SourceApiTestCase(IsolatedAsyncioTestCase):
     @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
     def setUp(self, async_client: MagicMock) -> None:
         self.http_client = AsyncMock()

--- a/tests/nvd/source/test_api.py
+++ b/tests/nvd/source/test_api.py
@@ -199,7 +199,7 @@ class SourceApiTestCase(IsolatedAsyncioTestCase):
     async def test_sources_broken_response_return_exceptions(self):
         responses = create_source_responses(3)
         responses[1].json.return_value["sources"][0][
-            "published"
+            "last_modified"
         ] = "I'm an invalid date"
         self.http_client.get.side_effect = responses
 
@@ -220,7 +220,7 @@ class SourceApiTestCase(IsolatedAsyncioTestCase):
     async def test_sources_broken_response(self):
         responses = create_source_responses(3)
         responses[1].json.return_value["sources"][0][
-            "published"
+            "last_modified"
         ] = "I'm an invalid date"
         self.http_client.get.side_effect = responses
 

--- a/tests/nvd/test_api.py
+++ b/tests/nvd/test_api.py
@@ -191,11 +191,19 @@ class NVDApiTestCase(IsolatedAsyncioTestCase):
 
 class Result:
     def __init__(self, value: int) -> None:
-        self.value = value
+        # Parsing as int to pretend some kind of processing that could raise an exception
+        self.value = int(value)
 
 
-def result_func(data: JSON) -> Iterator[Result]:
-    return (Result(d) for d in data["values"])  # type: ignore
+def result_func(data: JSON, return_exceptions: bool) -> Iterator[Result]:
+    for result in data["values"]:  # type: ignore
+        try:
+            yield Result(result)  # type: ignore
+        except Exception as e:
+            if return_exceptions:
+                yield e  # type: ignore
+            else:
+                raise e
 
 
 class NVDResultsTestCase(IsolatedAsyncioTestCase):
@@ -545,6 +553,59 @@ class NVDResultsTestCase(IsolatedAsyncioTestCase):
                 "resultsPerPage": 3,
             }
         )
+
+    async def test_return_errors_true(self):
+        response_mock = MagicMock(spec=Response)
+        response_mock.json.side_effect = [
+            {
+                "values": [1, 2],
+                "total_results": 6,
+                "results_per_page": 2,
+            },
+            {
+                "values": ["I'm not an int", 4],
+                "total_results": 6,
+                "results_per_page": 2,
+            },
+            {
+                "values": [5, 6],
+                "total_results": 6,
+                "results_per_page": 2,
+            },
+        ]
+
+        api_mock = AsyncMock(spec=NVDApi)
+        api_mock._get.return_value = response_mock
+
+        nvd_results: NVDResults[Result] = NVDResults(
+            api_mock,
+            {},
+            result_func,
+            return_exceptions=True,
+        )
+
+        it = aiter(nvd_results.items())
+
+        result = await anext(it)
+        self.assertEqual(result.value, 1)
+
+        result = await anext(it)
+        self.assertEqual(result.value, 2)
+
+        result = await anext(it)
+        self.assertIsInstance(result, ValueError)
+
+        result = await anext(it)
+        self.assertEqual(result.value, 4)
+
+        result = await anext(it)
+        self.assertEqual(result.value, 5)
+
+        result = await anext(it)
+        self.assertEqual(result.value, 6)
+
+        with self.assertRaises(StopAsyncIteration):
+            await anext(it)
 
     async def test_request_results_limit(self):
         response_mock = MagicMock(spec=Response)

--- a/tests/nvd/test_api.py
+++ b/tests/nvd/test_api.py
@@ -20,6 +20,7 @@ from pontos.nvd.api import (
     NVDResults,
     convert_camel_case,
     format_date,
+    return_or_raise,
 )
 from tests import IsolatedAsyncioTestCase, aiter, anext
 
@@ -55,6 +56,22 @@ class FormatDateTestCase(unittest.TestCase):
         fd = format_date(dt)
 
         self.assertEqual(fd, "2022-12-10T10:00:12.000+05:00")
+
+
+class YieldOrRaiseTestCase(unittest.TestCase):
+    def test_ok(self):
+        result = return_or_raise(lambda: Result(1), True)
+
+        self.assertEqual(result.value, 1)
+
+    def test_return_exceptions(self):
+        result = return_or_raise(lambda: Result("I'm not an int"), True)
+
+        self.assertIsInstance(result, ValueError)
+
+    def test_raise_exceptions(self):
+        with self.assertRaises(ValueError):
+            return_or_raise(lambda: Result("I'm not an int"), False)
 
 
 class NVDApiTestCase(IsolatedAsyncioTestCase):
@@ -195,15 +212,11 @@ class Result:
         self.value = int(value)
 
 
-def result_func(data: JSON, return_exceptions: bool) -> Iterator[Result]:
-    for result in data["values"]:  # type: ignore
-        try:
-            yield Result(result)  # type: ignore
-        except Exception as e:
-            if return_exceptions:
-                yield e  # type: ignore
-            else:
-                raise e
+def result_func(
+    data: JSON, return_exceptions: bool
+) -> Iterator[Result | Exception]:
+    for value in data["values"]:  # type: ignore
+        yield return_or_raise(lambda: Result(value), return_exceptions)  # type: ignore
 
 
 class NVDResultsTestCase(IsolatedAsyncioTestCase):


### PR DESCRIPTION
## What
This PR adds the capability for consumers of the NVD APIs to handle exceptions themselves.

## Why
Without this, any exception inside Pontos during NVD API reponse parsing is aborting the whole call.

With this change, consumers can enable `return_exceptions` so that exceptions are treated as results and also yielded as part of the usual iteration. This is inspired by [`asyncio.gather(*aws, return_exceptions=False)`](https://docs.python.org/3/library/asyncio-task.html#asyncio.gather)

Example (works, because a CVE change in the NVD API is currently broken):
```python
import asyncio

from pontos.models import ModelError
from pontos.nvd.cve_changes import CVEChangesApi


async def main():
    async with CVEChangesApi() as api:
        async for cve_change in api.changes(
            cve_id="CVE-2006-2389", return_exceptions=True
        ):
            if isinstance(cve_change, ModelError):
                print(cve_change)
                print(f"Oh no, {cve_change.data['cve_change_id']} is broken!")
                continue

            print(f"Found {cve_change.cve_change_id} on {cve_change.created}")


asyncio.run(main())
```
```
➜  pontos git:(vta-927_nvd_api_return_errors) ✗ poetry run python test.py
Found c86c9681-75c8-4807-a7e7-cd60971dee67 on 2006-07-12 15:37:00+00:00
Found 7e925241-3a49-4ef7-80ac-e28fc6d142ff on 2017-07-20 01:31:26.020000+00:00
Found 487099fc-6fa6-444a-888f-3618ca4ce595 on 2017-10-11 01:30:55.423000+00:00
Found a947ad22-93b2-489d-b3b5-4d4d39d365fb on 2018-10-12 21:40:14.027000+00:00
Found f30cc899-69b2-4391-8e67-9645fa4362f0 on 2024-05-14 01:36:45.423000+00:00
Found 45286152-3c30-491d-9fc8-927a2b9bbef9 on 2024-11-21 00:11:12.470000+00:00
Error while creating CVEChange model. Could not set value for property 'event_name' from ''.
Oh no, 80CB285F-9B9E-4A57-82E4-C0903984EF53 is broken!
```

## References
Related to https://jira.greenbone.net/browse/VTA-927

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


