### PR TITLE
Fix importing Self for typing

### DIFF
--- a/pontos/github/api/api.py
+++ b/pontos/github/api/api.py
@@ -7,7 +7,6 @@ from contextlib import AbstractAsyncContextManager
 from types import TracebackType
 
 import httpx
-from typing_extensions import Self
 
 from pontos.github.api.artifacts import GitHubAsyncRESTArtifacts
 from pontos.github.api.billing import GitHubAsyncRESTBilling
@@ -33,6 +32,7 @@ from pontos.github.api.teams import GitHubAsyncRESTTeams
 from pontos.github.api.users import GitHubAsyncRESTUsers
 from pontos.github.api.workflows import GitHubAsyncRESTWorkflows
 from pontos.helper import deprecated
+from pontos.typing import Self
 
 
 class GitHubAsyncRESTApi(AbstractAsyncContextManager):

--- a/pontos/github/api/client.py
+++ b/pontos/github/api/client.py
@@ -10,7 +10,6 @@ from types import TracebackType
 from typing import Any
 
 import httpx
-from typing_extensions import Self
 
 from pontos.github.api.helper import (
     DEFAULT_GITHUB_API_URL,
@@ -20,6 +19,7 @@ from pontos.github.api.helper import (
     _get_next_url,
 )
 from pontos.github.models.base import GitHubModel
+from pontos.typing import Self
 
 Headers = Mapping[str, str]
 ParamValue = str | None

--- a/pontos/helper.py
+++ b/pontos/helper.py
@@ -24,11 +24,6 @@ from typing import (
     TypeVar,
 )
 
-if sys.version_info >= (3, 12):
-    from typing import override
-else:
-    from typing_extensions import override
-
 import httpx
 
 from pontos.errors import PontosError
@@ -43,7 +38,6 @@ __all__ = (
     "download_async",
     "ensure_unload_module",
     "enum_or_value",
-    "override",
     "parse_timedelta",
     "snake_case",
     "unload_module",

--- a/pontos/nvd/api.py
+++ b/pontos/nvd/api.py
@@ -30,10 +30,10 @@ from httpx import (
     Response,
     Timeout,
 )
-from typing_extensions import Self
 
 from pontos.errors import PontosError
 from pontos.helper import snake_case
+from pontos.typing import Self
 
 SLEEP_TIMEOUT = 30.0  # in seconds
 DEFAULT_TIMEOUT = 180.0  # three minutes

--- a/pontos/nvd/cpe/api.py
+++ b/pontos/nvd/cpe/api.py
@@ -13,7 +13,6 @@ from typing import (
 from uuid import UUID
 
 from httpx import Timeout
-from typing_extensions import Self
 
 from pontos.errors import PontosError
 from pontos.nvd.api import (
@@ -27,6 +26,7 @@ from pontos.nvd.api import (
     now,
 )
 from pontos.nvd.models.cpe import CPE
+from pontos.typing import Self
 
 DEFAULT_NIST_NVD_CPES_URL = "https://services.nvd.nist.gov/rest/json/cpes/2.0"
 MAX_CPES_PER_PAGE = 10000

--- a/pontos/nvd/cpe_match/api.py
+++ b/pontos/nvd/cpe_match/api.py
@@ -10,7 +10,6 @@ from typing import (
 )
 
 from httpx import Timeout
-from typing_extensions import Self
 
 from pontos.errors import PontosError
 from pontos.nvd.api import (
@@ -24,6 +23,7 @@ from pontos.nvd.api import (
     now,
 )
 from pontos.nvd.models.cpe_match_string import CPEMatchString
+from pontos.typing import Self
 
 __all__ = ("CPEMatchApi",)
 

--- a/pontos/nvd/cve/api.py
+++ b/pontos/nvd/cve/api.py
@@ -8,7 +8,6 @@ from datetime import datetime
 from types import TracebackType
 
 from httpx import Timeout
-from typing_extensions import Self
 
 from pontos.errors import PontosError
 from pontos.nvd.api import (
@@ -24,6 +23,7 @@ from pontos.nvd.api import (
 from pontos.nvd.models.cve import CVE
 from pontos.nvd.models.cvss_v2 import Severity as CVSSv2Severity
 from pontos.nvd.models.cvss_v3 import Severity as CVSSv3Severity
+from pontos.typing import Self
 
 __all__ = ("CVEApi",)
 

--- a/pontos/nvd/cve_changes/api.py
+++ b/pontos/nvd/cve_changes/api.py
@@ -7,7 +7,6 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from httpx import Timeout
-from typing_extensions import Self
 
 from pontos.errors import PontosError
 from pontos.nvd.api import (
@@ -20,6 +19,7 @@ from pontos.nvd.api import (
     now,
 )
 from pontos.nvd.models.cve_change import CVEChange, EventName
+from pontos.typing import Self
 
 __all__ = ("CVEChangesApi",)
 

--- a/pontos/nvd/source/api.py
+++ b/pontos/nvd/source/api.py
@@ -6,7 +6,6 @@ from collections.abc import Iterable, Iterator
 from datetime import datetime
 
 from httpx import Timeout
-from typing_extensions import Self
 
 from pontos.nvd.api import (
     DEFAULT_TIMEOUT_CONFIG,
@@ -18,6 +17,7 @@ from pontos.nvd.api import (
     now,
 )
 from pontos.nvd.models.source import Source
+from pontos.typing import Self
 
 __all__ = ("SourceApi",)
 

--- a/pontos/typing/__init__.py
+++ b/pontos/typing/__init__.py
@@ -3,8 +3,15 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 #
 
+import sys
 from abc import abstractmethod
 from typing import Protocol, runtime_checkable
+
+__all__ = (
+    "Self",
+    "SupportsStr",
+    "override",
+)
 
 
 @runtime_checkable
@@ -16,3 +23,14 @@ class SupportsStr(Protocol):
     @abstractmethod
     def __str__(self) -> str:
         pass
+
+
+if sys.version_info >= (3, 12):
+    from typing import override
+else:
+    from typing_extensions import override
+
+if sys.version_info >= (3, 11):
+    from typing import Self
+else:
+    from typing_extensions import Self

--- a/pontos/version/commands/_poetry.py
+++ b/pontos/version/commands/_poetry.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import tomlkit
 
-from ...helper import override
+from ...typing import override
 from .._errors import VersionError
 from .._version import Version, VersionUpdate
 from ..schemes import PEP440VersioningScheme

--- a/pontos/version/commands/_uv.py
+++ b/pontos/version/commands/_uv.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import tomlkit
 
-from ...helper import override
+from ...typing import override
 from .._errors import VersionError
 from .._version import Version, VersionUpdate
 from ..schemes import PEP440VersioningScheme


### PR DESCRIPTION


## What
Fix importing Self for typing

## Why

Move all typing related code into the `pontos.typing` package. Provide the Self type to not require the typing_extensions when using Python >= 3.12.

