### PR TITLE
Prevent duplication and modification of shebang in shell scripts

### DIFF
--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.bash
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.bash
@@ -1,4 +1,3 @@
-#!/bin/bash
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.sh
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.bash
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.bash
@@ -1,4 +1,3 @@
-#!/bin/bash
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.sh
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-2.0-or-later

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.bash
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.bash
@@ -1,4 +1,3 @@
-#!/bin/bash
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.sh
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.sh
@@ -1,4 +1,3 @@
-#!/bin/sh
 # SPDX-FileCopyrightText: <year> <company>
 #
 # SPDX-License-Identifier: GPL-3.0-or-later

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -191,9 +191,18 @@ def update_file(
                     )
                     if header:
                         fp.seek(0)  # back to beginning of file
-                        rest_of_file = fp.read()
-                        fp.seek(0)
-                        fp.write(header + "\n" + rest_of_file)
+                        first_line = fp.readline()
+
+                        # first line is a shebang, leave it
+                        if first_line.startswith("#!"):
+                            rest_of_file = fp.read()
+                            fp.seek(0)
+                            fp.write(first_line + header + "\n" + rest_of_file)
+                        else:
+                            rest_of_file = first_line + fp.read()
+                            fp.seek(0)
+                            fp.write(header + "\n" + rest_of_file)
+
                         print(f"{file}: Added license header.")
                         return
 

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -567,6 +567,34 @@ foo.baz(bar.boing)
             new_content = tmp.read_text(encoding="utf-8")
             self.assertEqual(expected_content, new_content)
 
+    def test_handle_file_with_shebang(self):
+        test_content = """#!/bin/bash
+"""  # noqa: E501
+
+        expected_content = f"""#!/bin/bash
+# SPDX-FileCopyrightText: {str(datetime.datetime.now().year)} Greenbone AG
+#
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+"""  # noqa: E501
+
+        company = "Greenbone AG"
+        year = str(datetime.datetime.now().year)
+        license_id = "GPL-3.0-or-later"
+
+        with temp_file(content=test_content, name="foo.sh") as tmp:
+
+            update_file(
+                tmp,
+                year,
+                license_id,
+                company,
+                cleanup=True,
+            )
+
+            new_content = tmp.read_text(encoding="utf-8")
+            self.assertEqual(expected_content, new_content)
+
 
 class ParseArgsTestCase(TestCase):
     def test_argparser_files(self):


### PR DESCRIPTION
## What

This changes the behavior when adding a header to a file which
previously had no copyright/license header. If the first line of the
file starts with a shebang (`#!`), the header is put below the first
line instead of above.


## Why

The previous approach was to include the shebang in the template, but
this caused the shebang to be duplicated as the template is prepended
without modifying the rest of the file. Since the template was chosen
based on the file extension, this could also cause a script with a `.sh`
extension and a `#!/bin/bash` shebang to now have a `#!/bin/sh` shebang,
potentially causing the script to be executed using a different shell.

## References

DOS-678

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [x] Tests


