### PR TITLE
Change: Rename "Status Change" to "CVE Status Change"

### DIFF
--- a/pontos/nvd/models/cve_change.py
+++ b/pontos/nvd/models/cve_change.py
@@ -25,7 +25,7 @@ class EventName(StrEnum):
     CVE_UNREJECTED = "CVE Unrejected"
     CVE_CISA_KEV_UPDATE = "CVE CISA KEV Update"
     REFERENCE_TAG_UPDATE = "Reference Tag Update"
-    STATUS_CHANGE = "Status Change"
+    CVE_STATUS_CHANGE = "CVE Status Change"
     DATA_REMEDIATION = "Data Remediation"
 
 


### PR DESCRIPTION
## What
This PR renames an event.

## Why
Because I just stumbled upon the updated NVD docs (https://nvd.nist.gov/developers/vulnerabilities) and noticed that they've renamed it.

Previously worked (see linked PR):
```
➜  ~ curl "https://services.nvd.nist.gov/rest/json/cvehistory/2.0/?eventName=Status%20Change&resultsPerPage=1" -I
HTTP/2 404 
date: Mon, 18 May 2026 14:01:06 GMT
[...]
```

Now working:
```
➜  ~ curl "https://services.nvd.nist.gov/rest/json/cvehistory/2.0/?eventName=CVE%20Status%20Change&resultsPerPage=1" -I 
HTTP/2 200 
date: Mon, 18 May 2026 14:02:14 GMT
[...]
```

## References
This is a follow-up of https://github.com/greenbone/pontos/pull/1207.

## Checklist

<!-- Remove this section if not applicable to your changes -->

- [ ] Tests

I checked out GitHub org and found no hints of this constant being used anywhere, so we should be able to safely rename it.
