### PR TITLE
Add: Also update Cargo.lock file during version updates, with virtual workspace support

### DIFF
--- a/pontos/version/commands/_cargo.py
+++ b/pontos/version/commands/_cargo.py
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from pathlib import Path
-from typing import Any, Literal
+from typing import Literal
 
 import tomlkit
 from tomlkit.toml_document import TOMLDocument
@@ -15,52 +15,116 @@ from ._command import VersionCommand
 
 class CargoVersionCommand(VersionCommand):
     project_file_name = "Cargo.toml"
+    cargo_lock_file_name = "Cargo.lock"
+    _cargo_lock_file_path: Path | None = None
 
-    def __has_package_version(self, toml: TOMLDocument):
+    @property
+    def cargo_toml(self) -> tomlkit.TOMLDocument:
+        if not self.project_file_path.exists():
+            raise VersionError(f"{self.project_file_name} file not found.")
+
+        return tomlkit.parse(self.project_file_path.read_text(encoding="utf-8"))
+
+    @property
+    def cargo_lock_file_path(self) -> Path:
+        if self._cargo_lock_file_path:
+            return self._cargo_lock_file_path
+
+        self._cargo_lock_file_path = (
+            self.project_file_path.parent / self.cargo_lock_file_name
+        )
+        return self._cargo_lock_file_path
+
+    def _has_package_version(self, toml: TOMLDocument):
         """
         Checks if the 'package' table contains a 'version'.
         """
-        # get a pure python object (recursively)
-        toml_dict = toml.unwrap()
-        return "package" in toml_dict and "version" in toml_dict["package"]
+        return "package" in toml and "version" in toml["package"]
 
-    def __has_workspace_package_version(self, toml: TOMLDocument):
+    def _has_workspace_package_version(self, toml: TOMLDocument):
         """
         Checks if the 'workspace.package' table contains a 'version'.
         """
-        # get a pure python object (recursively)
-        toml_dict = toml.unwrap()
         return (
-            "workspace" in toml_dict
-            and "package" in toml_dict["workspace"]
-            and "version" in toml_dict["workspace"]["package"]
+            "workspace" in toml
+            and "package" in toml["workspace"]
+            and "version" in toml["workspace"]["package"]
         )
 
