### PR TITLE
Add: CVE Change event name "Data Remediation"

### DIFF
--- a/pontos/nvd/models/cve_change.py
+++ b/pontos/nvd/models/cve_change.py
@@ -26,6 +26,7 @@ class EventName(StrEnum):
     CVE_CISA_KEV_UPDATE = "CVE CISA KEV Update"
     REFERENCE_TAG_UPDATE = "Reference Tag Update"
     STATUS_CHANGE = "Status Change"
+    DATA_REMEDIATION = "Data Remediation"
 
 
 @dataclass


### PR DESCRIPTION
## What
This PR adds a new, undocumented event name "Data Remediation":
```
➜  ~ curl -s "https://services.nvd.nist.gov/rest/json/cvehistory/2.0/?cveId=CVE-2025-14485" | jq ".cveChanges[1].change.eventName"
"Data Remediation"
```

## Why
To comply with the API response:
```
➜  pontos git:(main) poetry run pontos-nvd-cve-changes --cve-id CVE-2025-14485 -s 0                                                                                                                                                     
[...]
Traceback (most recent call last):                                                                                                                                                                                                      
  File "/home/nthumann/Greenbone/pontos/pontos/models/__init__.py", line 166, in from_dict
[...]
pontos.models.ModelError: Error while creating CVEChange model. Could not set value for property 'event_name' from 'Data Remediation'.
```

## References

<!-- Add identifier for issue tickets, links to other PRs, etc. -->

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests


