### PR TITLE
Fix: align project version metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [project]
 authors = [{ name = "Greenbone AG", email = "info@greenbone.net" }]
 name = "pontos"
-version = "26.5.1.dev1"
+version = "26.6.1.dev1"
 description = "Common utilities and tools maintained by Greenbone AG"
 license = "GPL-3.0-or-later"
 readme = "README.md"


### PR DESCRIPTION
## What

Aligns `[project].version` with `[tool.poetry].version`.

## Why

<!-- Describe why are these changes necessary? -->

The PyPI release workflow uses `poetry build`, and the package metadata appears to have picked up the stale `[project].version` value `26.5.1.dev1`, causing the wrong version to be published.

Keeping both version fields aligned prevents future releases from publishing an unexpected version.


## Checklist


- [ ] Tests


