### PR TITLE
Change: Allow RemoteProtocolError to trigger retry

### DIFF
--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -23,7 +23,13 @@ from typing import (
     TypeVar,
 )
 
-from httpx import URL, AsyncClient, Response, Timeout
+from httpx import (
+    URL,
+    AsyncClient,
+    RemoteProtocolError,
+    Response,
+    Timeout,
+)
 
 from pontos.errors import PontosError
 from pontos.helper import snake_case
@@ -450,19 +456,34 @@ class NVDApi(ABC):
         """
         headers = self._request_headers()
 
+        latest_after_error: Response | RemoteProtocolError
+
         for attempt in range(self._request_attempts):
             if attempt > 0:
                 delay = RETRY_DELAY**attempt
                 await asyncio.sleep(delay)
 
             await self._consider_rate_limit()
-            response = await self._client.get(
-                self._url, headers=headers, params=params
-            )
-            if not response.is_server_error:
-                break
 
-        return response
+            try:
+                response = await self._client.get(
+                    self._url, headers=headers, params=params
+                )
+
+                if response.is_server_error:
+                    latest_after_error = response
+                    continue
+
+                return response
+
+            except RemoteProtocolError as e:
+                latest_after_error = e
+                continue
+
+        if isinstance(latest_after_error, RemoteProtocolError):
+            raise latest_after_error
+
+        return latest_after_error
 
     async def __aenter__(self) -> "NVDApi":
         # reset rate limit counter

--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -456,7 +456,7 @@ class NVDApi(ABC):
         """
         headers = self._request_headers()
 
-        latest_after_error: Response | RemoteProtocolError
+        latest_error: Response | RemoteProtocolError
 
         for attempt in range(self._request_attempts):
             if attempt > 0:
@@ -471,19 +471,19 @@ class NVDApi(ABC):
                 )
 
                 if response.is_server_error:
-                    latest_after_error = response
+                    latest_error = response
                     continue
 
                 return response
 
             except RemoteProtocolError as e:
-                latest_after_error = e
+                latest_error = e
                 continue
 
-        if isinstance(latest_after_error, RemoteProtocolError):
-            raise latest_after_error
+        if isinstance(latest_error, RemoteProtocolError):
+            raise latest_error
 
-        return latest_after_error
+        return latest_error
 
     async def __aenter__(self) -> "NVDApi":
         # reset rate limit counter

--- a/tests/nvd/test_api.py
+++ b/tests/nvd/test_api.py
@@ -11,7 +11,7 @@ from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock, call, patch
 
-from httpx import AsyncClient, Response
+from httpx import AsyncClient, RemoteProtocolError, Response
 
 from pontos.nvd.api import (
     JSON,
@@ -205,6 +205,43 @@ class NVDApiTestCase(IsolatedAsyncioTestCase):
 
         sleep_mock.assert_not_called()
         self.assertFalse(result.is_server_error)
+
+    @patch("pontos.nvd.api.asyncio.sleep", autospec=True)
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    async def test_exceed_attempts(
+        self,
+        async_client: MagicMock,
+        sleep_mock: MagicMock,
+    ):
+        response_mocks = [
+            RemoteProtocolError("RIP connection"),
+            MagicMock(spec=Response, is_server_error=True),
+        ]
+        http_client = AsyncMock()
+        http_client.get.side_effect = response_mocks
+        async_client.return_value = http_client
+
+        api = NVDApi("https://foo.bar/baz", request_attempts=2)
+
+        result = await api._get()
+
+        calls = [call(2.0)]
+        sleep_mock.assert_has_calls(calls)
+        self.assertIsInstance(result, Response)
+
+    @patch("pontos.nvd.api.AsyncClient", spec=AsyncClient)
+    async def test_remote_protocol_error(
+        self,
+        async_client: MagicMock,
+    ):
+        http_client = AsyncMock()
+        http_client.get.side_effect = RemoteProtocolError("RIP connection")
+        async_client.return_value = http_client
+
+        api = NVDApi("https://foo.bar/baz")
+
+        with self.assertRaises(RemoteProtocolError):
+            await api._get()
 
 
 class Result:


### PR DESCRIPTION
## What
This PR changes the retry behavior so that `httpx.RemoteProtocolError` can also trigger a retry and is not immediately raised.

## Why
Even though NVD is much more stable than in the previous weeks, we still encounter `httpx.RemoteProtocolError` in various of our projects. I've checked if this can be worked around by disabling HTTP/2, but the error is still present.

Since we are already retrying on server-side HTTP errors, I think this is a good place to also handle server-side protocol errors. The current behavior is adapted so that we - if all attempts failed - return the response or error of the latest attempt so that the user is made aware.

## References
Failures in e.g. https://github.com/greenbone/vt-cve-library/actions/runs/28420327687/job/84231105765 or https://github.com/greenbone/vt-cve-feeder/actions/runs/28436997860/job/84265237085

## Checklist
- [x] Tests
- [x] Tested with downstream tools like vt-cve-library and confirmed that it's working as expected
- [x] Tested with a small demos script requesting CVEs, which previously ran into `RemoteProtocolError` after a few min