### PR TITLE
fix: preserve pagination cursor query parameters

### DIFF
--- a/pontos/github/api/client.py
+++ b/pontos/github/api/client.py
@@ -147,11 +147,7 @@ class GitHubAsyncRESTClient(AbstractAsyncContextManager):
         next_url = _get_next_url(response)
 
         while next_url:
-            # Workaround for https://github.com/encode/httpx/issues/3433
-            new_params = (
-                httpx.URL(next_url).params.merge(params) if params else None
-            )
-            response = await self.get(next_url, params=new_params)
+            response = await self.get(next_url)
 
             yield response
 

--- a/tests/github/api/test_client.py
+++ b/tests/github/api/test_client.py
@@ -93,6 +93,54 @@ class GitHubAsyncRESTClientTestCase(IsolatedAsyncioTestCase):
             ]
         )
 
+    async def test_get_all_with_params(self):
+        next_url = (
+            "https://example.com/resources?state=active&per_page=100&page=2"
+        )
+        response1 = MagicMock(links={"next": {"url": next_url}})
+        response2 = MagicMock(links=None)
+
+        self.http_client.get.side_effect = [
+            response1,
+            response2,
+        ]
+        it = aiter(
+            self.client.get_all(
+                "/resources", params={"state": "active", "per_page": "100"}
+            )
+        )
+
+        await anext(it)
+        await anext(it)
+
+        with self.assertRaises(StopAsyncIteration):
+            await anext(it)
+
+        self.http_client.get.assert_has_awaits(
+            [
+                call(
+                    f"{DEFAULT_GITHUB_API_URL}/resources",
+                    headers={
+                        "Accept": DEFAULT_ACCEPT_HEADER,
+                        "Authorization": "token token",
+                        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+                    },
+                    params={"state": "active", "per_page": "100"},
+                    follow_redirects=True,
+                ),
+                call(
+                    next_url,
+                    headers={
+                        "Accept": DEFAULT_ACCEPT_HEADER,
+                        "Authorization": "token token",
+                        "X-GitHub-Api-Version": GITHUB_API_VERSION,
+                    },
+                    params=None,
+                    follow_redirects=True,
+                ),
+            ]
+        )
+
     async def test_delete(self):
         await self.client.delete("/foo/bar")
 


### PR DESCRIPTION
## What

Follow GitHub pagination links unchanged so their cursor is not altered by the original request parameters.

## Why

Incorrect pagination led to some artifacts being missed while others were duplicated in the `download-artifact` action.

Generated with the help of `pi` coding agent harness (model: github-copilot/gpt-5.6-terra).

## Checklist

- [X] Tests