### PR TITLE
ci: remove enforce-admins bypass steps from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,21 +47,9 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
           poetry run git-cliff -v --strip header -o /tmp/changelog.md --unreleased --tag ${{ steps.release-version.outputs.release_version }} ${{ steps.release-version.outputs.last_release_version }}..HEAD
-      - name: Allow admin users bypassing protection on ${{ steps.release.outputs.ref }} branch
-        run: |
-          poetry run pontos-github-script pontos.github.scripts.enforce-admins ${{ github.repository }} ${{ steps.release.outputs.ref }} --allow
-        env:
-          GITHUB_USER: ${{ secrets.GREENBONE_BOT }}
-          GITHUB_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
       - name: Create release
         run: |
           poetry run pontos-release create --repository ${{ github.repository }} --release-type calendar --changelog /tmp/changelog.md --release-version ${{ steps.release-version.outputs.release_version }}
-        env:
-          GITHUB_USER: ${{ secrets.GREENBONE_BOT }}
-          GITHUB_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}
-      - name: Disable bypassing protection on ${{ steps.release.outputs.ref }} branch for admin users
-        run: |
-          poetry run pontos-github-script pontos.github.scripts.enforce-admins ${{ github.repository }} ${{ steps.release.outputs.ref }} --no-allow
         env:
           GITHUB_USER: ${{ secrets.GREENBONE_BOT }}
           GITHUB_TOKEN: ${{ secrets.GREENBONE_BOT_TOKEN }}


### PR DESCRIPTION
## What and Why

These steps toggled the classic branch-protection `enforce_admins` flag to allow the bot to push directly during a release. After moving from branch protection to rulesets, this is no longer necessary,

## References

DEVOPS-2087
