### PR TITLE
Add: "Status Change" event name

### DIFF
--- a/pontos/nvd/models/cve_change.py
+++ b/pontos/nvd/models/cve_change.py
@@ -25,6 +25,7 @@ class EventName(StrEnum):
     CVE_UNREJECTED = "CVE Unrejected"
     CVE_CISA_KEV_UPDATE = "CVE CISA KEV Update"
     REFERENCE_TAG_UPDATE = "Reference Tag Update"
+    STATUS_CHANGE = "Status Change"
 
 
 @dataclass


### PR DESCRIPTION
## What
This PR adds the new, currently undocumented event name "Status Change"

## Why
Because there is a new event name, which is current unhandled by Pontos:
```
➜  ~ curl -s "https://services.nvd.nist.gov/rest/json/cvehistory/2.0/?eventName=Status%20Change&resultsPerPage=1" | jq ".cveChanges[0].change.eventName"
"Status Change"
```

## References
Related to https://jira.greenbone.net/browse/VTA-927

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


