### PR TITLE
Update Greenbone license header

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -1,7 +1,7 @@
 # Pontos - Greenbone Python Utilities and Tools
 
 The pontos Python package is a collection of utilities, tools, classes and
-functions maintained by Greenbone Networks.
+functions maintained by Greenbone AG.
 
 ## User Guide
 

--- a/pontos/version/commands/_command.py
+++ b/pontos/version/commands/_command.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Greenbone Networks GmbH
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/version/schemes/__init__.py
+++ b/pontos/version/schemes/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Greenbone Networks GmbH
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/version/schemes/_pep440.py
+++ b/pontos/version/schemes/_pep440.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Greenbone Networks GmbH
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/version/schemes/_scheme.py
+++ b/pontos/version/schemes/_scheme.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Greenbone Networks GmbH
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pontos/version/schemes/_semantic.py
+++ b/pontos/version/schemes/_semantic.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Greenbone Networks GmbH
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "pontos"
 version = "26.4.4.dev1"
-description = "Common utilities and tools maintained by Greenbone Networks"
+description = "Common utilities and tools maintained by Greenbone AG"
 authors = ["Greenbone AG <info@greenbone.net>"]
 license = "GPL-3.0-or-later"
 readme = "README.md"

--- a/tests/updateheader/test_header.py
+++ b/tests/updateheader/test_header.py
@@ -436,7 +436,7 @@ class UpdateFileTestCase(TestCase):
             )
 
     def test_cleanup_file(self):
-        test_content = """# Copyright (C) 2021-2022 Greenbone Networks GmbH
+        test_content = """# Copyright (C) 2021-2022 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/tests/version/commands/__init__.py
+++ b/tests/version/commands/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Greenbone Networks GmbH
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/tests/version/schemes/__init__.py
+++ b/tests/version/schemes/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Greenbone Networks GmbH
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #

--- a/tests/version/schemes/test_semantic.py
+++ b/tests/version/schemes/test_semantic.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Greenbone Networks GmbH
+# Copyright (C) 2023 Greenbone AG
 #
 # SPDX-License-Identifier: GPL-3.0-or-later
 #


### PR DESCRIPTION
## What

I noticed that there were some places in Pontos where the old license header is still being used, so this PR updates those.


## References

VTOPS-3

## Checklist


- [x] Tests passing


