### PR TITLE
Prevent duplication and adding of XML declarations

### DIFF
--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.xml
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0"?>
-
 <!--
 SPDX-FileCopyrightText: <year> <company>
 

--- a/pontos/updateheader/templates/AGPL-3.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/AGPL-3.0-or-later/template.xsl
@@ -1,5 +1,3 @@
-<?xml version="1.0"?>
-
 <!--
 SPDX-FileCopyrightText: <year> <company>
 

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.xml
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0"?>
-
 <!--
 SPDX-FileCopyrightText: <year> <company>
 

--- a/pontos/updateheader/templates/GPL-2.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/GPL-2.0-or-later/template.xsl
@@ -1,5 +1,3 @@
-<?xml version="1.0"?>
-
 <!--
 SPDX-FileCopyrightText: <year> <company>
 

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.xml
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.xml
@@ -1,5 +1,3 @@
-<?xml version="1.0"?>
-
 <!--
 SPDX-FileCopyrightText: <year> <company>
 

--- a/pontos/updateheader/templates/GPL-3.0-or-later/template.xsl
+++ b/pontos/updateheader/templates/GPL-3.0-or-later/template.xsl
@@ -1,5 +1,3 @@
-<?xml version="1.0"?>
-
 <!--
 SPDX-FileCopyrightText: <year> <company>
 

--- a/pontos/updateheader/updateheader.py
+++ b/pontos/updateheader/updateheader.py
@@ -193,8 +193,10 @@ def update_file(
                         fp.seek(0)  # back to beginning of file
                         first_line = fp.readline()
 
-                        # first line is a shebang, leave it
-                        if first_line.startswith("#!"):
+                        # first line is a shebang or XML declaration, leave it
+                        if first_line.startswith("#!") or first_line.startswith(
+                            "<?xml"
+                        ):
                             rest_of_file = fp.read()
                             fp.seek(0)
                             fp.write(first_line + header + "\n" + rest_of_file)

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -595,6 +595,66 @@ foo.baz(bar.boing)
             new_content = tmp.read_text(encoding="utf-8")
             self.assertEqual(expected_content, new_content)
 
+    def test_handle_file_xml_with_xml_declaration(self):
+        test_content = """<?xml version="1.0"?>
+"""  # noqa: E501
+
+        expected_content = f"""<?xml version="1.0"?>
+<!--
+SPDX-FileCopyrightText: {str(datetime.datetime.now().year)} Greenbone AG
+
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+"""  # noqa: E501
+
+        company = "Greenbone AG"
+        year = str(datetime.datetime.now().year)
+        license_id = "GPL-3.0-or-later"
+
+        with temp_file(content=test_content, name="foo.xml") as tmp:
+
+            update_file(
+                tmp,
+                year,
+                license_id,
+                company,
+                cleanup=True,
+            )
+
+            new_content = tmp.read_text(encoding="utf-8")
+            self.assertEqual(expected_content, new_content)
+
+    def test_handle_file_xml_without_xml_declaration(self):
+        test_content = """<greeting>Hello, world!</greeting>
+"""  # noqa: E501
+
+        expected_content = f"""<!--
+SPDX-FileCopyrightText: {str(datetime.datetime.now().year)} Greenbone AG
+
+SPDX-License-Identifier: GPL-3.0-or-later
+-->
+
+<greeting>Hello, world!</greeting>
+"""  # noqa: E501
+
+        company = "Greenbone AG"
+        year = str(datetime.datetime.now().year)
+        license_id = "GPL-3.0-or-later"
+
+        with temp_file(content=test_content, name="foo.xml") as tmp:
+
+            update_file(
+                tmp,
+                year,
+                license_id,
+                company,
+                cleanup=True,
+            )
+
+            new_content = tmp.read_text(encoding="utf-8")
+            self.assertEqual(expected_content, new_content)
+
 
 class ParseArgsTestCase(TestCase):
     def test_argparser_files(self):


### PR DESCRIPTION
## What

This changes the behavior when adding a header to an XML file which previously had no copyright/license header. If the first line of the file is an XML declaration (meaning it starts with `<?xml`), the header is put below the first line instead of above.

## Why

The previous approach was to include the XML declaration in the template, but this caused the declaration to be duplicated for files already having an XML declaration as the template is prepended without modifying the rest of the file. Also, for files without XML declaration the declaration was silently added.

## References

DOS-678

#1208 

## Checklist

- [x] Tests