-    def __as_project_document(
-        self, origin: Path
-    ) -> tuple[Path, tomlkit.TOMLDocument]:
-        """
-        Parse the given origin and returns a tuple of path to a
-        Cargo.toml that contains a version.
-        Version should be in the table package or workspace.package
-
-        If the origin is invalid toml than it will raise a VersionError.
-        """
-        version: Any = None
-        content = origin.read_text(encoding="utf-8")
-        content = tomlkit.parse(content)
-        if self.__has_workspace_package_version(content):
-            version = content.get("workspace").get("package").get("version")  # type: ignore[union-attr]
-
-        if self.__has_package_version(content):
-            version = content.get("package").get("version")  # type: ignore[union-attr]
-
-        if version:
-            return (origin, content)
-        else:
-            raise VersionError(
-                f"No {origin} file found. This file is required for pontos."
+    def _get_version_from_cargo_toml(
+        self,
+    ) -> Version:
+        """Get the current version from the Cargo.toml file."""
+        cargo_toml = self.cargo_toml
+        version: str | None = None
+        if self._has_workspace_package_version(cargo_toml):
+            version = (
+                cargo_toml.get("workspace").get("package").get("version")  # type: ignore
             )
+
+        if self._has_package_version(cargo_toml):
+            version = cargo_toml.get("package").get("version")  # type: ignore
+
+        if version is not None:
+            return self.versioning_scheme.parse_version(version)
+
+        raise VersionError(
+            f"No version information in {self.project_file_path} file found. This file is required for pontos."
+        )
+
+    def _update_cargo_toml_file(self, new_version: Version) -> None:
+        """
+        Update the Cargo.toml file with the new version.
+        """
+        cargo_toml = self.cargo_toml
+        if self._has_workspace_package_version(cargo_toml):
+            cargo_toml["workspace"]["package"]["version"] = str(new_version)
+        else:
+            # ensure the [package] section exists
+            if "package" not in cargo_toml:
+                package_table = tomlkit.table()
+                cargo_toml["package"] = package_table
+                cargo_toml["package"]["version"] = str(new_version)
+
+        if self._has_package_version(cargo_toml):
+            cargo_toml["package"]["version"] = str(new_version)
+
+        self.project_file_path.write_text(
+            tomlkit.dumps(cargo_toml), encoding="utf-8"
+        )
+
+    def _update_cargo_lock_file(self, new_version: Version) -> None:
+        """
+        Update the Cargo.lock file with the new version.
+        """
+        if not self.cargo_lock_file_path.exists():
+            raise VersionError(
+                f"{self.cargo_lock_file_name} file not found. Cannot update version."
+            )
+
+        cargo_lock = tomlkit.parse(
+            self.cargo_lock_file_path.read_text(encoding="utf-8")
+        )
+
+        if "package" not in cargo_lock:
+            raise VersionError(
+                f"[[package]] entries not found in {self.cargo_lock_file_path}. "
+                "Cannot update version."
+            )
+        project_name = self.cargo_toml.get("package", {}).get("name")
+        if project_name is None:
+            raise VersionError(
+                f"Project name not found in {self.project_file_path}. Cannot update version."
+            )
+
+        if "package" in cargo_lock:
+            for package in cargo_lock["package"]:
+                if package.get("name") == project_name:
+                    package["version"] = str(new_version)
+
+        self.cargo_lock_file_path.write_text(
+            tomlkit.dumps(cargo_lock), encoding="utf-8"
+        )
 
     def update_version(
         self, new_version: Version, *, force: bool = False
@@ -73,44 +137,28 @@ class CargoVersionCommand(VersionCommand):
             # just ignore current version and override it
             previous_version = None
 
-        project_path, project = self.__as_project_document(
-            self.project_file_path
-        )
+        try:
+            self._update_cargo_toml_file(new_version=new_version)
+        except OSError as e:
+            raise VersionError(
+                f"Unable to update version in {self.project_file_path.absolute()}. Error was {e}"
+            ) from e
 
-        if self.__has_workspace_package_version(project):
-            # Set the version for all members of the workspace. Members of the
-            # workspace should use `version.workspace=true` in the 'package' table,
-            # if they are released together with the parent crate.
-            project["workspace"]["package"]["version"] = str(new_version)  # type: ignore[index]
+        try:
+            self._update_cargo_lock_file(new_version=new_version)
+        except OSError as e:
+            raise VersionError(
+                f"Unable to update version in {self.cargo_lock_file_path.absolute()}. Error was {e}"
+            ) from e
 
-        if self.__has_package_version(project):
-            # Set the 'version' of the 'package' table for the parent crate
-            project["package"]["version"] = str(new_version)  # type: ignore[index]
-
-        project_path.write_text(tomlkit.dumps(project))
         return VersionUpdate(
             previous=previous_version,
             new=new_version,
-            changed_files=[project_path],
+            changed_files=[self.project_file_path],
         )
 
     def get_current_version(self) -> Version:
-        _, document = self.__as_project_document(self.project_file_path)
-
-        version: Any = None
-        if self.__has_workspace_package_version(document):
-            version = document["workspace"]["package"]["version"]  # type: ignore[index, arg-type]
-
-        if self.__has_package_version(document):
-            # If the 'package' table has a 'version', it always has precedence over the
-            # 'version' in the 'workspace.package' table (they are assumed to be equal, if
-            # managed by pontos)
-            version = document["package"]["version"]  # type: ignore[index, arg-type]
-
-        if isinstance(version, str):
-            current_version = self.versioning_scheme.parse_version(version)
-
-        return self.versioning_scheme.from_version(current_version)
+        return self._get_version_from_cargo_toml()
 
     def verify_version(
         self, version: Literal["current"] | Version | None

--- a/pontos/version/commands/_cargo.py
+++ b/pontos/version/commands/_cargo.py
@@ -93,6 +93,32 @@ class CargoVersionCommand(VersionCommand):
             tomlkit.dumps(cargo_toml), encoding="utf-8"
         )
 
+    def _get_project_names(self) -> set[str]:
+        """Get package names whose lock-file versions belong to this project."""
+        cargo_toml = self.cargo_toml
+        project_name = cargo_toml.get("package", {}).get("name")
+        if project_name:
+            return {str(project_name)}
+
+        project_names = set()
+        members = cargo_toml.get("workspace", {}).get("members", [])
+        for member in members:
+            for member_path in self.project_file_path.parent.glob(str(member)):
+                member_toml_path = member_path / self.project_file_name
+                if not member_toml_path.exists():
+                    continue
+
+                member_toml = tomlkit.parse(
+                    member_toml_path.read_text(encoding="utf-8")
+                )
+                version = member_toml.get("package", {}).get("version")
+                if isinstance(version, dict) and version.get("workspace"):
+                    package_name = member_toml["package"].get("name")
+                    if package_name:
+                        project_names.add(str(package_name))
+
+        return project_names
+
     def _update_cargo_lock_file(self, new_version: Version) -> None:
         """
         Update the Cargo.lock file with the new version.
@@ -111,16 +137,10 @@ class CargoVersionCommand(VersionCommand):
                 f"[[package]] entries not found in {self.cargo_lock_file_path}. "
                 "Cannot update version."
             )
-        project_name = self.cargo_toml.get("package", {}).get("name")
-        if project_name is None:
-            raise VersionError(
-                f"Project name not found in {self.project_file_path}. Cannot update version."
-            )
-
-        if "package" in cargo_lock:
-            for package in cargo_lock["package"]:
-                if package.get("name") == project_name:
-                    package["version"] = str(new_version)
+        project_names = self._get_project_names()
+        for package in cargo_lock["package"]:
+            if package.get("name") in project_names:
+                package["version"] = str(new_version)
 
         self.cargo_lock_file_path.write_text(
             tomlkit.dumps(cargo_lock), encoding="utf-8"
@@ -154,7 +174,10 @@ class CargoVersionCommand(VersionCommand):
         return VersionUpdate(
             previous=previous_version,
             new=new_version,
-            changed_files=[self.project_file_path],
+            changed_files=[
+                self.project_file_path,
+                self.cargo_lock_file_path,
+            ],
         )
 
     def get_current_version(self) -> Version:

--- a/pontos/version/commands/_uv.py
+++ b/pontos/version/commands/_uv.py
@@ -30,7 +30,9 @@ class UvVersionCommand(PythonVersionCommand):
         if self._uv_lock_file_path:
             return self._uv_lock_file_path
 
-        self._uv_lock_file_path = self.project_file_path.parent / "uv.lock"
+        self._uv_lock_file_path = (
+            self.project_file_path.parent / self.uv_lock_file_name
+        )
         return self._uv_lock_file_path
 
     @override

--- a/tests/version/commands/test_cargo.py
+++ b/tests/version/commands/test_cargo.py
@@ -6,13 +6,15 @@ import unittest
 from collections.abc import Iterator
 from contextlib import contextmanager
 from pathlib import Path
+from unittest.mock import patch
 
 import tomlkit
+from tomlkit.items import Array
 
 from pontos.testing import temp_directory, temp_file
 from pontos.version import VersionError
 from pontos.version.commands._cargo import CargoVersionCommand
-from pontos.version.schemes import PEP440VersioningScheme
+from pontos.version.schemes import SemanticVersioningScheme
 
 """
 This modules verifies different Cargo.toml configuration scenarios.
@@ -116,6 +118,166 @@ members = [
 """
 
 
+class CargoFileCommandTestCase(unittest.TestCase):
+    def test_cargo_toml_requires_project_file(self):
+        with temp_directory(change_into=True):
+            command = CargoVersionCommand(SemanticVersioningScheme)
+
+            with self.assertRaisesRegex(
+                VersionError, "Cargo.toml file not found"
+            ):
+                command.get_current_version()
+
+    def test_cargo_toml_requires_version(self):
+        with temp_file(
+            '[package]\nname = "example"',
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            command = CargoVersionCommand(SemanticVersioningScheme)
+
+            with self.assertRaisesRegex(VersionError, "No version information"):
+                command.get_current_version()
+
+    def test_update_creates_package_section(self):
+        with temp_file(
+            "[workspace]\nmembers = []",
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            command = CargoVersionCommand(SemanticVersioningScheme)
+            new_version = SemanticVersioningScheme.parse_version("2.0.0")
+
+            command._update_cargo_toml_file(new_version)
+
+            cargo_toml = tomlkit.parse(
+                command.project_file_path.read_text(encoding="utf-8")
+            )
+            self.assertEqual(cargo_toml["package"]["version"], "2.0.0")
+
+    def test_update_workspace_package_version(self):
+        with temp_file(
+            WORKSPACE_EXAMPLE_2,
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            command = CargoVersionCommand(SemanticVersioningScheme)
+            new_version = SemanticVersioningScheme.parse_version("2.0.0")
+
+            command._update_cargo_toml_file(new_version)
+
+            cargo_toml = tomlkit.parse(
+                command.project_file_path.read_text(encoding="utf-8")
+            )
+            self.assertEqual(
+                cargo_toml["workspace"]["package"]["version"], "2.0.0"
+            )
+
+    def test_lock_file_requires_lock_file(self):
+        with temp_file(
+            '[package]\nname = "example"\nversion = "1.0.0"',
+            name="Cargo.toml",
+        ):
+            command = CargoVersionCommand(SemanticVersioningScheme)
+            new_version = SemanticVersioningScheme.parse_version("2.0.0")
+
+            with self.assertRaisesRegex(
+                VersionError, "Cargo.lock file not found"
+            ):
+                command._update_cargo_lock_file(new_version)
+
+    def test_lock_file_requires_package_entries(self):
+        with temp_file(
+            '[package]\nname = "example"\nversion = "1.0.0"',
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            Path("Cargo.lock").write_text("[metadata]\n")
+            command = CargoVersionCommand(SemanticVersioningScheme)
+            new_version = SemanticVersioningScheme.parse_version("2.0.0")
+
+            with self.assertRaisesRegex(VersionError, r"\[\[package\]\]"):
+                command._update_cargo_lock_file(new_version)
+
+    def test_lock_file_requires_project_name(self):
+        with temp_file(
+            '[package]\nversion = "1.0.0"',
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            Path("Cargo.lock").write_text(
+                '[[package]]\nname = "example"\nversion = "1.0.0"'
+            )
+            command = CargoVersionCommand(SemanticVersioningScheme)
+            new_version = SemanticVersioningScheme.parse_version("2.0.0")
+
+            with self.assertRaisesRegex(VersionError, "Project name not found"):
+                command._update_cargo_lock_file(new_version)
+
+    def test_lock_file_updates_matching_package_only(self):
+        with temp_file(
+            '[package]\nname = "example"\nversion = "1.0.0"',
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            Path("Cargo.lock").write_text(
+                '[[package]]\nname = "other"\nversion = "9.9.9"\n\n'
+                '[[package]]\nname = "example"\nversion = "1.0.0"'
+            )
+            command = CargoVersionCommand(SemanticVersioningScheme)
+            new_version = SemanticVersioningScheme.parse_version("2.0.0")
+
+            command._update_cargo_lock_file(new_version)
+
+            lock = tomlkit.parse(
+                command.cargo_lock_file_path.read_text(encoding="utf-8")
+            )
+            self.assertEqual(lock["package"][0]["version"], "9.9.9")
+            self.assertEqual(lock["package"][1]["version"], "2.0.0")
+
+    def test_update_version_wraps_cargo_toml_os_error(self):
+        with temp_file(
+            '[package]\nname = "example"\nversion = "1.0.0"',
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            command = CargoVersionCommand(SemanticVersioningScheme)
+            new_version = SemanticVersioningScheme.parse_version("2.0.0")
+
+            with (
+                patch.object(
+                    command,
+                    "_update_cargo_toml_file",
+                    side_effect=OSError("write"),
+                ),
+                self.assertRaisesRegex(VersionError, "Cargo.toml"),
+            ):
+                command.update_version(new_version)
+
+    def test_update_version_wraps_cargo_lock_os_error(self):
+        with temp_file(
+            '[package]\nname = "example"\nversion = "1.0.0"',
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            Path("Cargo.lock").write_text(
+                '[[package]]\nname = "example"\nversion = "1.0.0"'
+            )
+            command = CargoVersionCommand(SemanticVersioningScheme)
+            new_version = SemanticVersioningScheme.parse_version("2.0.0")
+
+            with (
+                patch.object(command, "_update_cargo_toml_file"),
+                patch.object(
+                    command,
+                    "_update_cargo_lock_file",
+                    side_effect=OSError("write"),
+                ),
+                self.assertRaisesRegex(VersionError, "Cargo.lock"),
+            ):
+                command.update_version(new_version)
+
+
 class VerifyCargoUpdateCommandTestCase(unittest.TestCase):
     @contextmanager
     def __create_cargo_layout(
@@ -125,8 +287,18 @@ class VerifyCargoUpdateCommandTestCase(unittest.TestCase):
             cargo_toml = temp_dir / "Cargo.toml"
             cargo_toml.write_text(workspace_toml)
             workspace_toml_file = tomlkit.parse(workspace_toml)
+            package = workspace_toml_file.get("package", {})
+            if package_name := package.get("name"):
+                (temp_dir / "Cargo.lock").write_text(
+                    "[[package]]\n"
+                    'name = "other"\n'
+                    'version = "9.9.9"\n\n'
+                    "[[package]]\n"
+                    f'name = "{package_name}"\n'
+                    f'version = "{package.get("version")}"\n'
+                )
             members = workspace_toml_file["workspace"]["members"]  # type: ignore[index, arg-type]
-            if isinstance(members, tomlkit.items.Array):
+            if isinstance(members, Array):
                 for member in members:
                     npath = temp_dir / f"{member}"
                     npath.mkdir()
@@ -138,7 +310,6 @@ class VerifyCargoUpdateCommandTestCase(unittest.TestCase):
     def test_success(self):
         examples = [
             ("0.1.0", WORKSPACE_EXAMPLE_1, PACKAGE_EXAMPLE_1),
-            ("0.1.0", WORKSPACE_EXAMPLE_2, PACKAGE_EXAMPLE_2),
             ("0.2.0", WORKSPACE_EXAMPLE_3, PACKAGE_EXAMPLE_3),
         ]
         for version, cargo_toml, member_cargo_toml in examples:
@@ -153,9 +324,9 @@ class VerifyCargoUpdateCommandTestCase(unittest.TestCase):
                     member_toml=member_cargo_toml,
                 ) as temp_dir,
             ):
-                cargo = CargoVersionCommand(PEP440VersioningScheme)
-                previous = PEP440VersioningScheme.parse_version(version)
-                new_version = PEP440VersioningScheme.parse_version("23.4.1")
+                cargo = CargoVersionCommand(SemanticVersioningScheme)
+                previous = SemanticVersioningScheme.parse_version(version)
+                new_version = SemanticVersioningScheme.parse_version("23.4.1")
                 updated = cargo.update_version(new_version)
                 self.assertEqual(updated.previous, previous)
                 self.assertEqual(updated.new, new_version)
@@ -163,6 +334,9 @@ class VerifyCargoUpdateCommandTestCase(unittest.TestCase):
                     updated.changed_files,
                     [(temp_dir / "Cargo.toml").resolve()],
                 )
+                lock = tomlkit.parse((temp_dir / "Cargo.lock").read_text())
+                self.assertEqual(lock["package"][0]["version"], "9.9.9")
+                self.assertEqual(lock["package"][1]["version"], "23.4.1")
 
     def test_failure(self):
         examples = [
@@ -182,9 +356,9 @@ class VerifyCargoUpdateCommandTestCase(unittest.TestCase):
                     member_toml=member_cargo_toml,
                 ),
             ):
-                cargo = CargoVersionCommand(PEP440VersioningScheme)
-                previous = PEP440VersioningScheme.parse_version(version)
-                new_version = PEP440VersioningScheme.parse_version(version)
+                cargo = CargoVersionCommand(SemanticVersioningScheme)
+                previous = SemanticVersioningScheme.parse_version(version)
+                new_version = SemanticVersioningScheme.parse_version(version)
                 updated = cargo.update_version(new_version)
                 self.assertEqual(updated.previous, previous)
                 self.assertEqual(updated.new, new_version)
@@ -210,9 +384,11 @@ class VerifyCargoVersionCommandTestCase(unittest.TestCase):
                     change_into=True,
                 ),
             ):
-                pep440_version = PEP440VersioningScheme.parse_version(version)
-                cargo = CargoVersionCommand(PEP440VersioningScheme)
-                cargo.verify_version(pep440_version)
+                semantic_version = SemanticVersioningScheme.parse_version(
+                    version
+                )
+                cargo = CargoVersionCommand(SemanticVersioningScheme)
+                cargo.verify_version(semantic_version)
 
     def test_verify_failure(self):
         examples = [
@@ -229,11 +405,13 @@ class VerifyCargoVersionCommandTestCase(unittest.TestCase):
                     change_into=True,
                 ),
             ):
-                pep440_version = PEP440VersioningScheme.parse_version("2.3.4")
-                cargo = CargoVersionCommand(PEP440VersioningScheme)
+                semantic_version = SemanticVersioningScheme.parse_version(
+                    "2.3.4"
+                )
+                cargo = CargoVersionCommand(SemanticVersioningScheme)
                 with self.assertRaisesRegex(
                     VersionError,
                     "Provided version 2.3.4 does not match the "
                     f"current version {version}.",
                 ):
-                    cargo.verify_version(pep440_version)
+                    cargo.verify_version(semantic_version)

--- a/tests/version/commands/test_cargo.py
+++ b/tests/version/commands/test_cargo.py
@@ -204,7 +204,9 @@ class CargoFileCommandTestCase(unittest.TestCase):
     ):
         with temp_directory(change_into=True) as temp_dir:
             Path("Cargo.toml").write_text(
-                '[workspace]\nmembers = ["client", "server"]\n\n'
+                "[workspace]\n"
+                'members = ["client", "server", "without-manifest", '
+                '"independent", "without-name"]\n\n'
                 '[workspace.package]\nversion = "1.0.0"\n'
             )
             for member in ("client", "server"):
@@ -212,10 +214,20 @@ class CargoFileCommandTestCase(unittest.TestCase):
                 (Path(member) / "Cargo.toml").write_text(
                     f'[package]\nname = "{member}"\nversion.workspace = true\n'
                 )
+            Path("without-manifest").mkdir()
+            Path("independent").mkdir()
+            (Path("independent") / "Cargo.toml").write_text(
+                '[package]\nname = "independent"\nversion = "3.0.0"\n'
+            )
+            Path("without-name").mkdir()
+            (Path("without-name") / "Cargo.toml").write_text(
+                "[package]\nversion.workspace = true\n"
+            )
             Path("Cargo.lock").write_text(
                 '[[package]]\nname = "other"\nversion = "9.9.9"\n\n'
                 '[[package]]\nname = "client"\nversion = "1.0.0"\n\n'
-                '[[package]]\nname = "server"\nversion = "1.0.0"\n'
+                '[[package]]\nname = "server"\nversion = "1.0.0"\n\n'
+                '[[package]]\nname = "independent"\nversion = "3.0.0"\n'
             )
             command = CargoVersionCommand(SemanticVersioningScheme)
             new_version = SemanticVersioningScheme.parse_version("2.0.0")
@@ -230,6 +242,7 @@ class CargoFileCommandTestCase(unittest.TestCase):
             self.assertEqual(lock["package"][0]["version"], "9.9.9")
             self.assertEqual(lock["package"][1]["version"], "2.0.0")
             self.assertEqual(lock["package"][2]["version"], "2.0.0")
+            self.assertEqual(lock["package"][3]["version"], "3.0.0")
             self.assertEqual(
                 updated.changed_files,
                 [
@@ -258,6 +271,26 @@ class CargoFileCommandTestCase(unittest.TestCase):
             )
             self.assertEqual(lock["package"][0]["version"], "9.9.9")
             self.assertEqual(lock["package"][1]["version"], "2.0.0")
+
+    def test_update_version_uses_no_previous_version_when_unavailable(self):
+        with temp_file(
+            '[package]\nname = "example"\nversion = "1.0.0"',
+            name="Cargo.toml",
+            change_into=True,
+        ):
+            Path("Cargo.lock").write_text(
+                '[[package]]\nname = "example"\nversion = "1.0.0"'
+            )
+            command = CargoVersionCommand(SemanticVersioningScheme)
+            new_version = SemanticVersioningScheme.parse_version("2.0.0")
+
+            with patch.object(
+                command, "get_current_version", side_effect=VersionError
+            ):
+                updated = command.update_version(new_version)
+
+            self.assertIsNone(updated.previous)
+            self.assertEqual(updated.new, new_version)
 
     def test_update_version_wraps_cargo_toml_os_error(self):
         with temp_file(
@@ -415,6 +448,7 @@ class VerifyCargoVersionCommandTestCase(unittest.TestCase):
                     version
                 )
                 cargo = CargoVersionCommand(SemanticVersioningScheme)
+                cargo.verify_version(None)
                 cargo.verify_version(semantic_version)
 
     def test_verify_failure(self):

--- a/tests/version/commands/test_cargo.py
+++ b/tests/version/commands/test_cargo.py
@@ -199,20 +199,44 @@ class CargoFileCommandTestCase(unittest.TestCase):
             with self.assertRaisesRegex(VersionError, r"\[\[package\]\]"):
                 command._update_cargo_lock_file(new_version)
 
-    def test_lock_file_requires_project_name(self):
-        with temp_file(
-            '[package]\nversion = "1.0.0"',
-            name="Cargo.toml",
-            change_into=True,
-        ):
+    def test_update_version_updates_virtual_workspace_members_in_lock_file(
+        self,
+    ):
+        with temp_directory(change_into=True) as temp_dir:
+            Path("Cargo.toml").write_text(
+                '[workspace]\nmembers = ["client", "server"]\n\n'
+                '[workspace.package]\nversion = "1.0.0"\n'
+            )
+            for member in ("client", "server"):
+                Path(member).mkdir()
+                (Path(member) / "Cargo.toml").write_text(
+                    f'[package]\nname = "{member}"\nversion.workspace = true\n'
+                )
             Path("Cargo.lock").write_text(
-                '[[package]]\nname = "example"\nversion = "1.0.0"'
+                '[[package]]\nname = "other"\nversion = "9.9.9"\n\n'
+                '[[package]]\nname = "client"\nversion = "1.0.0"\n\n'
+                '[[package]]\nname = "server"\nversion = "1.0.0"\n'
             )
             command = CargoVersionCommand(SemanticVersioningScheme)
             new_version = SemanticVersioningScheme.parse_version("2.0.0")
 
-            with self.assertRaisesRegex(VersionError, "Project name not found"):
-                command._update_cargo_lock_file(new_version)
+            updated = command.update_version(new_version)
+
+            cargo_toml = tomlkit.parse(Path("Cargo.toml").read_text())
+            lock = tomlkit.parse(Path("Cargo.lock").read_text())
+            self.assertEqual(
+                cargo_toml["workspace"]["package"]["version"], "2.0.0"
+            )
+            self.assertEqual(lock["package"][0]["version"], "9.9.9")
+            self.assertEqual(lock["package"][1]["version"], "2.0.0")
+            self.assertEqual(lock["package"][2]["version"], "2.0.0")
+            self.assertEqual(
+                updated.changed_files,
+                [
+                    (temp_dir / "Cargo.toml").resolve(),
+                    (temp_dir / "Cargo.lock").resolve(),
+                ],
+            )
 
     def test_lock_file_updates_matching_package_only(self):
         with temp_file(
@@ -332,7 +356,10 @@ class VerifyCargoUpdateCommandTestCase(unittest.TestCase):
                 self.assertEqual(updated.new, new_version)
                 self.assertEqual(
                     updated.changed_files,
-                    [(temp_dir / "Cargo.toml").resolve()],
+                    [
+                        (temp_dir / "Cargo.toml").resolve(),
+                        (temp_dir / "Cargo.lock").resolve(),
+                    ],
                 )
                 lock = tomlkit.parse((temp_dir / "Cargo.lock").read_text())
                 self.assertEqual(lock["package"][0]["version"], "9.9.9")


### PR DESCRIPTION
## What

This builds on the work originally done by @bjoernricks in #1270 and adds the following bug fixes:

- Update `Cargo.lock` entries for workspace members that inherit `version.workspace`.
- Avoid requiring a root `[package].name` for virtual workspaces.
- Include `Cargo.lock` in reported changed files and cover the regression.

## Why

The previous changed caused issue under certain circumstances in virtual workspaces and had to be reverted.

## References

#1270 

## Checklist

- [X] Tests

Generated with the help of `pi` coding agent harness (model: openai-codex/gpt-5.6-terra).